### PR TITLE
Align player components with primary color

### DIFF
--- a/index.html
+++ b/index.html
@@ -267,7 +267,7 @@
         }
 
         .stat-badge {
-            background: var(--color-secondary);
+            background: var(--color-primary);
             padding: 2px 4px;
             border-radius: var(--radius);
             font-size: var(--font-sm);
@@ -276,7 +276,7 @@
 
         .stat-badge.excellent { background: var(--color-success); }
         .stat-badge.good { background: var(--color-warning); color: #000; }
-        .stat-badge.average { background: var(--color-secondary); }
+        .stat-badge.average { background: var(--color-primary); }
 
         .smart-price {
             font-size: var(--font-lg);
@@ -297,7 +297,7 @@
             align-items: flex-end;
             padding: 4px 8px;
             border-radius: var(--radius);
-            background: var(--color-secondary);
+            background: var(--color-primary);
             color: var(--text-color);
         }
 


### PR DESCRIPTION
## Summary
- switch player stat and price badges to use primary color instead of secondary

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/fantacalcio2025-mod-difesa/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68bc6d78da6c8324b0e222727e1cdb1d