### PR TITLE
Add full targets view with persistent state

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,6 +49,33 @@
             margin-bottom: 20px;
         }
 
+        .nav-tabs {
+            margin-top: 15px;
+            display: flex;
+            justify-content: center;
+            gap: 10px;
+        }
+
+        .nav-btn {
+            padding: 8px 16px;
+            border-radius: 20px;
+            border: none;
+            background: rgba(255, 255, 255, 0.2);
+            color: white;
+            cursor: pointer;
+        }
+
+        .nav-btn.active {
+            background: white;
+            color: #2a5298;
+            font-weight: bold;
+        }
+
+        #targets-view {
+            display: none;
+            padding: 30px;
+        }
+
         .stats-overview {
             display: grid;
             grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
@@ -539,6 +566,10 @@
         <div class="header">
             <h1>Fantacalcio 2025</h1>
             <div class="subtitle">Ultra-Intelligent Database & Smart Pricing</div>
+            <div class="nav-tabs">
+                <button id="nav-home" class="nav-btn active">Lista</button>
+                <button id="nav-targets" class="nav-btn">Targets</button>
+            </div>
             <div class="stats-overview">
                 <div class="stat-card">
                     <div class="stat-value" id="total-players">465</div>
@@ -559,6 +590,7 @@
             </div>
         </div>
 
+        <div id="main-view">
         <div class="search-container">
             <div class="search-box">
                 <input type="text" class="search-input" placeholder="🔍 Cerca giocatori... (nome, team, stats)"
@@ -652,11 +684,6 @@
                 </div>
 
                 <div class="sidebar-section">
-                    <div class="sidebar-title">🎯 Obiettivi</div>
-                    <ul class="recommendations" id="target-list"></ul>
-                </div>
-
-                <div class="sidebar-section">
                     <div class="ai-insights">
                         <div class="insight-title">🤖 AI Insights</div>
                         <div class="insight-text" id="ai-insight">
@@ -664,7 +691,6 @@
                         </div>
                     </div>
                 </div>
-
                 <div class="sidebar-section">
                     <div class="sidebar-title">💎 Opportunità Top</div>
                     <ul class="recommendations" id="top-opportunities">
@@ -688,6 +714,11 @@
                     </div>
                 </div>
             </div>
+        </div>
+        </div>
+
+        <div id="targets-view">
+            <div class="players-grid" id="targets-grid"></div>
         </div>
     </div>
 
@@ -723,8 +754,16 @@
                 'A': { max: 140, spent: 0, count: 0, needed: 6 }
             }
         };
-        const targets = {};
-        const purchased = {};
+        const targets = JSON.parse(localStorage.getItem('targets') || '{}');
+        const purchased = JSON.parse(localStorage.getItem('purchased') || '{}');
+
+        Object.values(purchased).forEach(p => {
+            budget.total.spent += p.price;
+            if (budget.roles[p.role]) {
+                budget.roles[p.role].spent += p.price;
+                budget.roles[p.role].count += 1;
+            }
+        });
 
         // Initialize
         document.addEventListener('DOMContentLoaded', () => {
@@ -782,6 +821,10 @@
             window.addEventListener('click', (e) => {
                 if (e.target === modal) modal.style.display = 'none';
             });
+
+            // Navigation
+            document.getElementById('nav-home').addEventListener('click', showMainView);
+            document.getElementById('nav-targets').addEventListener('click', showTargetsView);
         }
 
         function handleSearch(e) {
@@ -803,6 +846,22 @@
             currentFilters.reliability = document.getElementById('reliability-filter').value;
             currentFilters.opportunity = document.getElementById('opportunity-filter').value;
             renderPlayers();
+        }
+
+        function showMainView() {
+            document.getElementById('main-view').style.display = 'block';
+            document.getElementById('targets-view').style.display = 'none';
+            document.getElementById('nav-home').classList.add('active');
+            document.getElementById('nav-targets').classList.remove('active');
+            renderPlayers();
+        }
+
+        function showTargetsView() {
+            document.getElementById('main-view').style.display = 'none';
+            document.getElementById('targets-view').style.display = 'block';
+            document.getElementById('nav-home').classList.remove('active');
+            document.getElementById('nav-targets').classList.add('active');
+            updateTargetsUI();
         }
 
         function updatePriceRange() {
@@ -929,9 +988,32 @@
         }
 
         function updateTargetsUI() {
-            const list = document.getElementById('target-list');
-            if (!list) return;
-            list.innerHTML = Object.values(targets).map(t => `<li class="recommendation">${t.name} (${t.role}) - €${t.price}</li>`).join('');
+            localStorage.setItem('targets', JSON.stringify(targets));
+            const container = document.getElementById('targets-grid');
+            if (!container) return;
+            const roleIcons = { 'P': '🥅', 'D': '🛡️', 'C': '⚡', 'A': '⚔️' };
+            const slotCounts = { 'P': 0, 'D': 0, 'C': 0, 'A': 0 };
+            const cards = Object.entries(targets).map(([key, t]) => {
+                slotCounts[t.role]++;
+                const slot = slotCounts[t.role];
+                const boughtClass = purchased[key] ? 'bought' : '';
+                return `
+                    <div class="player-card ${boughtClass}">
+                        <div class="player-info">
+                            <div class="player-name">${roleIcons[t.role]} ${t.name}</div>
+                            <div class="player-team">Ruolo: ${t.role} • Slot ${slot}</div>
+                        </div>
+                        <div class="player-price">
+                            <div class="smart-price">€${t.price}</div>
+                        </div>
+                        <div class="player-actions">
+                            <button class="action-btn" onclick="toggleTarget('${t.name}', '${t.role}', ${t.price})">❌</button>
+                            <button class="action-btn" onclick="editTarget('${key}')">✏️</button>
+                            <button class="action-btn" onclick="buyPlayer('${t.name}', ${t.price}, '${t.role}')">💸</button>
+                        </div>
+                    </div>`;
+            }).join('');
+            container.innerHTML = cards || '<p>Nessun obiettivo selezionato</p>';
         }
 
         function toggleTarget(name, role, price) {
@@ -944,17 +1026,27 @@
             updateTargetsUI();
         }
 
+        function editTarget(key) {
+            const target = targets[key];
+            if (!target) return;
+            const newPrice = prompt('Nuovo prezzo per ' + target.name, target.price);
+            if (newPrice !== null && !isNaN(newPrice)) {
+                target.price = parseInt(newPrice);
+                updateTargetsUI();
+            }
+        }
+
         function buyPlayer(name, price, role) {
             const key = `${role}:${name}`;
             if (purchased[key]) return;
-            purchased[key] = true;
+            purchased[key] = { name, role, price };
+            localStorage.setItem('purchased', JSON.stringify(purchased));
             budget.total.spent += price;
             budget.roles[role].spent += price;
             budget.roles[role].count += 1;
             updateBudgetUI();
             const el = document.getElementById(`player-${role}-${name.replace(/\s+/g,'-')}`);
             if (el) el.classList.add('bought');
-            delete targets[key];
             updateTargetsUI();
             checkAlerts(role);
         }
@@ -970,10 +1062,10 @@
             const player = decodePlayer(playerArray, role);
             const opportunity = getOpportunityLevel(player);
             const reliabilityStars = getReliabilityStars(player.stats.a);
-            
+
             const opportunityColors = {
                 'high': '#28a745',
-                'medium': '#ffc107', 
+                'medium': '#ffc107',
                 'low': '#6c757d'
             };
 
@@ -984,8 +1076,11 @@
                 'A': '⚔️'
             };
 
+            const key = `${role}:${player.nome}`;
+            const boughtClass = purchased[key] ? 'bought' : '';
+
             return `
-                <div class="player-card" id="player-${role}-${player.nome.replace(/\s+/g,'-')}" onclick="showPlayerDetails('${playerArray[0]}', '${role}')">
+                <div class="player-card ${boughtClass}" id="player-${role}-${player.nome.replace(/\s+/g,'-')}" onclick="showPlayerDetails('${playerArray[0]}', '${role}')">
                     <div style="position: relative; flex:1;">
                         ${opportunity === 'high' ? '<div class="opportunity-badge">🔥</div>' : ''}
                         <div class="player-info">


### PR DESCRIPTION
## Summary
- Add navigation tabs to switch between player list and new targets view
- Render target cards with role, slot, price, and actions
- Persist targets and purchases using localStorage and update budget accordingly

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bbfa83ec9083248b50bedd32ab3974