### PR TITLE
Enable notes fallback and season switching

### DIFF
--- a/index.html
+++ b/index.html
@@ -1231,7 +1231,8 @@
                     max: Math.round(playerArray[2][1]),
                     avg: Math.round(playerArray[2][2])
                 },
-                stats: playerArray[3]
+                stats: playerArray[3],
+                notes: { comm: "" }
             };
 
             if (role === 'P' || role === 'D') {
@@ -1239,7 +1240,7 @@
                 if (playerArray.length >= 9) {
                     baseData.performance = playerArray[5];
                     baseData.fascia = playerArray[6];
-                    baseData.notes = playerArray[7] || {};
+                    baseData.notes = playerArray[7] || { comm: "" };
                     baseData.allPrices = playerArray[8];
                 } else {
                     baseData.fascia = playerArray[5];
@@ -1249,7 +1250,7 @@
                 baseData.performance = playerArray[4];
                 baseData.discipline = playerArray[5];
                 baseData.fascia = playerArray[6];
-                baseData.notes = playerArray[7] || {};
+                baseData.notes = playerArray[7] || { comm: "" };
                 baseData.allPrices = playerArray[8];
             }
 
@@ -1874,8 +1875,8 @@
             let detailsHtml = `
                 <h2>${roleIcons[role]} ${player.nome}</h2>
                 <p style="color: var(--text-muted); margin-bottom: 20px;">${player.team} • ${player.fascia}</p>
-                ${player.notes?.comm ? `<p style="margin-bottom:20px;">${player.notes.comm}</p>` : ''}
-                
+                ${player.notes?.comm ? `<div id="player-comm" style="margin-bottom:20px;"></div>` : ''}
+
                 <div class="player-details">
                     <div class="detail-section">
                         <div class="detail-title">💰 Analisi Prezzi Smart</div>
@@ -1937,29 +1938,27 @@
                             </div>
                         </div>
                     </div>
-                    <div class="detail-section">
-                        <div class="detail-title">⏱️ Last 2 Seasons</div>
-                        <div style="display: grid; grid-template-columns: repeat(2, 1fr); gap: 15px;">
-                            ${player.performance?.["2025_26"] ? `<div><strong>2025/26:</strong> G:${player.performance["2025_26"].goals ?? player.performance["2025_26"].g ?? 0} A:${player.performance["2025_26"].assists ?? player.performance["2025_26"].as ?? 0} Min:${player.performance["2025_26"].minutes ?? player.performance["2025_26"].min ?? 0} MV:${player.performance["2025_26"].rating ?? player.performance["2025_26"].mv ?? 'N/A'}</div>` : ''}
-                            ${player.performance?.["2024_25"] ? `<div><strong>2024/25:</strong> G:${player.performance["2024_25"].goals ?? player.performance["2024_25"].g ?? 0} A:${player.performance["2024_25"].assists ?? player.performance["2024_25"].as ?? 0} Min:${player.performance["2024_25"].minutes ?? player.performance["2024_25"].min ?? 0} MV:${player.performance["2024_25"].rating ?? player.performance["2024_25"].mv ?? 'N/A'}</div>` : ''}
-                        </div>
-                    </div>
             `;
 
-            // Role-specific advanced stats
-            if (role === 'C' || role === 'A') {
-                const perf = player.performance?.["2025_26"] || {};
+            const seasons = Object.keys(player.performance || {}).sort().slice(-2).reverse();
+            if (seasons.length) {
                 detailsHtml += `
                     <div class="detail-section">
                         <div class="detail-title">⚽ Performance</div>
-                        <div style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 15px;">
-                            <div><strong>Gol:</strong> ${perf.g ?? perf.goals ?? 0}</div>
-                            <div><strong>Assist:</strong> ${perf.as ?? perf.assists ?? 0}</div>
-                            <div><strong>Presenze:</strong> ${perf.p ?? perf.presenze ?? 0}</div>
-                            <div><strong>Rigoristi:</strong> ${perf.rs ?? 0}</div>
-                            <div><strong>Media Voto:</strong> ${perf.mv ?? perf.rating ?? 'N/A'}</div>
-                            <div><strong>FMV Exp:</strong> ${perf.fexp ?? 'N/A'}</div>
+                        <div id="season-rows">
+                `;
+                seasons.forEach(season => {
+                    const perf = player.performance[season] || {};
+                    const g = perf.goals ?? perf.g ?? 0;
+                    const a = perf.assists ?? perf.as ?? 0;
+                    const m = perf.minutes ?? perf.min ?? 0;
+                    const r = perf.rating ?? perf.mv ?? 'N/A';
+                    const label = season.replace('_','/');
+                    detailsHtml += `<div class="season-row" data-season="${season}" style="cursor:pointer; padding:4px 0;"><strong>${label}:</strong> G:${g} A:${a} Min:${m} MV:${r}</div>`;
+                });
+                detailsHtml += `
                         </div>
+                        <div id="selected-season" style="margin-top:10px;"></div>
                     </div>
                 `;
             }
@@ -1979,6 +1978,27 @@
             `;
 
             detailsContainer.innerHTML = detailsHtml;
+
+            if (player.notes?.comm) {
+                const commEl = document.getElementById('player-comm');
+                if (commEl) commEl.innerHTML = player.notes.comm.replace(/\n/g, '<br>');
+            }
+
+            const seasonRows = detailsContainer.querySelectorAll('.season-row');
+            const selectedSeasonEl = detailsContainer.querySelector('#selected-season');
+            seasonRows.forEach(row => {
+                row.addEventListener('click', () => {
+                    const season = row.dataset.season;
+                    const stats = player.performance[season] || {};
+                    seasonRows.forEach(r => r.classList.remove('active'));
+                    row.classList.add('active');
+                    selectedSeasonEl.innerHTML = Object.entries(stats)
+                        .map(([k, v]) => `<div><strong>${k}:</strong> ${v}</div>`)
+                        .join('');
+                });
+            });
+            if (seasonRows.length) seasonRows[0].click();
+
             modal.style.display = 'flex';
             if (push) history.pushState({ view: 'player', player: playerName, role }, '');
         }

--- a/scripts/generate_database.py
+++ b/scripts/generate_database.py
@@ -89,6 +89,7 @@ def main() -> None:
             "performance": {},
             "notes": {"comm": ""},
         }
+        fallback_comm = ""
         for _, row in grp.iterrows():
             year = str(row["season"]).split("_")[0]
             player["allPrices"][f"{row['source']}_{year}"] = int(row["price"])
@@ -101,8 +102,20 @@ def main() -> None:
                     "rating": float(row.get("rating", 0) or 0),
                 },
             )
-            if row["source"] == "sos_fanta" and isinstance(row.get("comm"), str) and row.get("comm"):
-                player["notes"]["comm"] = row["comm"]
+            comm = row.get("comm")
+            if row["source"] == "sos_fanta" and isinstance(comm, str) and comm:
+                player["notes"]["comm"] = comm
+            elif not fallback_comm and isinstance(comm, str) and comm:
+                fallback_comm = comm
+        if not player["notes"]["comm"] and fallback_comm:
+            player["notes"]["comm"] = fallback_comm
+
+        for season in SOURCES.keys():
+            player["performance"].setdefault(
+                season,
+                {"goals": 0, "assists": 0, "minutes": 0, "rating": 0},
+            )
+
         result.setdefault(role, []).append(player)
 
     with Path("players_database.json").open("w", encoding="utf-8") as f:


### PR DESCRIPTION
## Summary
- Ensure database builder fills missing comments from any provider and pre-populates performance for both seasons
- Default notes object in player decoder so all roles expose descriptions
- Show full player notes and interactive season stats with selectable rows

## Testing
- `python -m py_compile scripts/generate_database.py`
- `python scripts/generate_database.py` *(fails: pandas is required to run this script)*
- `pip install pandas` *(fails: Could not find a version that satisfies the requirement pandas)*

------
https://chatgpt.com/codex/tasks/task_e_68bc859f14388324bf8fed9f6fbede0a