### PR TITLE
Add slot planner and slot-aware budgeting

### DIFF
--- a/index.html
+++ b/index.html
@@ -344,6 +344,21 @@
             margin-top: 3px;
         }
 
+        .slots-planner {
+            width: 100%;
+            border-collapse: collapse;
+        }
+
+        .slots-planner th, .slots-planner td {
+            padding: 4px;
+            text-align: center;
+            font-size: 0.8rem;
+        }
+
+        .slot-input {
+            width: 40px;
+        }
+
         .loading {
             text-align: center;
             padding: 40px;
@@ -652,6 +667,39 @@
                 </div>
 
                 <div class="sidebar-section">
+                    <div class="sidebar-title">📌 Slots Planner</div>
+                    <table class="slots-planner">
+                        <tr>
+                            <th>R</th><th>Top</th><th>SemiTop</th><th>Jolly</th>
+                        </tr>
+                        <tr>
+                            <td>P</td>
+                            <td><input type="number" class="slot-input" id="slot-plan-P-Top" min="0" value="0"> <small id="slot-count-P-Top">0/0</small></td>
+                            <td><input type="number" class="slot-input" id="slot-plan-P-SemiTop" min="0" value="0"> <small id="slot-count-P-SemiTop">0/0</small></td>
+                            <td><input type="number" class="slot-input" id="slot-plan-P-Jolly" min="0" value="0"> <small id="slot-count-P-Jolly">0/0</small></td>
+                        </tr>
+                        <tr>
+                            <td>D</td>
+                            <td><input type="number" class="slot-input" id="slot-plan-D-Top" min="0" value="0"> <small id="slot-count-D-Top">0/0</small></td>
+                            <td><input type="number" class="slot-input" id="slot-plan-D-SemiTop" min="0" value="0"> <small id="slot-count-D-SemiTop">0/0</small></td>
+                            <td><input type="number" class="slot-input" id="slot-plan-D-Jolly" min="0" value="0"> <small id="slot-count-D-Jolly">0/0</small></td>
+                        </tr>
+                        <tr>
+                            <td>C</td>
+                            <td><input type="number" class="slot-input" id="slot-plan-C-Top" min="0" value="0"> <small id="slot-count-C-Top">0/0</small></td>
+                            <td><input type="number" class="slot-input" id="slot-plan-C-SemiTop" min="0" value="0"> <small id="slot-count-C-SemiTop">0/0</small></td>
+                            <td><input type="number" class="slot-input" id="slot-plan-C-Jolly" min="0" value="0"> <small id="slot-count-C-Jolly">0/0</small></td>
+                        </tr>
+                        <tr>
+                            <td>A</td>
+                            <td><input type="number" class="slot-input" id="slot-plan-A-Top" min="0" value="0"> <small id="slot-count-A-Top">0/0</small></td>
+                            <td><input type="number" class="slot-input" id="slot-plan-A-SemiTop" min="0" value="0"> <small id="slot-count-A-SemiTop">0/0</small></td>
+                            <td><input type="number" class="slot-input" id="slot-plan-A-Jolly" min="0" value="0"> <small id="slot-count-A-Jolly">0/0</small></td>
+                        </tr>
+                    </table>
+                </div>
+
+                <div class="sidebar-section">
                     <div class="sidebar-title">🎯 Obiettivi</div>
                     <ul class="recommendations" id="target-list"></ul>
                 </div>
@@ -725,6 +773,19 @@
         };
         const targets = {};
         const purchased = {};
+        const slotTypes = ['Top', 'SemiTop', 'Jolly'];
+        const slotPlan = {
+            'P': { Top: 0, SemiTop: 0, Jolly: 0 },
+            'D': { Top: 0, SemiTop: 0, Jolly: 0 },
+            'C': { Top: 0, SemiTop: 0, Jolly: 0 },
+            'A': { Top: 0, SemiTop: 0, Jolly: 0 }
+        };
+        const slotPurchases = {
+            'P': { Top: 0, SemiTop: 0, Jolly: 0 },
+            'D': { Top: 0, SemiTop: 0, Jolly: 0 },
+            'C': { Top: 0, SemiTop: 0, Jolly: 0 },
+            'A': { Top: 0, SemiTop: 0, Jolly: 0 }
+        };
 
         // Initialize
         document.addEventListener('DOMContentLoaded', () => {
@@ -781,6 +842,23 @@
             
             window.addEventListener('click', (e) => {
                 if (e.target === modal) modal.style.display = 'none';
+            });
+
+            setupSlotPlanner();
+        }
+
+        function setupSlotPlanner() {
+            ['P','D','C','A'].forEach(role => {
+                slotTypes.forEach(slot => {
+                    const input = document.getElementById(`slot-plan-${role}-${slot}`);
+                    if (input) {
+                        input.addEventListener('input', e => {
+                            slotPlan[role][slot] = parseInt(e.target.value) || 0;
+                            updateBudgetUI();
+                            updateTargetsUI();
+                        });
+                    }
+                });
             });
         }
 
@@ -925,13 +1003,64 @@
                 document.getElementById(`budget-${role}-max`).textContent = budget.roles[role].max;
                 document.getElementById(`count-${role}`).textContent = budget.roles[role].count;
                 document.getElementById(`needed-${role}`).textContent = budget.roles[role].needed;
+                slotTypes.forEach(slot => {
+                    const span = document.getElementById(`slot-count-${role}-${slot}`);
+                    if (span) {
+                        span.textContent = `${slotPurchases[role][slot]}/${slotPlan[role][slot]}`;
+                    }
+                });
             });
+        }
+
+        function getRemainingSlotQuota(role, slot) {
+            return Math.max((slotPlan[role][slot] || 0) - (slotPurchases[role][slot] || 0), 0);
+        }
+
+        function checkSlotAlert(role, slot) {
+            if (getRemainingSlotQuota(role, slot) <= 0) {
+                alert(`Quota slot ${slot} per ruolo ${role} raggiunta`);
+            }
+        }
+
+        function calculateTargetPrices() {
+            const slotBudgets = {};
+            ['P','D','C','A'].forEach(role => {
+                slotBudgets[role] = {};
+                const total = Object.values(slotPlan[role]).reduce((a, b) => a + parseInt(b || 0), 0);
+                slotTypes.forEach(slot => {
+                    slotBudgets[role][slot] = total ? budget.roles[role].max * (slotPlan[role][slot] || 0) / total : 0;
+                });
+            });
+
+            Object.values(targets).forEach(t => {
+                const slotBudget = slotBudgets[t.role]?.[t.slot] || 0;
+                const plannedCount = slotPlan[t.role]?.[t.slot] || 1;
+                t.targetPrice = Math.round(slotBudget / plannedCount);
+            });
+
+            return slotBudgets;
         }
 
         function updateTargetsUI() {
             const list = document.getElementById('target-list');
             if (!list) return;
-            list.innerHTML = Object.values(targets).map(t => `<li class="recommendation">${t.name} (${t.role}) - €${t.price}</li>`).join('');
+            calculateTargetPrices();
+            const grouped = {};
+            Object.values(targets).forEach(t => {
+                if (!grouped[t.slot]) grouped[t.slot] = [];
+                grouped[t.slot].push(t);
+            });
+
+            let html = '';
+            slotTypes.forEach(slot => {
+                const players = grouped[slot] || [];
+                const remaining = ['P','D','C','A'].map(role => `${role}:${getRemainingSlotQuota(role, slot)}`).join(' ');
+                html += `<li><strong>${slot} (${remaining})</strong></li>`;
+                players.forEach(p => {
+                    html += `<li class="recommendation" style="margin-left:10px;">${p.name} (${p.role}) - €${p.price} (TP: €${p.targetPrice})</li>`;
+                });
+            });
+            list.innerHTML = html;
         }
 
         function toggleTarget(name, role, price) {
@@ -939,7 +1068,9 @@
             if (targets[key]) {
                 delete targets[key];
             } else {
-                targets[key] = { name, role, price };
+                let slot = prompt('Seleziona slot (Top, SemiTop, Jolly):', 'Top');
+                if (!slotTypes.includes(slot)) return;
+                targets[key] = { name, role, price, slot };
             }
             updateTargetsUI();
         }
@@ -947,16 +1078,23 @@
         function buyPlayer(name, price, role) {
             const key = `${role}:${name}`;
             if (purchased[key]) return;
+            let slot = targets[key]?.slot;
+            if (!slot) {
+                slot = prompt('Seleziona slot per acquisto (Top, SemiTop, Jolly):', 'Jolly');
+                if (!slotTypes.includes(slot)) slot = 'Jolly';
+            }
             purchased[key] = true;
             budget.total.spent += price;
             budget.roles[role].spent += price;
             budget.roles[role].count += 1;
+            slotPurchases[role][slot] += 1;
             updateBudgetUI();
             const el = document.getElementById(`player-${role}-${name.replace(/\s+/g,'-')}`);
             if (el) el.classList.add('bought');
             delete targets[key];
             updateTargetsUI();
             checkAlerts(role);
+            checkSlotAlert(role, slot);
         }
 
         function checkAlerts(role) {


### PR DESCRIPTION
## Summary
- add slots planner section to configure Top/SemiTop/Jolly quotas
- track slot purchases and allocate role budget per slot
- group targets by slot with remaining quotas and target prices

## Testing
- `python -m py_compile scripts/generate_database.py`


------
https://chatgpt.com/codex/tasks/task_e_68bbfad144e48324a75f1c3bdcd49be3