### PR TITLE
Move strategy budget inputs into Budget sidebar

### DIFF
--- a/index.html
+++ b/index.html
@@ -754,6 +754,16 @@
 
                 <div class="sidebar-section">
                     <div class="sidebar-title">💰 Budget</div>
+                    <button id="open-strategy" class="action-btn" style="width: 100%; margin-top: 10px;">📐 Strategia</button>
+                    <div id="strategy-container" style="display: none; margin-top: 10px;">
+                        <div style="display: grid; grid-template-columns: repeat(2, 1fr); gap: 10px; margin-bottom: 10px;">
+                            <label>P: <input type="number" id="strategy-P" min="0" max="100" style="width:60px;"></label>
+                            <label>D: <input type="number" id="strategy-D" min="0" max="100" style="width:60px;"></label>
+                            <label>C: <input type="number" id="strategy-C" min="0" max="100" style="width:60px;"></label>
+                            <label>A: <input type="number" id="strategy-A" min="0" max="100" style="width:60px;"></label>
+                        </div>
+                        <button id="save-strategy" class="action-btn" style="width:100%;">Salva</button>
+                    </div>
                     <ul class="recommendations">
                         <li>Totale: <span id="budget-total">0</span>/<span id="budget-total-max">500</span></li>
                         <li>P: <span id="budget-P">0</span>/<span id="budget-P-max">50</span> (<span id="count-P">0</span>/<span id="needed-P">3</span>)</li>
@@ -799,7 +809,6 @@
                 <details class="sidebar-card" open>
                     <summary class="sidebar-card-title">🎯 Obiettivi</summary>
                     <ul class="recommendations" id="target-list"></ul>
-                    <button id="open-strategy" class="action-btn" style="width: 100%;">📐 Strategia</button>
                 </details>
 
                 <details class="sidebar-card">
@@ -837,21 +846,6 @@
 
         <div id="targets-view">
             <div class="players-grid" id="targets-grid"></div>
-        </div>
-    </div>
-
-    <!-- Strategy Modal -->
-    <div id="strategy-modal" class="modal">
-        <div class="modal-content">
-            <span class="close">&times;</span>
-            <h2>Strategia Budget (%)</h2>
-            <div style="display: grid; grid-template-columns: repeat(2, 1fr); gap: 10px; margin-bottom: 10px;">
-                <label>P: <input type="number" id="strategy-P" min="0" max="100" style="width:60px;"></label>
-                <label>D: <input type="number" id="strategy-D" min="0" max="100" style="width:60px;"></label>
-                <label>C: <input type="number" id="strategy-C" min="0" max="100" style="width:60px;"></label>
-                <label>A: <input type="number" id="strategy-A" min="0" max="100" style="width:60px;"></label>
-            </div>
-            <button id="save-strategy" class="action-btn" style="width:100%;">Salva</button>
         </div>
     </div>
 
@@ -973,6 +967,8 @@
             document.getElementById('max-price').addEventListener('input', updatePriceRange);
             ['P','D','C','A'].forEach(role => {
                 strategy[role] = Math.round((budget.roles[role].max / budget.total.max) * 100);
+                const input = document.getElementById(`strategy-${role}`);
+                if (input) input.value = strategy[role];
             });
             updateBudgetUI();
             updateTargetsUI();
@@ -1019,15 +1015,16 @@
             });
         }
 
-        // Strategy modal
-        const strategyModal = document.getElementById('strategy-modal');
-        const strategyClose = strategyModal.querySelector('.close');
-        document.getElementById('open-strategy').addEventListener('click', openStrategyModal);
-        strategyClose.addEventListener('click', () => strategyModal.style.display = 'none');
-        document.getElementById('save-strategy').addEventListener('click', saveStrategy);
-        window.addEventListener('click', (e) => {
-            if (e.target === strategyModal) strategyModal.style.display = 'none';
+        // Strategy inputs toggle
+        const strategyContainer = document.getElementById('strategy-container');
+        document.getElementById('open-strategy').addEventListener('click', () => {
+            if (strategyContainer.style.display === 'none' || strategyContainer.style.display === '') {
+                strategyContainer.style.display = 'block';
+            } else {
+                strategyContainer.style.display = 'none';
+            }
         });
+        document.getElementById('save-strategy').addEventListener('click', saveStrategy);
 
         // Navigation
         document.getElementById('nav-home').addEventListener('click', showMainView);
@@ -1216,24 +1213,20 @@
             updateTargetsUI();
         }
 
-        function openStrategyModal() {
-            const strategyModal = document.getElementById('strategy-modal');
-            ['P','D','C','A'].forEach(role => {
-                document.getElementById(`strategy-${role}`).value = strategy[role] || 0;
-            });
-            strategyModal.style.display = 'flex';
-        }
-
         function saveStrategy() {
             const total = budget.total.max;
+            let newTotal = 0;
             ['P','D','C','A'].forEach(role => {
                 const val = parseInt(document.getElementById(`strategy-${role}`).value) || 0;
                 strategy[role] = val;
-                budget.roles[role].max = Math.round(total * val / 100);
+                const roleMax = Math.round(total * val / 100);
+                budget.roles[role].max = roleMax;
+                newTotal += roleMax;
             });
+            budget.total.max = newTotal;
             updateBudgetUI();
-            document.getElementById('strategy-modal').style.display = 'none';
             updateSmartPricing();
+            strategyContainer.style.display = 'none';
         }
 
         function updateBudgetUI() {


### PR DESCRIPTION
## Summary
- embed budget strategy inputs directly inside the 💰 Budget sidebar and toggle them with the Strategia button
- update saveStrategy and init logic to use new inputs and recalc role totals
- remove obsolete modal markup and related listeners

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc1a5077cc8324be7248a59984cb26