### PR TITLE
Refine sidebar with card layout and collapsible sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -330,6 +330,24 @@
             margin-bottom: 30px;
         }
 
+        .sidebar-card {
+            background: #fff;
+            border-radius: 10px;
+            padding: 15px;
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+            margin-bottom: 20px;
+            box-shadow: 0 2px 6px rgba(0,0,0,0.05);
+        }
+
+        .sidebar-card-title {
+            font-size: 1.1rem;
+            font-weight: bold;
+            margin-bottom: 10px;
+            cursor: pointer;
+        }
+
         .sidebar-title {
             font-size: 1.2rem;
             font-weight: bold;
@@ -746,31 +764,30 @@
                     </table>
                 </div>
 
-                <div class="sidebar-section">
-                    <div class="sidebar-title">🎯 Obiettivi</div>
+                <details class="sidebar-card" open>
+                    <summary class="sidebar-card-title">🎯 Obiettivi</summary>
                     <ul class="recommendations" id="target-list"></ul>
-                    <button id="open-strategy" class="action-btn" style="width: 100%; margin-top: 10px;">📐 Strategia</button>
-                </div>
+                    <button id="open-strategy" class="action-btn" style="width: 100%;">📐 Strategia</button>
+                </details>
 
-                <div class="sidebar-section">
-                    <div class="ai-insights">
-                        <div class="insight-title">🤖 AI Insights</div>
-                        <div class="insight-text" id="ai-insight">
-                            Analizzando le tendenze di mercato e le performance storiche...
-                        </div>
+                <details class="sidebar-card">
+                    <summary class="sidebar-card-title">🤖 AI Insights</summary>
+                    <div class="insight-text" id="ai-insight">
+                        Analizzando le tendenze di mercato e le performance storiche...
                     </div>
-                </div>
-                <div class="sidebar-section">
-                    <div class="sidebar-title">💎 Opportunità Top</div>
+                </details>
+
+                <details class="sidebar-card" open>
+                    <summary class="sidebar-card-title">💎 Opportunità Top</summary>
                     <ul class="recommendations" id="top-opportunities">
                         <li class="recommendation">
                             <div class="recommendation-text">Caricamento opportunità...</div>
                         </li>
                     </ul>
-                </div>
+                </details>
 
-                <div class="sidebar-section">
-                    <div class="sidebar-title">📈 Trend Prezzi</div>
+                <details class="sidebar-card">
+                    <summary class="sidebar-card-title">📈 Trend Prezzi</summary>
                     <div class="quick-stats">
                         <div class="quick-stat">
                             <div class="quick-stat-value" id="rising-trend">+12%</div>
@@ -781,7 +798,7 @@
                             <div class="quick-stat-label">Volatilità</div>
                         </div>
                     </div>
-                </div>
+                </details>
             </div>
         </div>
         </div>


### PR DESCRIPTION
## Summary
- Reworked sidebar sections into reusable card components with flex-based layout
- Added card styling and headings plus optional collapsible behavior for less-used sections

## Testing
- `pytest`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc143befa88324ac403f9d1171aca0