### PR TITLE
Document openpyxl dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+openpyxl


### PR DESCRIPTION
## Summary
- declare openpyxl requirement for database generation

## Testing
- `pip install openpyxl` *(fails: Could not find a version that satisfies the requirement openpyxl)*
- `python scripts/generate_database.py` *(fails: ModuleNotFoundError: No module named 'openpyxl')*


------
https://chatgpt.com/codex/tasks/task_e_68bc89482ad48324a2484bb23730bc81