### PR TITLE
Improve mobile Safari layout and modernize UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,9 +12,10 @@
         }
 
         body {
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-            min-height: 100vh;
+            font-family: system-ui, -apple-system, sans-serif;
+            background: linear-gradient(135deg, #1e3a8a 0%, #9333ea 100%);
+            height: 100vh;
+            min-height: 100dvh;
             color: #333;
             padding: 20px;
         }
@@ -23,16 +24,17 @@
             max-width: 1200px;
             margin: 0 auto;
             background: rgba(255, 255, 255, 0.95);
-            border-radius: 20px;
+            border-radius: 12px;
             box-shadow: 0 20px 40px rgba(0,0,0,0.1);
             backdrop-filter: blur(10px);
+            -webkit-backdrop-filter: blur(10px);
             overflow: hidden;
         }
 
         .header {
-            background: linear-gradient(135deg, #1e3c72 0%, #2a5298 100%);
+            background: linear-gradient(135deg, #1e40af 0%, #2563eb 100%);
             color: white;
-            padding: 30px;
+            padding: clamp(10px, 4vw, 30px);
             text-align: center;
             position: relative;
         }
@@ -58,7 +60,7 @@
 
         .nav-btn {
             padding: 8px 16px;
-            border-radius: 20px;
+            border-radius: 12px;
             border: none;
             background: rgba(255, 255, 255, 0.2);
             color: white;
@@ -67,13 +69,13 @@
 
         .nav-btn.active {
             background: white;
-            color: #2a5298;
+            color: #2563eb;
             font-weight: bold;
         }
 
         #targets-view {
             display: none;
-            padding: 30px;
+            padding: clamp(10px, 4vw, 30px);
         }
 
         .stats-overview {
@@ -86,9 +88,10 @@
         .stat-card {
             background: rgba(255,255,255,0.2);
             padding: 20px;
-            border-radius: 15px;
+            border-radius: 12px;
             text-align: center;
             backdrop-filter: blur(10px);
+            -webkit-backdrop-filter: blur(10px);
         }
 
         .stat-value {
@@ -103,7 +106,7 @@
         }
 
         .search-container {
-            padding: 30px;
+            padding: clamp(10px, 4vw, 30px);
             background: #f8f9fa;
             border-bottom: 1px solid #e9ecef;
         }
@@ -119,14 +122,14 @@
             padding: 15px 20px;
             font-size: 1.1rem;
             border: 2px solid #e9ecef;
-            border-radius: 25px;
+            border-radius: 12px;
             outline: none;
             transition: all 0.3s ease;
         }
 
         .search-input:focus {
-            border-color: #667eea;
-            box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+            border-color: #2563eb;
+            box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
         }
 
         .filters {
@@ -139,17 +142,17 @@
 
         .filter-btn {
             padding: 8px 16px;
-            border: 2px solid #667eea;
+            border: 2px solid #2563eb;
             background: white;
-            color: #667eea;
-            border-radius: 20px;
+            color: #2563eb;
+            border-radius: 12px;
             cursor: pointer;
             transition: all 0.3s ease;
             font-size: 0.9rem;
         }
 
         .filter-btn.active {
-            background: #667eea;
+            background: #2563eb;
             color: white;
         }
 
@@ -157,7 +160,7 @@
             display: grid;
             grid-template-columns: 1fr 350px;
             gap: 30px;
-            padding: 30px;
+            padding: clamp(10px, 4vw, 30px);
         }
 
         .players-grid {
@@ -167,8 +170,8 @@
 
         .role-section {
             background: white;
-            border-radius: 15px;
-            padding: 25px;
+            border-radius: 12px;
+            padding: clamp(10px, 4vw, 30px);
             box-shadow: 0 8px 25px rgba(0,0,0,0.1);
         }
 
@@ -192,10 +195,10 @@
 
         .role-count {
             margin-left: auto;
-            background: #667eea;
+            background: #2563eb;
             color: white;
             padding: 5px 12px;
-            border-radius: 15px;
+            border-radius: 12px;
             font-size: 0.9rem;
         }
 
@@ -214,7 +217,7 @@
         .player-card:hover {
             transform: translateY(-2px);
             box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-            border-left-color: #667eea;
+            border-left-color: #2563eb;
         }
 
         .player-card.bought {
@@ -235,10 +238,10 @@
 
         .action-btn {
             border: none;
-            background: #667eea;
+            background: #2563eb;
             color: white;
             padding: 6px 8px;
-            border-radius: 8px;
+            border-radius: 12px;
             font-size: 0.8rem;
             cursor: pointer;
         }
@@ -247,7 +250,7 @@
             background: #28a745;
             color: white;
             padding: 2px 6px;
-            border-radius: 8px;
+            border-radius: 12px;
             font-size: 0.8rem;
             margin-left: 4px;
             display: inline-block;
@@ -278,7 +281,7 @@
         .stat-badge {
             background: #e9ecef;
             padding: 3px 8px;
-            border-radius: 10px;
+            border-radius: 12px;
             font-size: 0.8rem;
             color: #495057;
         }
@@ -295,7 +298,7 @@
         .smart-price {
             font-size: 1.3rem;
             font-weight: bold;
-            color: #667eea;
+            color: #2563eb;
             margin-bottom: 5px;
         }
 
@@ -311,15 +314,15 @@
             background: #28a745;
             color: white;
             padding: 2px 6px;
-            border-radius: 10px;
+            border-radius: 12px;
             font-size: 0.7rem;
             font-weight: bold;
         }
 
         .sidebar {
             background: white;
-            border-radius: 15px;
-            padding: 25px;
+            border-radius: 12px;
+            padding: clamp(10px, 4vw, 30px);
             box-shadow: 0 8px 25px rgba(0,0,0,0.1);
             height: fit-content;
             position: sticky;
@@ -332,7 +335,7 @@
 
         .sidebar-card {
             background: #fff;
-            border-radius: 10px;
+            border-radius: 12px;
             padding: 15px;
             display: flex;
             flex-direction: column;
@@ -372,7 +375,7 @@
         .quick-stat-value {
             font-size: 1.5rem;
             font-weight: bold;
-            color: #667eea;
+            color: #2563eb;
         }
 
         .quick-stat-label {
@@ -388,7 +391,7 @@
         .recommendation {
             padding: 12px;
             background: #f8f9fa;
-            border-radius: 10px;
+            border-radius: 12px;
             margin-bottom: 10px;
             border-left: 3px solid #28a745;
         }
@@ -419,6 +422,15 @@
             width: 40px;
         }
 
+        .slot-input,
+        #strategy-P,
+        #strategy-D,
+        #strategy-C,
+        #strategy-A {
+            -webkit-appearance: none;
+            margin: 0;
+        }
+
         .loading {
             text-align: center;
             padding: 40px;
@@ -427,7 +439,7 @@
 
         .spinner {
             border: 4px solid #f3f3f3;
-            border-top: 4px solid #667eea;
+            border-top: 4px solid #2563eb;
             border-radius: 50%;
             width: 40px;
             height: 40px;
@@ -444,27 +456,42 @@
             .main-content {
                 grid-template-columns: 1fr;
                 gap: 20px;
-                padding: 20px;
+                padding: clamp(10px, 4vw, 30px);
             }
-            
+
             .sidebar {
                 order: -1;
                 position: static;
             }
-            
+
             .header h1 {
                 font-size: 2rem;
             }
-            
+
             .stats-overview {
                 grid-template-columns: repeat(2, 1fr);
             }
         }
 
+        @media (max-width: 480px) {
+            .header h1 {
+                font-size: 1.8rem;
+            }
+            .header .subtitle {
+                font-size: 1rem;
+            }
+            .filters {
+                gap: 6px;
+            }
+            .main-content {
+                gap: 20px;
+            }
+        }
+
         .advanced-filters {
             background: white;
-            padding: 20px;
-            border-radius: 15px;
+            padding: clamp(10px, 4vw, 30px);
+            border-radius: 12px;
             margin-bottom: 20px;
         }
 
@@ -491,7 +518,7 @@
             width: 100%;
             padding: 8px 12px;
             border: 1px solid #ddd;
-            border-radius: 8px;
+            border-radius: 12px;
             background: white;
         }
 
@@ -512,10 +539,10 @@
         }
 
         .ai-insights {
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            background: linear-gradient(135deg, #2563eb 0%, #9333ea 100%);
             color: white;
             padding: 20px;
-            border-radius: 15px;
+            border-radius: 12px;
             margin-bottom: 20px;
         }
 
@@ -537,19 +564,24 @@
             left: 0;
             top: 0;
             width: 100%;
-            height: 100%;
+            height: 100vh;
+            min-height: 100dvh;
             background-color: rgba(0,0,0,0.5);
+            align-items: center;
+            justify-content: center;
         }
 
         .modal-content {
             background-color: white;
-            margin: 5% auto;
+            margin: 0;
             padding: 30px;
-            border-radius: 15px;
+            border-radius: 12px;
             width: 90%;
             max-width: 600px;
-            max-height: 80vh;
+            height: auto;
+            max-height: calc(100dvh - 2rem);
             overflow-y: auto;
+            -webkit-overflow-scrolling: touch;
         }
 
         .close {
@@ -573,7 +605,7 @@
         .detail-section {
             background: #f8f9fa;
             padding: 15px;
-            border-radius: 10px;
+            border-radius: 12px;
         }
 
         .detail-title {
@@ -593,7 +625,7 @@
             text-align: center;
             padding: 10px;
             background: white;
-            border-radius: 8px;
+            border-radius: 12px;
             border: 1px solid #ddd;
         }
 
@@ -605,7 +637,7 @@
 
         .source-value {
             font-weight: bold;
-            color: #667eea;
+            color: #2563eb;
         }
     </style>
 </head>
@@ -1189,7 +1221,7 @@
             ['P','D','C','A'].forEach(role => {
                 document.getElementById(`strategy-${role}`).value = strategy[role] || 0;
             });
-            strategyModal.style.display = 'block';
+            strategyModal.style.display = 'flex';
         }
 
         function saveStrategy() {
@@ -1725,7 +1757,7 @@
                                 <div style="font-size: 0.9rem; color: #666;">Minimo</div>
                             </div>
                             <div style="text-align: center;">
-                                <div style="font-size: 1.8rem; font-weight: bold; color: #667eea;">€${player.prezzi.avg}</div>
+                                <div style="font-size: 1.8rem; font-weight: bold; color: #2563eb;">€${player.prezzi.avg}</div>
                                 <div style="font-size: 0.9rem; color: #666;">Consenso</div>
                             </div>
                             <div style="text-align: center;">
@@ -1790,7 +1822,7 @@
             detailsHtml += `
                     <div class="detail-section">
                         <div class="detail-title">🎯 Raccomandazione AI</div>
-                        <div style="background: #f8f9fa; padding: 15px; border-radius: 8px; border-left: 4px solid #667eea;">
+                        <div style="background: #f8f9fa; padding: 15px; border-radius: 12px; border-left: 4px solid #2563eb;">
                             <strong>Ideale:</strong> €${priceHints.ideal}<br>
                             <strong>Suggerito:</strong> €${priceHints.suggested}<br>
                             <strong>Massimo:</strong> €${priceHints.max}<br>
@@ -1802,7 +1834,7 @@
             `;
 
             detailsContainer.innerHTML = detailsHtml;
-            modal.style.display = 'block';
+            modal.style.display = 'flex';
         }
 
         // Add loading completion


### PR DESCRIPTION
## Summary
- Replace vh-based heights with 100vh/100dvh fallbacks for Safari
- Add -webkit-backdrop-filter blur and flex-based modal layout
- Modernize color palette, spacing, and remove iOS number spinners

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc1646cec08324bf897c515f32faf5