### PR TITLE
feat: add team logos and price badge

### DIFF
--- a/index.html
+++ b/index.html
@@ -307,6 +307,22 @@
             color: #666;
         }
 
+        .price-badge {
+            margin-left: auto;
+            display: flex;
+            flex-direction: column;
+            align-items: flex-end;
+            padding: 4px 8px;
+            border-radius: 8px;
+            color: #fff;
+        }
+
+        .team-logo {
+            height: 40px;
+            width: 40px;
+            border-radius: 50%;
+        }
+
         .opportunity-badge {
             position: absolute;
             top: -5px;
@@ -1494,8 +1510,9 @@
 
             return `
                 <div class="player-card ${boughtClass} ${externalClass}" id="player-${role}-${player.nome.replace(/\s+/g,'-')}" onclick="showPlayerDetails('${playerArray[0]}', '${role}')">
-                    <div style="position: relative; flex:1;">
+                    <div style="position: relative; flex:1; display: flex; align-items: center; gap: 10px;">
                         ${opportunity === 'high' ? '<div class="opportunity-badge">🔥</div>' : ''}
+                        <img class="team-logo" src="img/team-icons/${player.team}.png" alt="${player.team} logo">
                         <div class="player-info">
                             <div class="player-name">${roleIcons[role]} ${player.nome}</div>
                             <div class="player-team">${player.team} • ${player.fascia}</div>
@@ -1521,8 +1538,8 @@
                                 ` : ''}
                             </div>
                         </div>
-                        <div class="player-price">
-                            <div class="smart-price" style="color: ${opportunityColors[opportunity]}">
+                        <div class="price-badge" style="background-color: ${opportunityColors[opportunity]}; margin-left: auto;">
+                            <div class="smart-price" style="color: inherit;">
                                 €${player.prezzi.avg}
                             </div>
                             <div class="price-range">


### PR DESCRIPTION
## Summary
- display team logo on each player card
- style price info as color-coded badge
- introduce reusable team logo and price badge styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc22f7a1e083249522d6f61ef72645