### PR TITLE
Fix price badge alignment and size

### DIFF
--- a/index.html
+++ b/index.html
@@ -296,11 +296,17 @@
             margin-left: auto;
             display: flex;
             flex-direction: column;
-            align-items: flex-end;
+            align-items: center;
+            justify-content: center;
+            width: 60px;
+            min-width: 60px;
+            height: 50px;
+            min-height: 50px;
             padding: 4px 8px;
             border-radius: var(--radius);
             background: var(--color-primary);
             color: var(--text-color);
+            text-align: center;
         }
 
         .coin-icon {


### PR DESCRIPTION
## Summary
- set a fixed width and height for `.price-badge`
- center price values inside the badge using flexbox

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6fd38848832481bf594f03948846