### PR TITLE
Handle array or object player lookups

### DIFF
--- a/index.html
+++ b/index.html
@@ -1323,8 +1323,14 @@
 
         function findPlayer(name, role) {
             const players = PLAYERS_DB[role] || [];
-            const playerArray = players.find(p => p[0] === name);
-            return playerArray ? decodePlayer(playerArray, role) : null;
+            const playerRecord = players.find(
+                p => (Array.isArray(p) ? p[0] : p.nome) === name
+            );
+            return playerRecord
+                ? Array.isArray(playerRecord)
+                    ? decodePlayer(playerRecord, role)
+                    : playerRecord
+                : null;
         }
 
         function calculateTargetPrices(player, role) {
@@ -1850,11 +1856,15 @@
 
         function showPlayerDetails(playerName, role, push = true) {
             const players = PLAYERS_DB[role] || [];
-            const playerArray = players.find(p => p[0] === playerName);
-            
-            if (!playerArray) return;
-            
-            const player = decodePlayer(playerArray, role);
+            const playerRecord = players.find(
+                p => (Array.isArray(p) ? p[0] : p.nome) === playerName
+            );
+
+            if (!playerRecord) return;
+
+            const player = Array.isArray(playerRecord)
+                ? decodePlayer(playerRecord, role)
+                : playerRecord;
             const priceHints = calculateTargetPrices(player, role);
             const modal = document.getElementById('player-modal');
             const detailsContainer = document.getElementById('player-details');

--- a/scripts/generate_database.py
+++ b/scripts/generate_database.py
@@ -87,7 +87,7 @@ def main() -> None:
             "prezzi": {"min": min_p, "max": max_p, "avg": avg},
             "allPrices": {},
             "performance": {},
-            "notes": {},
+            "notes": {"comm": ""},
         }
         for _, row in grp.iterrows():
             year = str(row["season"]).split("_")[0]


### PR DESCRIPTION
## Summary
- Support both array- and object-based records in `findPlayer` and `showPlayerDetails` so modal lookups work regardless of data format.
- Ensure future database generation always includes an empty `notes.comm` field.

## Testing
- `python3 scripts/generate_database.py` *(fails: pandas is required to run this script)*
- `pip install pandas` *(fails: Could not find a version that satisfies the requirement pandas; 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_68bc816947c083249c4f7bd48a148790