### PR TITLE
Use historical prices to compute trend and volatility

### DIFF
--- a/index.html
+++ b/index.html
@@ -1570,7 +1570,42 @@
                 document.getElementById('avg-price').textContent = `€${avgPrice}`;
             }
 
+            updatePriceTrends();
             updateTopOpportunities();
+        }
+
+        function updatePriceTrends() {
+            const roles = currentRole === 'all' ? ['P', 'D', 'C', 'A'] : [currentRole];
+            let percentChanges = [];
+            let volatilities = [];
+
+            roles.forEach(role => {
+                const players = PLAYERS_DB[role] || [];
+                const filteredPlayers = filterPlayers(players, role);
+                filteredPlayers.forEach(playerArray => {
+                    const player = decodePlayer(playerArray, role);
+                    const priceEntries = Object.entries(player.allPrices || {}).sort((a, b) => a[0].localeCompare(b[0]));
+                    const prices = priceEntries.map(([, price]) => Number(price)).filter(p => !isNaN(p));
+
+                    if (prices.length >= 2) {
+                        const change = ((prices[prices.length - 1] - prices[0]) / prices[0]) * 100;
+                        percentChanges.push(change);
+
+                        const mean = prices.reduce((sum, p) => sum + p, 0) / prices.length;
+                        const variance = prices.reduce((sum, p) => sum + Math.pow(p - mean, 2), 0) / prices.length;
+                        volatilities.push(Math.sqrt(variance));
+                    }
+                });
+            });
+
+            const avgChange = percentChanges.length ? percentChanges.reduce((a, b) => a + b, 0) / percentChanges.length : 0;
+            document.getElementById('rising-trend').textContent = `${avgChange >= 0 ? '+' : ''}${avgChange.toFixed(1)}%`;
+
+            const avgVolatility = volatilities.length ? volatilities.reduce((a, b) => a + b, 0) / volatilities.length : 0;
+            let volLabel = 'Low';
+            if (avgVolatility > 5) volLabel = 'High';
+            else if (avgVolatility > 2) volLabel = 'Medium';
+            document.getElementById('volatility').textContent = volLabel;
         }
 
         function updateTopOpportunities() {
@@ -1731,11 +1766,6 @@
             detailsContainer.innerHTML = detailsHtml;
             modal.style.display = 'block';
         }
-
-        // Add some dynamic behavior
-        setInterval(() => {
-            document.getElementById('rising-trend').textContent = `+${Math.floor(Math.random() * 20 + 5)}%`;
-        }, 5000);
 
         // Add loading completion
         setTimeout(() => {


### PR DESCRIPTION
## Summary
- compute average percent change and volatility across filtered players
- refresh quick stats on each database load or filter change

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc116c1f4c8324a79ae2a975cc0ba4