### PR TITLE
Add coin icon to price displays

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Fantacalcio 2025 - Ultra Intelligence</title>
+    <!-- Optional: load Font Awesome for custom coin icon -->
+    <!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"> -->
     <style>
         * {
             margin: 0;
@@ -299,6 +301,11 @@
             border-radius: var(--radius);
             background: var(--color-primary);
             color: var(--text-color);
+        }
+
+        .coin-icon {
+            display: inline-block;
+            margin-left: 2px;
         }
 
         .opportunity-badge {
@@ -799,8 +806,8 @@
                         <input type="range" class="range-input" id="min-price" min="1" max="200" value="1" step="1">
                         <input type="range" class="range-input" id="max-price" min="1" max="200" value="200" step="1">
                         <div class="range-values">
-                            <span id="min-price-val">1</span>
-                            <span id="max-price-val">200</span>
+                            <span id="min-price-val">1<span class="coin-icon">🪙</span></span>
+                            <span id="max-price-val">200<span class="coin-icon">🪙</span></span>
                         </div>
                     </div>
                 </div>
@@ -1205,8 +1212,8 @@
             
             currentFilters.maxPrice = maxPrice;
             
-            document.getElementById('min-price-val').textContent = currentFilters.minPrice;
-            document.getElementById('max-price-val').textContent = currentFilters.maxPrice;
+            document.getElementById('min-price-val').innerHTML = currentFilters.minPrice + '<span class="coin-icon">🪙</span>';
+            document.getElementById('max-price-val').innerHTML = currentFilters.maxPrice + '<span class="coin-icon">🪙</span>';
             
             renderPlayers();
         }
@@ -1435,14 +1442,14 @@
                                 </div>
                             </div>
                             <div class="price-badge">
-                                <div class="smart-price">${Math.round(price)}</div>
+                                <div class="smart-price">${Math.round(price)}<span class="coin-icon">🪙</span></div>
                             </div>
                             <div class="player-actions">
                                 <button class="action-btn" onclick="toggleTarget('${t.name}', '${role}', ${Math.round(t.price)})">❌</button>
                                 <button class="action-btn" onclick="editTarget('${key}')">✏️</button>
                                 <button class="action-btn" onclick="promptBuyPlayer('${t.name}', ${Math.round(price)}, '${role}')">💸</button>
                                 <button class="action-btn" onclick="${othersInfo ? `unmarkBoughtElsewhere('${t.name}', '${role}')` : `markBoughtElsewhere('${t.name}', '${role}')`}">🚫</button>
-                                ${purchasedInfo ? `<button class="action-btn" onclick="unbuyPlayer('${t.name}', '${role}')">🔄</button><span class=\"purchase-badge\">${Math.round(purchasedInfo.price)}</span>` : ''}
+                                ${purchasedInfo ? `<button class="action-btn" onclick="unbuyPlayer('${t.name}', '${role}')">🔄</button><span class=\"purchase-badge\">${Math.round(purchasedInfo.price)}<span class=\"coin-icon\">🪙</span></span>` : ''}
                             </div>
                         </div>`;
                     });
@@ -1484,11 +1491,11 @@
                     players.forEach(t => {
                         const key = `${t.role}:${t.name}`;
                         const price = purchased[key]?.price ?? t.price;
-                        if (t.prices) {
-                            html += `<li class="recommendation" style="margin-left:10px;">${t.name} (${t.role}) - I:${t.prices.ideal} S:${t.prices.suggested} M:${t.prices.max} • ${Math.round(price)}${t.targetPrice ? ` (TP: ${Math.round(t.targetPrice)})` : ''}</li>`;
-                        } else {
-                            html += `<li class="recommendation" style="margin-left:10px;">${t.name} (${t.role}) - ${Math.round(price)}${t.targetPrice ? ` (TP: ${Math.round(t.targetPrice)})` : ''}</li>`;
-                        }
+                            if (t.prices) {
+                                html += `<li class="recommendation" style="margin-left:10px;">${t.name} (${t.role}) - I:${t.prices.ideal}<span class="coin-icon">🪙</span> S:${t.prices.suggested}<span class="coin-icon">🪙</span> M:${t.prices.max}<span class="coin-icon">🪙</span> • ${Math.round(price)}<span class="coin-icon">🪙</span>${t.targetPrice ? ` (TP: ${Math.round(t.targetPrice)}<span class="coin-icon">🪙</span>)` : ''}</li>`;
+                            } else {
+                                html += `<li class="recommendation" style="margin-left:10px;">${t.name} (${t.role}) - ${Math.round(price)}<span class="coin-icon">🪙</span>${t.targetPrice ? ` (TP: ${Math.round(t.targetPrice)}<span class="coin-icon">🪙</span>)` : ''}</li>`;
+                            }
                     });
                 });
                 list.innerHTML = html;
@@ -1569,7 +1576,7 @@
                     badge.className = 'purchase-badge';
                     actions.appendChild(badge);
                 }
-                badge.textContent = `${price}`;
+                badge.innerHTML = `${price}<span class="coin-icon">🪙</span>`;
             }
             targets[key] = targets[key] || { name, role, price, slot };
             targets[key].price = price;
@@ -1690,17 +1697,17 @@
                         </div>
                         <div class="price-badge">
                             <div class="smart-price">
-                                ${Math.round(player.prezzi.avg)}
+                                ${Math.round(player.prezzi.avg)}<span class="coin-icon">🪙</span>
                             </div>
                             <div class="price-range">
-                                ${Math.round(player.prezzi.min)}-${Math.round(player.prezzi.max)}
+                                ${Math.round(player.prezzi.min)}<span class="coin-icon">🪙</span>-${Math.round(player.prezzi.max)}<span class="coin-icon">🪙</span>
                             </div>
                         </div>
                     </div>
                     <div class="player-actions">
                         <button class="action-btn" onclick="event.stopPropagation(); toggleTarget('${player.nome}', '${role}', ${Math.round(player.prezzi.avg)})">🎯</button>
                         <button class="action-btn" onclick="event.stopPropagation(); promptBuyPlayer('${player.nome}', ${Math.round(player.prezzi.avg)}, '${role}')">💸</button>
-                        ${purchasedInfo ? `<button class="action-btn" onclick="event.stopPropagation(); unbuyPlayer('${player.nome}', '${role}')">🔄</button><span class=\"purchase-badge\">${Math.round(purchasedInfo.price)}</span>` : ''}
+                        ${purchasedInfo ? `<button class="action-btn" onclick="event.stopPropagation(); unbuyPlayer('${player.nome}', '${role}')">🔄</button><span class=\"purchase-badge\">${Math.round(purchasedInfo.price)}<span class=\"coin-icon\">🪙</span></span>` : ''}
                     </div>
                 </div>
             `;
@@ -1796,7 +1803,7 @@
                         ${roleIcons[opp.role]} ${opp.nome} (${opp.team})
                     </div>
                     <div class="recommendation-price">
-                        Target: ${Math.round(opp.targetPrice)} crediti (Risparmio: ${Math.round(opp.savings)} crediti) • Affidabilità: ${opp.reliability}/5 • Forma: ${opp.recentForm.toFixed(2)}
+                        Target: ${Math.round(opp.targetPrice)}<span class="coin-icon">🪙</span> crediti (Risparmio: ${Math.round(opp.savings)}<span class="coin-icon">🪙</span> crediti) • Affidabilità: ${opp.reliability}/5 • Forma: ${opp.recentForm.toFixed(2)}
                     </div>
                 </li>
             `).join('') || '<li class="recommendation"><div class="recommendation-text">Nessuna opportunità con i filtri attuali</div></li>';
@@ -1820,10 +1827,10 @@
 
             const topPlayers = highReliability.slice(0, 3);
             const insightText = topPlayers.length
-                ? `Giocatori affidabili a basso costo: ${topPlayers.map(p => `${roleIcons[p.role]} ${p.nome} ${Math.round(p.prezzi.avg)} crediti`).join(', ')}`
+                ? `Giocatori affidabili a basso costo: ${topPlayers.map(p => `${roleIcons[p.role]} ${p.nome} ${Math.round(p.prezzi.avg)}<span class="coin-icon">🪙</span> crediti`).join(', ')}`
                 : 'Nessun giocatore affidabile trovato.';
 
-            document.getElementById('ai-insight').textContent = insightText;
+            document.getElementById('ai-insight').innerHTML = insightText;
             setTimeout(generateAIInsights, 10000);
         }
 
@@ -1849,15 +1856,15 @@
                         <div class="detail-title">💰 Analisi Prezzi Smart</div>
                         <div style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 15px; margin-bottom: 15px;">
                             <div style="text-align: center;">
-                                <div style="font-size: 1.5rem; font-weight: 600; color: var(--color-warning);">${player.prezzi.min} crediti</div>
+                                <div style="font-size: 1.5rem; font-weight: 600; color: var(--color-warning);">${player.prezzi.min}<span class="coin-icon">🪙</span> crediti</div>
                                 <div style="font-size: var(--font-base); color: var(--text-muted);">Minimo</div>
                             </div>
                             <div style="text-align: center;">
-                                <div style="font-size: 1.8rem; font-weight: 600; color: var(--color-primary);">${player.prezzi.avg} crediti</div>
+                                <div style="font-size: 1.8rem; font-weight: 600; color: var(--color-primary);">${player.prezzi.avg}<span class="coin-icon">🪙</span> crediti</div>
                                 <div style="font-size: var(--font-base); color: var(--text-muted);">Consenso</div>
                             </div>
                             <div style="text-align: center;">
-                                <div style="font-size: 1.5rem; font-weight: 600; color: var(--color-success);">${player.prezzi.max} crediti</div>
+                                <div style="font-size: 1.5rem; font-weight: 600; color: var(--color-success);">${player.prezzi.max}<span class="coin-icon">🪙</span> crediti</div>
                                 <div style="font-size: var(--font-base); color: var(--text-muted);">Massimo</div>
                             </div>
                         </div>
@@ -1870,7 +1877,7 @@
                 detailsHtml += `
                     <div class="source-price">
                         <div class="source-name">${cleanSource}</div>
-                        <div class="source-value">${Math.round(price)} crediti</div>
+                        <div class="source-value">${Math.round(price)}<span class="coin-icon">🪙</span> crediti</div>
                     </div>
                 `;
             });
@@ -1919,9 +1926,9 @@
                     <div class="detail-section">
                         <div class="detail-title">🎯 Raccomandazione AI</div>
                         <div style="background: var(--card-bg); padding: 15px; border-radius: var(--radius); border-left: 4px solid var(--color-primary);">
-                            <strong>Ideale:</strong> ${priceHints.ideal} crediti<br>
-                            <strong>Suggerito:</strong> ${priceHints.suggested} crediti<br>
-                            <strong>Massimo:</strong> ${priceHints.max} crediti<br>
+                            <strong>Ideale:</strong> ${priceHints.ideal}<span class="coin-icon">🪙</span> crediti<br>
+                            <strong>Suggerito:</strong> ${priceHints.suggested}<span class="coin-icon">🪙</span> crediti<br>
+                            <strong>Massimo:</strong> ${priceHints.max}<span class="coin-icon">🪙</span> crediti<br>
                             <strong>Opportunità:</strong> ${getOpportunityLevel(player).toUpperCase()}<br>
                             <strong>Strategia:</strong> ${getOpportunityLevel(player) === 'high' ? 'Punta al prezzo minimo, alta volatilità' : 'Prezzo stabile, offri vicino al consenso'}
                         </div>


### PR DESCRIPTION
## Summary
- Add optional Font Awesome link and coin icon styling
- Show coin icon beside smart prices, ranges, recommendations, and slider values
- Ensure dynamic updates render coin icons via innerHTML

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc6e0106648324bdd9cecac0b3892b