### PR TITLE
Expand price slider max to 200

### DIFF
--- a/index.html
+++ b/index.html
@@ -608,11 +608,11 @@
                     </div>
                     <div class="price-range-slider">
                         <label class="filter-label">Range di Prezzo</label>
-                        <input type="range" class="range-input" id="min-price" min="1" max="100" value="1">
-                        <input type="range" class="range-input" id="max-price" min="1" max="100" value="100">
+                        <input type="range" class="range-input" id="min-price" min="1" max="200" value="1">
+                        <input type="range" class="range-input" id="max-price" min="1" max="200" value="200">
                         <div class="range-values">
                             <span id="min-price-val">1</span>
-                            <span id="max-price-val">100</span>
+                            <span id="max-price-val">200</span>
                         </div>
                     </div>
                 </div>
@@ -710,7 +710,7 @@
             reliability: 'all',
             opportunity: 'all',
             minPrice: 1,
-            maxPrice: 100
+            maxPrice: 200
         };
 
         // Budget and target tracking


### PR DESCRIPTION
## Summary
- Raise price range slider maximum to 200 and update displayed default
- Align `currentFilters` maxPrice with new limit

## Testing
- `node - <<'NODE' ... NODE` (verify price range)
- `npm test` (fails: no package.json)

------
https://chatgpt.com/codex/tasks/task_e_68bbf70aad408324b9a59f1050d2df82