### PR TITLE
Load all worksheets when generating database

### DIFF
--- a/players_database.json
+++ b/players_database.json
@@ -6,7 +6,7 @@
       "prezzi": {
         "min": 42,
         "max": 50,
-        "avg": 45.9
+        "avg": 45.8
       },
       "stats": {
         "t": 5,
@@ -17,6 +17,7 @@
       "allPrices": {
         "fantaboom_2025": 50,
         "fantaclassic_2025": 46,
+        "profeta_2025": 45,
         "sos_fanta_2025": 42,
         "fantaboom_2024": 50,
         "fantaclassic_2024": 46,
@@ -47,7 +48,7 @@
       "prezzi": {
         "min": 44,
         "max": 50,
-        "avg": 46.6
+        "avg": 47.0
       },
       "stats": {
         "t": 4,
@@ -58,6 +59,7 @@
       "allPrices": {
         "fantaboom_2025": 49,
         "fantaclassic_2025": 45,
+        "profeta_2025": 50,
         "sos_fanta_2025": 44,
         "fantaboom_2024": 49,
         "fantaclassic_2024": 45,
@@ -88,7 +90,7 @@
       "prezzi": {
         "min": 42,
         "max": 48,
-        "avg": 45.9
+        "avg": 45.8
       },
       "stats": {
         "t": 4,
@@ -99,6 +101,7 @@
       "allPrices": {
         "fantaboom_2025": 48,
         "fantaclassic_2025": 48,
+        "profeta_2025": 45,
         "sos_fanta_2025": 42,
         "fantaboom_2024": 48,
         "fantaclassic_2024": 48,
@@ -129,7 +132,7 @@
       "prezzi": {
         "min": 40,
         "max": 50,
-        "avg": 44.0
+        "avg": 44.8
       },
       "stats": {
         "t": 3,
@@ -140,6 +143,7 @@
       "allPrices": {
         "fantaboom_2025": 45,
         "fantaclassic_2025": 44,
+        "profeta_2025": 50,
         "sos_fanta_2025": 40,
         "fantaboom_2024": 45,
         "fantaclassic_2024": 44,
@@ -170,7 +174,7 @@
       "prezzi": {
         "min": 45,
         "max": 50,
-        "avg": 46.3
+        "avg": 46.8
       },
       "stats": {
         "t": 5,
@@ -181,6 +185,7 @@
       "allPrices": {
         "fantaboom_2025": 45,
         "fantaclassic_2025": 47,
+        "profeta_2025": 50,
         "sos_fanta_2025": 45,
         "fantaboom_2024": 45,
         "fantaclassic_2024": 47,
@@ -211,7 +216,7 @@
       "prezzi": {
         "min": 27,
         "max": 40,
-        "avg": 33.4
+        "avg": 34.2
       },
       "stats": {
         "t": 5,
@@ -222,6 +227,7 @@
       "allPrices": {
         "fantaboom_2025": 35,
         "fantaclassic_2025": 35,
+        "profeta_2025": 40,
         "sos_fanta_2025": 27,
         "fantaboom_2024": 35,
         "fantaclassic_2024": 35,
@@ -252,7 +258,7 @@
       "prezzi": {
         "min": 30,
         "max": 40,
-        "avg": 31.7
+        "avg": 32.8
       },
       "stats": {
         "t": 5,
@@ -263,6 +269,7 @@
       "allPrices": {
         "fantaboom_2025": 30,
         "fantaclassic_2025": 31,
+        "profeta_2025": 40,
         "sos_fanta_2025": 30,
         "fantaboom_2024": 30,
         "fantaclassic_2024": 31,
@@ -293,7 +300,7 @@
       "prezzi": {
         "min": 19,
         "max": 30,
-        "avg": 23.1
+        "avg": 24.0
       },
       "stats": {
         "t": 3,
@@ -304,6 +311,7 @@
       "allPrices": {
         "fantaboom_2025": 25,
         "fantaclassic_2025": 22,
+        "profeta_2025": 30,
         "sos_fanta_2025": 19,
         "fantaboom_2024": 25,
         "fantaclassic_2024": 22,
@@ -334,7 +342,7 @@
       "prezzi": {
         "min": 12,
         "max": 25,
-        "avg": 18.4
+        "avg": 19.2
       },
       "stats": {
         "t": 4,
@@ -345,6 +353,7 @@
       "allPrices": {
         "fantaboom_2025": 20,
         "fantaclassic_2025": 20,
+        "profeta_2025": 25,
         "sos_fanta_2025": 12,
         "fantaboom_2024": 20,
         "fantaclassic_2024": 20,
@@ -375,7 +384,7 @@
       "prezzi": {
         "min": 7,
         "max": 12,
-        "avg": 9.7
+        "avg": 10.0
       },
       "stats": {
         "t": 5,
@@ -386,6 +395,7 @@
       "allPrices": {
         "fantaboom_2025": 12,
         "fantaclassic_2025": 9,
+        "profeta_2025": 12,
         "sos_fanta_2025": 7,
         "fantaboom_2024": 12,
         "fantaclassic_2024": 9,
@@ -416,7 +426,7 @@
       "prezzi": {
         "min": 6,
         "max": 12,
-        "avg": 10.0
+        "avg": 10.2
       },
       "stats": {
         "t": 4,
@@ -427,6 +437,7 @@
       "allPrices": {
         "fantaboom_2025": 12,
         "fantaclassic_2025": 11,
+        "profeta_2025": 12,
         "sos_fanta_2025": 6,
         "fantaboom_2024": 12,
         "fantaclassic_2024": 11,
@@ -457,7 +468,7 @@
       "prezzi": {
         "min": 8,
         "max": 15,
-        "avg": 11.3
+        "avg": 11.8
       },
       "stats": {
         "t": 4,
@@ -468,6 +479,7 @@
       "allPrices": {
         "fantaboom_2025": 12,
         "fantaclassic_2025": 12,
+        "profeta_2025": 15,
         "sos_fanta_2025": 8,
         "fantaboom_2024": 12,
         "fantaclassic_2024": 12,
@@ -498,7 +510,7 @@
       "prezzi": {
         "min": 10,
         "max": 20,
-        "avg": 12.6
+        "avg": 13.5
       },
       "stats": {
         "t": 5,
@@ -509,6 +521,7 @@
       "allPrices": {
         "fantaboom_2025": 11,
         "fantaclassic_2025": 13,
+        "profeta_2025": 20,
         "sos_fanta_2025": 10,
         "fantaboom_2024": 11,
         "fantaclassic_2024": 13,
@@ -539,7 +552,7 @@
       "prezzi": {
         "min": 5,
         "max": 10,
-        "avg": 6.0
+        "avg": 6.5
       },
       "stats": {
         "t": 5,
@@ -550,6 +563,7 @@
       "allPrices": {
         "fantaboom_2025": 5,
         "fantaclassic_2025": 5,
+        "profeta_2025": 10,
         "sos_fanta_2025": 6,
         "fantaboom_2024": 5,
         "fantaclassic_2024": 5,
@@ -580,7 +594,7 @@
       "prezzi": {
         "min": 1,
         "max": 5,
-        "avg": 2.7
+        "avg": 3.0
       },
       "stats": {
         "t": 3,
@@ -591,6 +605,7 @@
       "allPrices": {
         "fantaboom_2025": 4,
         "fantaclassic_2025": 2,
+        "profeta_2025": 5,
         "sos_fanta_2025": 1,
         "fantaboom_2024": 4,
         "fantaclassic_2024": 2,
@@ -621,7 +636,7 @@
       "prezzi": {
         "min": 4,
         "max": 10,
-        "avg": 5.1
+        "avg": 5.8
       },
       "stats": {
         "t": 5,
@@ -632,6 +647,7 @@
       "allPrices": {
         "fantaboom_2025": 4,
         "fantaclassic_2025": 5,
+        "profeta_2025": 10,
         "sos_fanta_2025": 4,
         "fantaboom_2024": 4,
         "fantaclassic_2024": 5,
@@ -662,7 +678,7 @@
       "prezzi": {
         "min": 2,
         "max": 5,
-        "avg": 3.4
+        "avg": 3.2
       },
       "stats": {
         "t": 5,
@@ -673,6 +689,7 @@
       "allPrices": {
         "fantaboom_2025": 3,
         "fantaclassic_2025": 5,
+        "profeta_2025": 2,
         "sos_fanta_2025": 3,
         "fantaboom_2024": 3,
         "fantaclassic_2024": 5,
@@ -703,7 +720,7 @@
       "prezzi": {
         "min": 0,
         "max": 2,
-        "avg": 1.1
+        "avg": 1.2
       },
       "stats": {
         "t": 3,
@@ -714,6 +731,7 @@
       "allPrices": {
         "fantaboom_2025": 2,
         "fantaclassic_2025": 0,
+        "profeta_2025": 2,
         "sos_fanta_2025": 1,
         "fantaboom_2024": 2,
         "fantaclassic_2024": 0,
@@ -744,7 +762,7 @@
       "prezzi": {
         "min": 1,
         "max": 10,
-        "avg": 2.6
+        "avg": 3.5
       },
       "stats": {
         "t": 4,
@@ -755,6 +773,7 @@
       "allPrices": {
         "fantaboom_2025": 1,
         "fantaclassic_2025": 1,
+        "profeta_2025": 10,
         "sos_fanta_2025": 2,
         "fantaboom_2024": 1,
         "fantaclassic_2024": 1,
@@ -785,7 +804,7 @@
       "prezzi": {
         "min": 1,
         "max": 2,
-        "avg": 1.1
+        "avg": 1.2
       },
       "stats": {
         "t": 3,
@@ -796,6 +815,7 @@
       "allPrices": {
         "fantaboom_2025": 1,
         "fantaclassic_2025": 1,
+        "profeta_2025": 2,
         "sos_fanta_2025": 1,
         "fantaboom_2024": 1,
         "fantaclassic_2024": 1,
@@ -826,7 +846,7 @@
       "prezzi": {
         "min": 13,
         "max": 18,
-        "avg": 15.3
+        "avg": 15.2
       },
       "stats": {
         "t": 3,
@@ -837,6 +857,7 @@
       "allPrices": {
         "fantaboom_2025": 15,
         "fantaclassic_2025": 13,
+        "profeta_2025": 15,
         "sos_fanta_2025": 18,
         "fantaboom_2024": 15,
         "fantaclassic_2024": 13,
@@ -867,7 +888,7 @@
       "prezzi": {
         "min": 0,
         "max": 2,
-        "avg": 1.1
+        "avg": 1.2
       },
       "stats": {
         "t": 2,
@@ -878,6 +899,7 @@
       "allPrices": {
         "fantaboom_2025": 1,
         "fantaclassic_2025": 0,
+        "profeta_2025": 2,
         "sos_fanta_2025": 2,
         "fantaboom_2024": 1,
         "fantaclassic_2024": 0,
@@ -908,7 +930,7 @@
       "prezzi": {
         "min": 0,
         "max": 1,
-        "avg": 0.6
+        "avg": 0.5
       },
       "stats": {
         "t": 2,
@@ -919,6 +941,7 @@
       "allPrices": {
         "fantaboom_2025": 1,
         "fantaclassic_2025": 0,
+        "profeta_2025": 0,
         "sos_fanta_2025": 1,
         "fantaboom_2024": 1,
         "fantaclassic_2024": 0,
@@ -949,7 +972,7 @@
       "prezzi": {
         "min": 0,
         "max": 2,
-        "avg": 0.9
+        "avg": 1.0
       },
       "stats": {
         "t": 2,
@@ -960,6 +983,7 @@
       "allPrices": {
         "fantaboom_2025": 1,
         "fantaclassic_2025": 0,
+        "profeta_2025": 2,
         "sos_fanta_2025": 1,
         "fantaboom_2024": 1,
         "fantaclassic_2024": 0,
@@ -1001,6 +1025,7 @@
       "allPrices": {
         "fantaboom_2025": 7,
         "fantaclassic_2025": 5,
+        "profeta_2025": 5,
         "sos_fanta_2025": 3,
         "fantaboom_2024": 7,
         "fantaclassic_2024": 5,
@@ -1031,7 +1056,7 @@
       "prezzi": {
         "min": 0,
         "max": 4,
-        "avg": 2.0
+        "avg": 1.8
       },
       "stats": {
         "t": 3,
@@ -1042,6 +1067,7 @@
       "allPrices": {
         "fantaboom_2025": 2,
         "fantaclassic_2025": 4,
+        "profeta_2025": 0,
         "sos_fanta_2025": 1,
         "fantaboom_2024": 2,
         "fantaclassic_2024": 4,
@@ -1072,7 +1098,7 @@
       "prezzi": {
         "min": 1,
         "max": 5,
-        "avg": 1.6
+        "avg": 2.0
       },
       "stats": {
         "t": 3,
@@ -1083,6 +1109,7 @@
       "allPrices": {
         "fantaboom_2025": 1,
         "fantaclassic_2025": 1,
+        "profeta_2025": 5,
         "sos_fanta_2025": 1,
         "fantaboom_2024": 1,
         "fantaclassic_2024": 1,
@@ -1113,7 +1140,7 @@
       "prezzi": {
         "min": 0,
         "max": 2,
-        "avg": 0.9
+        "avg": 1.0
       },
       "stats": {
         "t": 3,
@@ -1124,6 +1151,7 @@
       "allPrices": {
         "fantaboom_2025": 1,
         "fantaclassic_2025": 0,
+        "profeta_2025": 2,
         "sos_fanta_2025": 1,
         "fantaboom_2024": 1,
         "fantaclassic_2024": 0,
@@ -1154,7 +1182,7 @@
       "prezzi": {
         "min": 0,
         "max": 1,
-        "avg": 0.3
+        "avg": 0.2
       },
       "stats": {
         "t": 2,
@@ -1165,6 +1193,7 @@
       "allPrices": {
         "fantaboom_2025": 0,
         "fantaclassic_2025": 0,
+        "profeta_2025": 0,
         "sos_fanta_2025": 1,
         "fantaboom_2024": 0,
         "fantaclassic_2024": 0,
@@ -1206,6 +1235,7 @@
       "allPrices": {
         "fantaboom_2025": 0,
         "fantaclassic_2025": 0,
+        "profeta_2025": 0,
         "sos_fanta_2025": 0,
         "fantaboom_2024": 0,
         "fantaclassic_2024": 0,
@@ -1247,6 +1277,7 @@
       "allPrices": {
         "fantaboom_2025": 0,
         "fantaclassic_2025": 0,
+        "profeta_2025": 0,
         "sos_fanta_2025": 0,
         "fantaboom_2024": 0,
         "fantaclassic_2024": 0,
@@ -1277,7 +1308,7 @@
       "prezzi": {
         "min": 0,
         "max": 1,
-        "avg": 0.3
+        "avg": 0.2
       },
       "stats": {
         "t": 1,
@@ -1288,6 +1319,7 @@
       "allPrices": {
         "fantaboom_2025": 0,
         "fantaclassic_2025": 0,
+        "profeta_2025": 0,
         "sos_fanta_2025": 1,
         "fantaboom_2024": 0,
         "fantaclassic_2024": 0,
@@ -1329,6 +1361,7 @@
       "allPrices": {
         "fantaboom_2025": 0,
         "fantaclassic_2025": 0,
+        "profeta_2025": 0,
         "sos_fanta_2025": 0,
         "fantaboom_2024": 0,
         "fantaclassic_2024": 0,
@@ -1359,7 +1392,7 @@
       "prezzi": {
         "min": 0,
         "max": 1,
-        "avg": 0.3
+        "avg": 0.2
       },
       "stats": {
         "t": 1,
@@ -1370,6 +1403,7 @@
       "allPrices": {
         "fantaboom_2025": 0,
         "fantaclassic_2025": 0,
+        "profeta_2025": 0,
         "sos_fanta_2025": 1,
         "fantaboom_2024": 0,
         "fantaclassic_2024": 0,
@@ -1411,6 +1445,7 @@
       "allPrices": {
         "fantaboom_2025": 0,
         "fantaclassic_2025": 0,
+        "profeta_2025": 0,
         "sos_fanta_2025": 0,
         "fantaboom_2024": 0,
         "fantaclassic_2024": 0,
@@ -1452,6 +1487,7 @@
       "allPrices": {
         "fantaboom_2025": 0,
         "fantaclassic_2025": 0,
+        "profeta_2025": 0,
         "sos_fanta_2025": 0,
         "fantaboom_2024": 0,
         "fantaclassic_2024": 0,
@@ -1493,6 +1529,7 @@
       "allPrices": {
         "fantaboom_2025": 0,
         "fantaclassic_2025": 0,
+        "profeta_2025": 0,
         "sos_fanta_2025": 0,
         "fantaboom_2024": 0,
         "fantaclassic_2024": 0,
@@ -1523,7 +1560,7 @@
       "prezzi": {
         "min": 0,
         "max": 1,
-        "avg": 0.3
+        "avg": 0.2
       },
       "stats": {
         "t": 1,
@@ -1534,6 +1571,7 @@
       "allPrices": {
         "fantaboom_2025": 0,
         "fantaclassic_2025": 0,
+        "profeta_2025": 0,
         "sos_fanta_2025": 1,
         "fantaboom_2024": 0,
         "fantaclassic_2024": 0,
@@ -1564,7 +1602,7 @@
       "prezzi": {
         "min": 0,
         "max": 1,
-        "avg": 0.3
+        "avg": 0.2
       },
       "stats": {
         "t": 1,
@@ -1575,6 +1613,7 @@
       "allPrices": {
         "fantaboom_2025": 0,
         "fantaclassic_2025": 0,
+        "profeta_2025": 0,
         "sos_fanta_2025": 1,
         "fantaboom_2024": 0,
         "fantaclassic_2024": 0,
@@ -1616,6 +1655,7 @@
       "allPrices": {
         "fantaboom_2025": 0,
         "fantaclassic_2025": 0,
+        "profeta_2025": 0,
         "sos_fanta_2025": 0,
         "fantaboom_2024": 0,
         "fantaclassic_2024": 0,
@@ -1657,6 +1697,7 @@
       "allPrices": {
         "fantaboom_2025": 0,
         "fantaclassic_2025": 0,
+        "profeta_2025": 0,
         "sos_fanta_2025": 0,
         "fantaboom_2024": 0,
         "fantaclassic_2024": 0,
@@ -1698,6 +1739,7 @@
       "allPrices": {
         "fantaboom_2025": 0,
         "fantaclassic_2025": 0,
+        "profeta_2025": 0,
         "sos_fanta_2025": 0,
         "fantaboom_2024": 0,
         "fantaclassic_2024": 0,
@@ -1728,7 +1770,7 @@
       "prezzi": {
         "min": 0,
         "max": 1,
-        "avg": 0.3
+        "avg": 0.2
       },
       "stats": {
         "t": 2,
@@ -1739,6 +1781,7 @@
       "allPrices": {
         "fantaboom_2025": 0,
         "fantaclassic_2025": 0,
+        "profeta_2025": 0,
         "sos_fanta_2025": 1,
         "fantaboom_2024": 0,
         "fantaclassic_2024": 0,
@@ -1780,6 +1823,7 @@
       "allPrices": {
         "fantaboom_2025": 0,
         "fantaclassic_2025": 0,
+        "profeta_2025": 0,
         "sos_fanta_2025": 0,
         "fantaboom_2024": 0,
         "fantaclassic_2024": 0,
@@ -1821,6 +1865,7 @@
       "allPrices": {
         "fantaboom_2025": 0,
         "fantaclassic_2025": 0,
+        "profeta_2025": 0,
         "sos_fanta_2025": 0,
         "fantaboom_2024": 0,
         "fantaclassic_2024": 0,
@@ -1862,6 +1907,7 @@
       "allPrices": {
         "fantaboom_2025": 0,
         "fantaclassic_2025": 0,
+        "profeta_2025": 0,
         "sos_fanta_2025": 0,
         "fantaboom_2024": 0,
         "fantaclassic_2024": 0,
@@ -1903,6 +1949,7 @@
       "allPrices": {
         "fantaboom_2025": 0,
         "fantaclassic_2025": 0,
+        "profeta_2025": 0,
         "sos_fanta_2025": 0,
         "fantaboom_2024": 0,
         "fantaclassic_2024": 0,
@@ -1933,7 +1980,7 @@
       "prezzi": {
         "min": 0,
         "max": 1,
-        "avg": 0.3
+        "avg": 0.2
       },
       "stats": {
         "t": 1,
@@ -1944,6 +1991,7 @@
       "allPrices": {
         "fantaboom_2025": 0,
         "fantaclassic_2025": 0,
+        "profeta_2025": 0,
         "sos_fanta_2025": 1,
         "fantaboom_2024": 0,
         "fantaclassic_2024": 0,
@@ -1985,6 +2033,7 @@
       "allPrices": {
         "fantaboom_2025": 0,
         "fantaclassic_2025": 0,
+        "profeta_2025": 0,
         "sos_fanta_2025": 0,
         "fantaboom_2024": 0,
         "fantaclassic_2024": 0,
@@ -2026,6 +2075,7 @@
       "allPrices": {
         "fantaboom_2025": 0,
         "fantaclassic_2025": 0,
+        "profeta_2025": 0,
         "sos_fanta_2025": 0,
         "fantaboom_2024": 0,
         "fantaclassic_2024": 0,
@@ -2067,6 +2117,7 @@
       "allPrices": {
         "fantaboom_2025": 0,
         "fantaclassic_2025": 0,
+        "profeta_2025": 0,
         "sos_fanta_2025": 0,
         "fantaboom_2024": 0,
         "fantaclassic_2024": 0,
@@ -2097,7 +2148,7 @@
       "prezzi": {
         "min": 0,
         "max": 1,
-        "avg": 0.3
+        "avg": 0.2
       },
       "stats": {
         "t": 1,
@@ -2108,6 +2159,7 @@
       "allPrices": {
         "fantaboom_2025": 0,
         "fantaclassic_2025": 0,
+        "profeta_2025": 0,
         "sos_fanta_2025": 1,
         "fantaboom_2024": 0,
         "fantaclassic_2024": 0,
@@ -2138,7 +2190,7 @@
       "prezzi": {
         "min": 0,
         "max": 1,
-        "avg": 0.3
+        "avg": 0.2
       },
       "stats": {
         "t": 2,
@@ -2149,6 +2201,7 @@
       "allPrices": {
         "fantaboom_2025": 0,
         "fantaclassic_2025": 0,
+        "profeta_2025": 0,
         "sos_fanta_2025": 1,
         "fantaboom_2024": 0,
         "fantaclassic_2024": 0,
@@ -2190,6 +2243,7 @@
       "allPrices": {
         "fantaboom_2025": 0,
         "fantaclassic_2025": 0,
+        "profeta_2025": 0,
         "sos_fanta_2025": 0,
         "fantaboom_2024": 0,
         "fantaclassic_2024": 0,
@@ -2231,6 +2285,7 @@
       "allPrices": {
         "fantaboom_2025": 0,
         "fantaclassic_2025": 0,
+        "profeta_2025": 0,
         "sos_fanta_2025": 0,
         "fantaboom_2024": 0,
         "fantaclassic_2024": 0,
@@ -2261,7 +2316,7 @@
       "prezzi": {
         "min": 0,
         "max": 1,
-        "avg": 0.3
+        "avg": 0.2
       },
       "stats": {
         "t": 1,
@@ -2272,6 +2327,7 @@
       "allPrices": {
         "fantaboom_2025": 0,
         "fantaclassic_2025": 0,
+        "profeta_2025": 0,
         "sos_fanta_2025": 1,
         "fantaboom_2024": 0,
         "fantaclassic_2024": 0,
@@ -2302,7 +2358,7 @@
       "prezzi": {
         "min": 0,
         "max": 1,
-        "avg": 0.3
+        "avg": 0.2
       },
       "stats": {
         "t": 1,
@@ -2313,6 +2369,7 @@
       "allPrices": {
         "fantaboom_2025": 0,
         "fantaclassic_2025": 0,
+        "profeta_2025": 0,
         "sos_fanta_2025": 1,
         "fantaboom_2024": 0,
         "fantaclassic_2024": 0,
@@ -2354,6 +2411,7 @@
       "allPrices": {
         "fantaboom_2025": 0,
         "fantaclassic_2025": 0,
+        "profeta_2025": 0,
         "sos_fanta_2025": 0,
         "fantaboom_2024": 0,
         "fantaclassic_2024": 0,
@@ -2395,6 +2453,7 @@
       "allPrices": {
         "fantaboom_2025": 0,
         "fantaclassic_2025": 0,
+        "profeta_2025": 0,
         "sos_fanta_2025": 0,
         "fantaboom_2024": 0,
         "fantaclassic_2024": 0,
@@ -2436,6 +2495,7 @@
       "allPrices": {
         "fantaboom_2025": 0,
         "fantaclassic_2025": 0,
+        "profeta_2025": 0,
         "sos_fanta_2025": 0,
         "fantaboom_2024": 0,
         "fantaclassic_2024": 0,
@@ -2477,6 +2537,7 @@
       "allPrices": {
         "fantaboom_2025": 0,
         "fantaclassic_2025": 0,
+        "profeta_2025": 0,
         "sos_fanta_2025": 0,
         "fantaboom_2024": 0,
         "fantaclassic_2024": 0,
@@ -2518,6 +2579,7 @@
       "allPrices": {
         "fantaboom_2025": 0,
         "fantaclassic_2025": 0,
+        "profeta_2025": 0,
         "sos_fanta_2025": 0,
         "fantaboom_2024": 0,
         "fantaclassic_2024": 0,
@@ -2548,9 +2610,9 @@
       "nome": "DUMFRIES",
       "team": "INT",
       "prezzi": {
-        "min": 45,
+        "min": 44,
         "max": 45,
-        "avg": 45.0
+        "avg": 44.5
       },
       "stats": {
         "t": 4,
@@ -2559,7 +2621,14 @@
         "f": 8.0
       },
       "allPrices": {
-        "profeta_2025": 45
+        "fantaboom_2025": 44,
+        "fantaclassic_2025": 44,
+        "profeta_2025": 45,
+        "sos_fanta_2025": 45,
+        "fantaboom_2024": 44,
+        "fantaclassic_2024": 44,
+        "profeta_2024": 45,
+        "sos_fanta_2024": 45
       },
       "performance": {
         "2025_26": {
@@ -2569,14 +2638,14 @@
           "rating": 6.5
         },
         "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "goals": 7,
+          "assists": 2,
+          "minutes": 1951,
+          "rating": 6.19
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Denzel Dumfries è stato il migliore dell’ultima stagione dell’Inter. Listato come difensore, da esterno è quasi un attaccante aggiunto e sarà così anche con Chivu. Non arriva alla doppia cifra ma 6-7 gol e almeno 2-3 assist può garantiti senza problemi. Scontato collocarlo tra i top di difesa."
       }
     },
     {
@@ -2584,8 +2653,8 @@
       "team": "INT",
       "prezzi": {
         "min": 40,
-        "max": 40,
-        "avg": 40.0
+        "max": 42,
+        "avg": 40.8
       },
       "stats": {
         "t": 5,
@@ -2594,7 +2663,14 @@
         "f": 6.25
       },
       "allPrices": {
-        "profeta_2025": 40
+        "fantaboom_2025": 42,
+        "fantaclassic_2025": 41,
+        "profeta_2025": 40,
+        "sos_fanta_2025": 40,
+        "fantaboom_2024": 42,
+        "fantaclassic_2024": 41,
+        "profeta_2024": 40,
+        "sos_fanta_2024": 40
       },
       "performance": {
         "2025_26": {
@@ -2604,23 +2680,23 @@
           "rating": 6.25
         },
         "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "goals": 4,
+          "assists": 7,
+          "minutes": 2165,
+          "rating": 6.31
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Federico Dimarco è ormai da anni una certezza assoluta al fantacalcio, tra i difensori più amati e più prolifici in termini di bonus. Viene da un’altra stagione da top di reparto per quanto riguarda voti, gol e assist. Con Chivu potrebbe cambiare qualcosa a livello di gioco, ma il suo mancino resta un’arma letale. Un altro fattore importante sono i calci piazzati."
       }
     },
     {
       "nome": "GOSENS",
       "team": "FIO",
       "prezzi": {
-        "min": 37,
+        "min": 33,
         "max": 37,
-        "avg": 37.0
+        "avg": 35.0
       },
       "stats": {
         "t": 4,
@@ -2629,7 +2705,14 @@
         "f": 6.25
       },
       "allPrices": {
-        "profeta_2025": 37
+        "fantaboom_2025": 35,
+        "fantaclassic_2025": 33,
+        "profeta_2025": 37,
+        "sos_fanta_2025": 35,
+        "fantaboom_2024": 35,
+        "fantaclassic_2024": 33,
+        "profeta_2024": 37,
+        "sos_fanta_2024": 35
       },
       "performance": {
         "2025_26": {
@@ -2639,364 +2722,14 @@
           "rating": 6.25
         },
         "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "goals": 5,
+          "assists": 3,
+          "minutes": 2527,
+          "rating": 6.12
         }
       },
       "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "BASTONI",
-      "team": "INT",
-      "prezzi": {
-        "min": 35,
-        "max": 35,
-        "avg": 35.0
-      },
-      "stats": {
-        "t": 5,
-        "a": 5,
-        "i": 4,
-        "f": 8.5
-      },
-      "allPrices": {
-        "profeta_2025": 35
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 1,
-          "assists": 1,
-          "minutes": 176,
-          "rating": 6.5
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "BREMER",
-      "team": "JUV",
-      "prezzi": {
-        "min": 30,
-        "max": 30,
-        "avg": 30.0
-      },
-      "stats": {
-        "t": 5,
-        "a": 5,
-        "i": 2,
-        "f": 6.25
-      },
-      "allPrices": {
-        "profeta_2025": 30
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 180,
-          "rating": 6.25
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "WESLEY",
-      "team": "ROM",
-      "prezzi": {
-        "min": 30,
-        "max": 30,
-        "avg": 30.0
-      },
-      "stats": {
-        "t": 4,
-        "a": 4,
-        "i": 3,
-        "f": 8.0
-      },
-      "allPrices": {
-        "profeta_2025": 30
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 1,
-          "assists": 0,
-          "minutes": 180,
-          "rating": 6.5
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "BUONGIORNO",
-      "team": "NAP",
-      "prezzi": {
-        "min": 27,
-        "max": 27,
-        "avg": 27.0
-      },
-      "stats": {
-        "t": 5,
-        "a": 5,
-        "i": 2,
-        "f": 7.5
-      },
-      "allPrices": {
-        "profeta_2025": 27
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 1,
-          "minutes": 22,
-          "rating": 6.5
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "DODÒ",
-      "team": "FIO",
-      "prezzi": {
-        "min": 27,
-        "max": 27,
-        "avg": 27.0
-      },
-      "stats": {
-        "t": 5,
-        "a": 4,
-        "i": 2,
-        "f": 6.5
-      },
-      "allPrices": {
-        "profeta_2025": 27
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 180,
-          "rating": 6.5
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "BELLANOVA",
-      "team": "ATA",
-      "prezzi": {
-        "min": 25,
-        "max": 25,
-        "avg": 25.0
-      },
-      "stats": {
-        "t": 4,
-        "a": 4,
-        "i": 5,
-        "f": 5.75
-      },
-      "allPrices": {
-        "profeta_2025": 25
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 180,
-          "rating": 5.75
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "CAMBIASO",
-      "team": "JUV",
-      "prezzi": {
-        "min": 25,
-        "max": 25,
-        "avg": 25.0
-      },
-      "stats": {
-        "t": 4,
-        "a": 5,
-        "i": 3,
-        "f": 3.5
-      },
-      "allPrices": {
-        "profeta_2025": 25
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 83,
-          "rating": 4.5
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "DI LORENZO",
-      "team": "NAP",
-      "prezzi": {
-        "min": 25,
-        "max": 25,
-        "avg": 25.0
-      },
-      "stats": {
-        "t": 5,
-        "a": 5,
-        "i": 5,
-        "f": 6.0
-      },
-      "allPrices": {
-        "profeta_2025": 25
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 180,
-          "rating": 6.0
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "GUTIERREZ",
-      "team": "NAP",
-      "prezzi": {
-        "min": 23,
-        "max": 23,
-        "avg": 23.0
-      },
-      "stats": {
-        "t": 3,
-        "a": 4,
-        "i": 2,
-        "f": 0.0
-      },
-      "allPrices": {
-        "profeta_2025": 23
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0.0
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "SOLET",
-      "team": "UDI",
-      "prezzi": {
-        "min": 23,
-        "max": 23,
-        "avg": 23.0
-      },
-      "stats": {
-        "t": 5,
-        "a": 4,
-        "i": 3,
-        "f": 6.25
-      },
-      "allPrices": {
-        "profeta_2025": 23
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 180,
-          "rating": 6.25
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
+        "comm": "Robin Gosens resta una garanzia al fantacalcio, nonostante il passare degli anni. Titolare fisso nell'ultima stagione, lo sarà anche con Pioli. Uno dei migliori difensori per rendimento e bonus: decisivo sia con i gol che con gli assist. Sempre sopra la sufficienza, meglio quando gioca da esterno con un modulo con la difesa a tre. La sua specialità è chiudere l’azione sul secondo palo, ma mette anche buoni cross dalla fascia."
       }
     },
     {
@@ -3004,8 +2737,8 @@
       "team": "ROM",
       "prezzi": {
         "min": 20,
-        "max": 20,
-        "avg": 20.0
+        "max": 33,
+        "avg": 26.5
       },
       "stats": {
         "t": 5,
@@ -3014,7 +2747,14 @@
         "f": 5.75
       },
       "allPrices": {
-        "profeta_2025": 20
+        "fantaboom_2025": 33,
+        "fantaclassic_2025": 24,
+        "profeta_2025": 20,
+        "sos_fanta_2025": 29,
+        "fantaboom_2024": 33,
+        "fantaclassic_2024": 24,
+        "profeta_2024": 20,
+        "sos_fanta_2024": 29
       },
       "performance": {
         "2025_26": {
@@ -3024,67 +2764,81 @@
           "rating": 5.75
         },
         "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "goals": 2,
+          "assists": 1,
+          "minutes": 3179,
+          "rating": 6.14
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Angelino ha chiuso la scorsa stagione con 38 partite a voto, non ne ha saltata nemmeno una. 2 gol e 1 assist, i numeri possono migliorare ancora sotto la guida di Gasperini. Gli esterni sono fondamentali nelle sue squadre, ricordiamo Gosens all’Atalanta per esempio. Negli ultimi anni invece più da assist che da gol. Angelino può esplodere con Gasp, all’asta si pagherà di più rispetto alla passata stagione. A sorpresa, solo 1 cartellino giallo: dato importante."
       }
     },
     {
-      "nome": "MANCINI",
-      "team": "ROM",
+      "nome": "BELLANOVA",
+      "team": "ATA",
       "prezzi": {
-        "min": 20,
-        "max": 20,
-        "avg": 20.0
+        "min": 25,
+        "max": 32,
+        "avg": 27.0
       },
       "stats": {
-        "t": 5,
+        "t": 4,
         "a": 4,
-        "i": 4,
-        "f": 6.0
+        "i": 5,
+        "f": 5.75
       },
       "allPrices": {
-        "profeta_2025": 20
+        "fantaboom_2025": 32,
+        "fantaclassic_2025": 25,
+        "profeta_2025": 25,
+        "sos_fanta_2025": 26,
+        "fantaboom_2024": 32,
+        "fantaclassic_2024": 25,
+        "profeta_2024": 25,
+        "sos_fanta_2024": 26
       },
       "performance": {
         "2025_26": {
           "goals": 0,
           "assists": 0,
           "minutes": 180,
-          "rating": 6.25
+          "rating": 5.75
         },
         "2024_25": {
           "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "assists": 9,
+          "minutes": 2495,
+          "rating": 6.04
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Raoul Bellanova ritrova Ivan Juric. L’allenatore croato lo aveva allenato per una stagione al Torino, facendolo migliorare molto. Era stata proprio quella la stagione dell’esplosione al fantacalcio, realizzò 7 assist. Con Bellanova i +1 non mancano, può essere così anche quest’anno. Deve migliorare invece in zona gol. Sulla fascia destra parte come titolare dell’Atalanta."
       }
     },
     {
-      "nome": "MARTIN",
-      "team": "GEN",
+      "nome": "DI LORENZO",
+      "team": "NAP",
       "prezzi": {
-        "min": 20,
-        "max": 20,
-        "avg": 20.0
+        "min": 25,
+        "max": 31,
+        "avg": 27.8
       },
       "stats": {
         "t": 5,
-        "a": 4,
+        "a": 5,
         "i": 5,
-        "f": 5.75
+        "f": 6.0
       },
       "allPrices": {
-        "profeta_2025": 20
+        "fantaboom_2025": 31,
+        "fantaclassic_2025": 25,
+        "profeta_2025": 25,
+        "sos_fanta_2025": 30,
+        "fantaboom_2024": 31,
+        "fantaclassic_2024": 25,
+        "profeta_2024": 25,
+        "sos_fanta_2024": 30
       },
       "performance": {
         "2025_26": {
@@ -3094,32 +2848,81 @@
           "rating": 6.0
         },
         "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "goals": 3,
+          "assists": 2,
+          "minutes": 3330,
+          "rating": 6.15
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Giovanni Di Lorenzo resta un pilastro del Napoli, il capitano della squadra campione d’Italia di Conte. Il posto sulla corsia destra della difesa è suo, non ci sono dubbi. 3 gol e 2 assist in 37 partite a voto nella passata stagione, è una vera e propria garanzia in termini di voti e porta anche dei bonus. Con il ritorno della squadra in Champions League qualche volta riposerà anche lui, ma sarà uno dei meno soggetti al turnover e resta una certezza assoluta per l’asta tra i difensori."
       }
     },
     {
-      "nome": "RRAHMANI",
-      "team": "NAP",
+      "nome": "BASTONI",
+      "team": "INT",
       "prezzi": {
-        "min": 20,
-        "max": 20,
-        "avg": 20.0
+        "min": 30,
+        "max": 35,
+        "avg": 32.8
       },
       "stats": {
-        "t": 4,
-        "a": 4,
+        "t": 5,
+        "a": 5,
         "i": 4,
+        "f": 8.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 30,
+        "fantaclassic_2025": 32,
+        "profeta_2025": 35,
+        "sos_fanta_2025": 34,
+        "fantaboom_2024": 30,
+        "fantaclassic_2024": 32,
+        "profeta_2024": 35,
+        "sos_fanta_2024": 34
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 1,
+          "assists": 1,
+          "minutes": 176,
+          "rating": 6.5
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 4,
+          "minutes": 2420,
+          "rating": 6.42
+        }
+      },
+      "notes": {
+        "comm": "Alessandro Bastoni è una certezza assoluta per l’Inter e per il fantacalcio. Lo scorso anno ha chiuso con la miglior media-voto del reparto, un vero top dal punto di vista del modificatore. È più che affidabile come voti ed è capace di portare anche qualche bonus. Con Chivu resta un titolare inamovibile, chissà che non possa anche portare più +3 come si è visto all'esordio contro il Torino."
+      }
+    },
+    {
+      "nome": "BREMER",
+      "team": "JUV",
+      "prezzi": {
+        "min": 30,
+        "max": 33,
+        "avg": 31.0
+      },
+      "stats": {
+        "t": 5,
+        "a": 5,
+        "i": 2,
         "f": 6.25
       },
       "allPrices": {
-        "profeta_2025": 20
+        "fantaboom_2025": 30,
+        "fantaclassic_2025": 31,
+        "profeta_2025": 30,
+        "sos_fanta_2025": 33,
+        "fantaboom_2024": 30,
+        "fantaclassic_2024": 31,
+        "profeta_2024": 30,
+        "sos_fanta_2024": 33
       },
       "performance": {
         "2025_26": {
@@ -3131,12 +2934,138 @@
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 540,
+          "rating": 6.5
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Gleison Bremer è rientrato dall’infortunio al crociato e ora sta bene e si è visto subito all'esordio con il Parma. Tornerà dunque a essere il vero pilastro al centro della difesa della Juventus. Tudor ne aveva parlato benissimo già quando allenava la Lazio. La Juve avrà anche le coppe e magari inizialmente Bremer non le potrà giocare tutte, poi sarà difficile per l’allenatore rinunciare al brasiliano. Si può pagare meno all’asta rispetto all'anno scorso perché arriva da un lungo infortunio. E qualche incognita fisica ci sarà perché è sempre così dopo la rottura del crociato, quindi il prezzo è giusto che sia lievemente inferiore alla versione 'premium' di Bremer."
+      }
+    },
+    {
+      "nome": "DODÒ",
+      "team": "FIO",
+      "prezzi": {
+        "min": 25,
+        "max": 28,
+        "avg": 26.2
+      },
+      "stats": {
+        "t": 5,
+        "a": 4,
+        "i": 2,
+        "f": 6.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 28,
+        "fantaclassic_2025": 25,
+        "profeta_2025": 27,
+        "sos_fanta_2025": 25,
+        "fantaboom_2024": 28,
+        "fantaclassic_2024": 25,
+        "profeta_2024": 27,
+        "sos_fanta_2024": 25
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 180,
+          "rating": 6.5
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 5,
+          "minutes": 3119,
+          "rating": 6.19
+        }
+      },
+      "notes": {
+        "comm": "Dodò ha le qualità per essere potenzialmente un top di reparto al fantacalcio, anche se finora ha faticato a trovare continuità dal punto di vista dei bonus. Nel finale dello scorso campionato ha dato segnali positivi e con Pioli può crescere ancora, soprattutto in fase offensiva e specialmente se dovesse fare il “quinto”. Sulla fascia destra della Fiorentina parte da titolare fisso e il nuovo allenatore punta forte su di lui per ottenere più assist e giocate decisive, gli chiede di più."
+      }
+    },
+    {
+      "nome": "CAMBIASO",
+      "team": "JUV",
+      "prezzi": {
+        "min": 25,
+        "max": 30,
+        "avg": 27.5
+      },
+      "stats": {
+        "t": 4,
+        "a": 5,
+        "i": 3,
+        "f": 3.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 27,
+        "fantaclassic_2025": 28,
+        "profeta_2025": 25,
+        "sos_fanta_2025": 30,
+        "fantaboom_2024": 27,
+        "fantaclassic_2024": 28,
+        "profeta_2024": 25,
+        "sos_fanta_2024": 30
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 83,
+          "rating": 4.5
+        },
+        "2024_25": {
+          "goals": 2,
+          "assists": 3,
+          "minutes": 2222,
+          "rating": 6.09
+        }
+      },
+      "notes": {
+        "comm": "Andrea Cambiaso non arriva da una stagione soddisfacente al fantacalcio, specialmente se consideriamo le aspettative. Quest’anno potrebbe partire con aspettative più basse ma può rendere di più, in particolare se riuscirà a evitare gli infortuni che lo hanno frenato nella passata stagione. Può fare gol ma soprattutto assist, il posto sulla fascia sinistra del 3-4-2-1 è suo e non andrà sottovalutato. Dopo una preseason positiva è però arrivato il rosso col Parma con due giornate di squalifica: può scendere il prezzo in seguito a questo stop forzato."
+      }
+    },
+    {
+      "nome": "WESLEY",
+      "team": "ROM",
+      "prezzi": {
+        "min": 27,
+        "max": 30,
+        "avg": 28.8
+      },
+      "stats": {
+        "t": 4,
+        "a": 4,
+        "i": 3,
+        "f": 8.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 27,
+        "fantaclassic_2025": 28,
+        "profeta_2025": 30,
+        "sos_fanta_2025": 30,
+        "fantaboom_2024": 27,
+        "fantaclassic_2024": 28,
+        "profeta_2024": 30,
+        "sos_fanta_2024": 30
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 1,
+          "assists": 0,
+          "minutes": 180,
+          "rating": 6.5
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 0,
+          "minutes": 983,
+          "rating": 7.0
+        }
+      },
+      "notes": {
+        "comm": "Wesley alla Roma è un acquisto fortemente voluto da Gasperini (aveva fatto il suo nome anche all'Atalanta). Investimento importante dei giallorossi, è lui il titolare sulla fascia destra, ci sono pochi dubbi in merito. Velocità e tecnica, può dare tantissimo in fase offensiva alla Roma, è il classico esterno che ha tutto per esplodere con Gasp: 2 gol e 3 assist in 28 partite con la maglia del Flamengo nell'ultima stagione. Complessivamente, 6 gol e 7 assist in 152 partite, con 22 gialli (massimo 4 nell'ultimo campionato). È un classe 2003, ha ampi margini di miglioramento. Ha segnato già all'esordio con il Bologna, può essere intorno al secondo slot al fantacalcio, con il vantaggio di giocare praticamente a centrocampo. La fascia destra è sua e può raggiungere numeri importanti come bonus, ultimamente gli esterni di Gasperini hanno portato più assist che gol."
       }
     },
     {
@@ -3144,8 +3073,8 @@
       "team": "LAZ",
       "prezzi": {
         "min": 20,
-        "max": 20,
-        "avg": 20.0
+        "max": 28,
+        "avg": 24.8
       },
       "stats": {
         "t": 5,
@@ -3154,7 +3083,14 @@
         "f": 5.5
       },
       "allPrices": {
-        "profeta_2025": 20
+        "fantaboom_2025": 26,
+        "fantaclassic_2025": 28,
+        "profeta_2025": 20,
+        "sos_fanta_2025": 25,
+        "fantaboom_2024": 26,
+        "fantaclassic_2024": 28,
+        "profeta_2024": 20,
+        "sos_fanta_2024": 25
       },
       "performance": {
         "2025_26": {
@@ -3165,57 +3101,64 @@
         },
         "2024_25": {
           "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "assists": 7,
+          "minutes": 1698,
+          "rating": 6.28
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Nuno Tavares proverà la cura Sarri. E potrebbe fargli bene. Un motivo su tutti: la Lazio giocherà una partita a settimana, mentre il problema del terzino sono gli infortuni. La situazione potrebbe migliorare giocando solo il campionato. Quando sta bene, il portoghese ha tutto per essere devastante come all’inizio della scorsa stagione, quando realizzò 7 assist. Il prezzo all’asta dovrà comunque tenere in conto della fragilità fisica."
       }
     },
     {
-      "nome": "VALERI",
-      "team": "PAR",
+      "nome": "BUONGIORNO",
+      "team": "NAP",
       "prezzi": {
-        "min": 17,
-        "max": 17,
-        "avg": 17.0
+        "min": 24,
+        "max": 28,
+        "avg": 26.0
       },
       "stats": {
-        "t": 4,
-        "a": 3,
-        "i": 4,
-        "f": 5.75
+        "t": 5,
+        "a": 5,
+        "i": 2,
+        "f": 7.5
       },
       "allPrices": {
-        "profeta_2025": 17
+        "fantaboom_2025": 25,
+        "fantaclassic_2025": 28,
+        "profeta_2025": 27,
+        "sos_fanta_2025": 24,
+        "fantaboom_2024": 25,
+        "fantaclassic_2024": 28,
+        "profeta_2024": 27,
+        "sos_fanta_2024": 24
       },
       "performance": {
         "2025_26": {
           "goals": 0,
-          "assists": 0,
-          "minutes": 180,
-          "rating": 5.75
+          "assists": 1,
+          "minutes": 22,
+          "rating": 6.5
         },
         "2024_25": {
-          "goals": 0,
+          "goals": 1,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 1926,
+          "rating": 6.36
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Alessandro Buongiorno ha giocato solo 22 partite nella scorsa stagione a Napoli, con 1 gol all’attivo. Si è fermato per infortunio diverse volte e ha chiuso ai box il campionato. Conte lo aveva fortemente voluto, è il centrale di sinistra titolare della squadra ma ruoterà un po’ visti tutti gli impegni. Quando è al 100% dovrebbe giocare, al netto delle rotazioni che ci saranno viste le coppe. Ma bisognerà capire se riuscirà ad avere più continuità dell’anno scorso, dove il limite sono stati gli infortuni. Tolti quelli, al fantacalcio il suo rendimento è assolutamente da top. Contro il Cagliari alla seconda è subentrato e un po' a sorpresa ha regalato un assist decisivo ad Anguissa."
       }
     },
     {
       "nome": "ZORTEA",
       "team": "BOL",
       "prezzi": {
-        "min": 17,
-        "max": 17,
-        "avg": 17.0
+        "min": 14,
+        "max": 23,
+        "avg": 17.2
       },
       "stats": {
         "t": 3,
@@ -3224,7 +3167,14 @@
         "f": 5.75
       },
       "allPrices": {
-        "profeta_2025": 17
+        "fantaboom_2025": 23,
+        "fantaclassic_2025": 15,
+        "profeta_2025": 17,
+        "sos_fanta_2025": 14,
+        "fantaboom_2024": 23,
+        "fantaclassic_2024": 15,
+        "profeta_2024": 17,
+        "sos_fanta_2024": 14
       },
       "performance": {
         "2025_26": {
@@ -3234,58 +3184,107 @@
           "rating": 5.75
         },
         "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "goals": 6,
+          "assists": 2,
+          "minutes": 2728,
+          "rating": 6.07
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Nadir Zortea è passato dal Cagliari al Bologna, calando leggermente come valutazione al fantacalcio. In particolare rispetto alla passata stagione, perché sarà difficile ripetere i 6 gol in Serie A. Il motivo è semplice: l'anno scorso con Nicola giocava da ala destra nel 4-2-3-1, quest'anno nello stesso modulo dovrebbe fare il terzino destro. In più un anno fa era titolare fisso senza ballottaggi, ora si giocherà il posto con Holm (e De Silvestri). Il Bologna punta molto su di lui e può diventare un possibile titolare, ma ci sono comunque quattro competizioni. Visto il gioco di Italiano sarà probabilmente meno da gol ma può essere più da assist (2 l'anno scorso) e più da buoni voti (6,07 di media-voto l'anno scorso)."
       }
     },
     {
-      "nome": "KALULU",
-      "team": "JUV",
+      "nome": "RRAHMANI",
+      "team": "NAP",
       "prezzi": {
-        "min": 15,
-        "max": 15,
-        "avg": 15.0
+        "min": 18,
+        "max": 21,
+        "avg": 19.5
       },
       "stats": {
         "t": 4,
         "a": 4,
-        "i": 3,
-        "f": 5.75
+        "i": 4,
+        "f": 6.25
       },
       "allPrices": {
-        "profeta_2025": 15
+        "fantaboom_2025": 19,
+        "fantaclassic_2025": 21,
+        "profeta_2025": 20,
+        "sos_fanta_2025": 18,
+        "fantaboom_2024": 19,
+        "fantaclassic_2024": 21,
+        "profeta_2024": 20,
+        "sos_fanta_2024": 18
       },
       "performance": {
         "2025_26": {
           "goals": 0,
           "assists": 0,
           "minutes": 180,
-          "rating": 5.75
+          "rating": 6.25
         },
         "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "goals": 1,
+          "assists": 1,
+          "minutes": 3406,
+          "rating": 6.14
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Amir Rrahmani rimane una garanzia per la difesa del Napoli e per il fantacalcio, anche dopo l’arrivo di Beukema. Sempre titolare, lo scorso anno ne ha giocate 38 su 38. Per questo è logico pensare che resti centrale per Conte, al massimo avrà solo qualche ballottaggio e turno di riposo in più considerando le quattro competizioni. Raramente prende insufficienze e può portare anche qualche bonus da palla inattiva. Affidabilità e continuità sono i suoi punti di forza, ottimo per il modificatore."
+      }
+    },
+    {
+      "nome": "MARTIN",
+      "team": "GEN",
+      "prezzi": {
+        "min": 16,
+        "max": 20,
+        "avg": 17.8
+      },
+      "stats": {
+        "t": 5,
+        "a": 4,
+        "i": 5,
+        "f": 5.75
+      },
+      "allPrices": {
+        "fantaboom_2025": 18,
+        "fantaclassic_2025": 16,
+        "profeta_2025": 20,
+        "sos_fanta_2025": 17,
+        "fantaboom_2024": 18,
+        "fantaclassic_2024": 16,
+        "profeta_2024": 20,
+        "sos_fanta_2024": 17
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 180,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 8,
+          "minutes": 3088,
+          "rating": 6.17
+        }
+      },
+      "notes": {
+        "comm": "Aaron Martin è pronto per la sua terza stagione in Serie A. Alla prima c’erano grandi aspettative ma ha reso meno del prevista. L’anno scorso invece si è ribaltata la situazione: era partito in sordina ma ha fatto ben 8 assist. Ora può confermarsi dopo l’exploit dell’anno scorso, è un grande assist-man grazie ai suoi cross e al suo piede mancino. Con Vieira aveva fatto ottime cose e rimane titolare."
       }
     },
     {
       "nome": "MIRANDA J.",
       "team": "BOL",
       "prezzi": {
-        "min": 15,
-        "max": 15,
-        "avg": 15.0
+        "min": 12,
+        "max": 18,
+        "avg": 14.5
       },
       "stats": {
         "t": 3,
@@ -3294,7 +3293,14 @@
         "f": 0.0
       },
       "allPrices": {
-        "profeta_2025": 15
+        "fantaboom_2025": 18,
+        "fantaclassic_2025": 13,
+        "profeta_2025": 15,
+        "sos_fanta_2025": 12,
+        "fantaboom_2024": 18,
+        "fantaclassic_2024": 13,
+        "profeta_2024": 15,
+        "sos_fanta_2024": 12
       },
       "performance": {
         "2025_26": {
@@ -3305,398 +3311,13 @@
         },
         "2024_25": {
           "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "assists": 6,
+          "minutes": 2291,
+          "rating": 6.05
         }
       },
       "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "PAVLOVIC",
-      "team": "MIL",
-      "prezzi": {
-        "min": 15,
-        "max": 15,
-        "avg": 15.0
-      },
-      "stats": {
-        "t": 3,
-        "a": 4,
-        "i": 4,
-        "f": 8.0
-      },
-      "allPrices": {
-        "profeta_2025": 15
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 1,
-          "assists": 0,
-          "minutes": 180,
-          "rating": 6.5
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "RAMON",
-      "team": "COM",
-      "prezzi": {
-        "min": 15,
-        "max": 15,
-        "avg": 15.0
-      },
-      "stats": {
-        "t": 4,
-        "a": 4,
-        "i": 4,
-        "f": 6.0
-      },
-      "allPrices": {
-        "profeta_2025": 15
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 180,
-          "rating": 6.25
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "VASQUEZ",
-      "team": "GEN",
-      "prezzi": {
-        "min": 15,
-        "max": 15,
-        "avg": 15.0
-      },
-      "stats": {
-        "t": 5,
-        "a": 3,
-        "i": 5,
-        "f": 6.25
-      },
-      "allPrices": {
-        "profeta_2025": 15
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 180,
-          "rating": 6.25
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "AKANJI",
-      "team": "INT",
-      "prezzi": {
-        "min": 13,
-        "max": 13,
-        "avg": 13.0
-      },
-      "stats": {
-        "t": 3,
-        "a": 4,
-        "i": 2,
-        "f": null
-      },
-      "allPrices": {
-        "profeta_2025": 13
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0.0
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "CARLOS AUGUSTO",
-      "team": "INT",
-      "prezzi": {
-        "min": 12,
-        "max": 12,
-        "avg": 12.0
-      },
-      "stats": {
-        "t": 3,
-        "a": 4,
-        "i": 3,
-        "f": 6.0
-      },
-      "allPrices": {
-        "profeta_2025": 12
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 37,
-          "rating": 6.0
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "VOJVODA",
-      "team": "COM",
-      "prezzi": {
-        "min": 12,
-        "max": 12,
-        "avg": 12.0
-      },
-      "stats": {
-        "t": 4,
-        "a": 4,
-        "i": 3,
-        "f": 6.5
-      },
-      "allPrices": {
-        "profeta_2025": 12
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 147,
-          "rating": 6.5
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "ACERBI",
-      "team": "INT",
-      "prezzi": {
-        "min": 10,
-        "max": 10,
-        "avg": 10.0
-      },
-      "stats": {
-        "t": 3,
-        "a": 5,
-        "i": 2,
-        "f": 6.0
-      },
-      "allPrices": {
-        "profeta_2025": 10
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 173,
-          "rating": 6.0
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "BEUKEMA",
-      "team": "NAP",
-      "prezzi": {
-        "min": 10,
-        "max": 10,
-        "avg": 10.0
-      },
-      "stats": {
-        "t": 3,
-        "a": 4,
-        "i": 4,
-        "f": 0.0
-      },
-      "allPrices": {
-        "profeta_2025": 10
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0.0
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "DE WINTER",
-      "team": "MIL",
-      "prezzi": {
-        "min": 10,
-        "max": 10,
-        "avg": 10.0
-      },
-      "stats": {
-        "t": 3,
-        "a": 3,
-        "i": 2,
-        "f": 0.0
-      },
-      "allPrices": {
-        "profeta_2025": 10
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0.0
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "DELPRATO",
-      "team": "PAR",
-      "prezzi": {
-        "min": 10,
-        "max": 10,
-        "avg": 10.0
-      },
-      "stats": {
-        "t": 4,
-        "a": 4,
-        "i": 5,
-        "f": 6.25
-      },
-      "allPrices": {
-        "profeta_2025": 10
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 180,
-          "rating": 6.25
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "DOIG",
-      "team": "SAS",
-      "prezzi": {
-        "min": 10,
-        "max": 10,
-        "avg": 10.0
-      },
-      "stats": {
-        "t": 4,
-        "a": 3,
-        "i": 3,
-        "f": 5.25
-      },
-      "allPrices": {
-        "profeta_2025": 10
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 126,
-          "rating": 5.5
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
+        "comm": "Juan Miranda si è presentato bene al suo primo anno in Italia. La sensazione, però, è che possa fare ancora meglio. Il prezzo all’asta salirà rispetto a un anno fa, ma non sarà eccessivo, a maggior ragione perché alla prima era squalificato e alla seconda ha giocato ancora titolare Lykogiannis. La sensazione è che però il titolare sarà Miranda, con Lykogiannis subito dietro (ha mostrato fin qui grande affidabilità). È un terzino da assist, non da gol. Le sue caratteristiche parlano chiaro: con il suo mancino è molto bravo a crossare, sia dal fondo che dalla trequarti."
       }
     },
     {
@@ -3704,8 +3325,8 @@
       "team": "MIL",
       "prezzi": {
         "min": 10,
-        "max": 10,
-        "avg": 10.0
+        "max": 17,
+        "avg": 13.2
       },
       "stats": {
         "t": 4,
@@ -3714,7 +3335,14 @@
         "f": 6.5
       },
       "allPrices": {
-        "profeta_2025": 10
+        "fantaboom_2025": 17,
+        "fantaclassic_2025": 14,
+        "profeta_2025": 10,
+        "sos_fanta_2025": 12,
+        "fantaboom_2024": 17,
+        "fantaclassic_2024": 14,
+        "profeta_2024": 10,
+        "sos_fanta_2024": 12
       },
       "performance": {
         "2025_26": {
@@ -3725,293 +3353,13 @@
         },
         "2024_25": {
           "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "GABBIA",
-      "team": "MIL",
-      "prezzi": {
-        "min": 10,
-        "max": 10,
-        "avg": 10.0
-      },
-      "stats": {
-        "t": 3,
-        "a": 4,
-        "i": 5,
-        "f": 6.0
-      },
-      "allPrices": {
-        "profeta_2025": 10
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 180,
+          "assists": 1,
+          "minutes": 2403,
           "rating": 6.0
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
         }
       },
       "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "GILA",
-      "team": "LAZ",
-      "prezzi": {
-        "min": 10,
-        "max": 10,
-        "avg": 10.0
-      },
-      "stats": {
-        "t": 4,
-        "a": 4,
-        "i": 3,
-        "f": 5.75
-      },
-      "allPrices": {
-        "profeta_2025": 10
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 180,
-          "rating": 5.75
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "HIEN",
-      "team": "ATA",
-      "prezzi": {
-        "min": 10,
-        "max": 10,
-        "avg": 10.0
-      },
-      "stats": {
-        "t": 5,
-        "a": 4,
-        "i": 3,
-        "f": 4.0
-      },
-      "allPrices": {
-        "profeta_2025": 10
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 180,
-          "rating": 5.25
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "LUPERTO",
-      "team": "CAG",
-      "prezzi": {
-        "min": 10,
-        "max": 10,
-        "avg": 10.0
-      },
-      "stats": {
-        "t": 5,
-        "a": 4,
-        "i": 4,
-        "f": 8.25
-      },
-      "allPrices": {
-        "profeta_2025": 10
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 1,
-          "assists": 0,
-          "minutes": 180,
-          "rating": 6.75
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "ROMAGNOLI",
-      "team": "LAZ",
-      "prezzi": {
-        "min": 10,
-        "max": 10,
-        "avg": 10.0
-      },
-      "stats": {
-        "t": 4,
-        "a": 3,
-        "i": 2,
-        "f": 0.0
-      },
-      "allPrices": {
-        "profeta_2025": 10
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0.0
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "ZAPPACOSTA",
-      "team": "ATA",
-      "prezzi": {
-        "min": 10,
-        "max": 10,
-        "avg": 10.0
-      },
-      "stats": {
-        "t": 3,
-        "a": 4,
-        "i": 2,
-        "f": 6.0
-      },
-      "allPrices": {
-        "profeta_2025": 10
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 25,
-          "rating": 6.0
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "BIRAGHI",
-      "team": "TOR",
-      "prezzi": {
-        "min": 8,
-        "max": 8,
-        "avg": 8.0
-      },
-      "stats": {
-        "t": 4,
-        "a": 3,
-        "i": 4,
-        "f": 5.5
-      },
-      "allPrices": {
-        "profeta_2025": 8
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 166,
-          "rating": 5.5
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "IDZES",
-      "team": "SAS",
-      "prezzi": {
-        "min": 8,
-        "max": 8,
-        "avg": 8.0
-      },
-      "stats": {
-        "t": 4,
-        "a": 4,
-        "i": 4,
-        "f": 5.5
-      },
-      "allPrices": {
-        "profeta_2025": 8
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 90,
-          "rating": 5.5
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
+        "comm": "Pervis Estupinan è arrivato al Milan per raccogliere la pesante eredità di Theo Hernandez come terzino sinistro. L'ecuadoregno sarà il titolare in quel ruolo, il che gli permetterà di esprimersi fin da subito nella fascia in cui si troverà a dialogare con Rafa Leao, uomo cardine del gioco di Allegri. Sicuramente meno esplosivo e tecnico di Theo, Estupinan è comunque un terzino a cui piace sganciarsi e proiettarsi in attacco, pur restando affidabile dietro. Nel suo miglior anno al Brighton è arrivato a servire 7 assist ai compagni, al Milan è un'alternativa per i corner. Giocatore affidabile ma non top di reparto come lo era Theo. Non andrà sicuramente alle cifre del francese ma a un prezzo contenuto può essere anche un buon affare dato che è titolare e gioca nel Milan. Un'incognita può essere rappresentata dagli infortuni: nelle ultime due stagioni ha saltato più di 30 partite. Nell'ultimo anno, però, è riuscito a trovare più continuità, fermandosi solo tra gennaio e febbraio."
       }
     },
     {
@@ -4019,8 +3367,8 @@
       "team": "JUV",
       "prezzi": {
         "min": 8,
-        "max": 8,
-        "avg": 8.0
+        "max": 16,
+        "avg": 12.2
       },
       "stats": {
         "t": 3,
@@ -4029,7 +3377,14 @@
         "f": 5.75
       },
       "allPrices": {
-        "profeta_2025": 8
+        "fantaboom_2025": 16,
+        "fantaclassic_2025": 10,
+        "profeta_2025": 8,
+        "sos_fanta_2025": 15,
+        "fantaboom_2024": 16,
+        "fantaclassic_2024": 10,
+        "profeta_2024": 8,
+        "sos_fanta_2024": 15
       },
       "performance": {
         "2025_26": {
@@ -4041,56 +3396,231 @@
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 1771,
+          "rating": 6.0
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Joao Mario prende il posto in rosa alla Juve di Alberto Costa, con cui c’è stato lo scambio. Classe 2000, il portoghese proverà a candidarsi per essere il titolare sulla fascia destra di Igor Tudor. Porta in dote numeri classici da terzino: pochi gol ma parecchi assist, nell’ultima stagione ne ha fatti 7 tra tutte le competizioni. E anche a livello fisico è un giocatore integro: solo uno stop per lui nell'ultima stagione, di circa 20 giorni. Parte sicuramente indietro rispetto ai vari top in difesa, all'asta sarà più un jolly. Ma visto che Tudor gioca con il 3-4-2-1 non andrà sottovalutato, avrà comunque una proiezione offensiva. Se poi alla fine dovesse essere lui il titolare della Juve, salirebbe molto anche il prezzo."
       }
     },
     {
-      "nome": "LAZARO",
-      "team": "TOR",
+      "nome": "AKANJI",
+      "team": "INT",
       "prezzi": {
-        "min": 8,
-        "max": 8,
-        "avg": 8.0
+        "min": 13,
+        "max": 15,
+        "avg": 14.0
       },
       "stats": {
         "t": 3,
         "a": 4,
-        "i": 3,
-        "f": 5.25
+        "i": 2,
+        "f": null
       },
       "allPrices": {
-        "profeta_2025": 8
+        "fantaboom_2025": 15,
+        "fantaclassic_2025": 15,
+        "profeta_2025": 13,
+        "sos_fanta_2025": 13,
+        "fantaboom_2024": 15,
+        "fantaclassic_2024": 15,
+        "profeta_2024": 13,
+        "sos_fanta_2024": 13
       },
       "performance": {
         "2025_26": {
           "goals": 0,
           "assists": 0,
-          "minutes": 93,
-          "rating": 5.5
+          "minutes": 0,
+          "rating": 0.0
         },
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 2020,
+          "rating": 0.0
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Manuel Akanji è il nuovo rinforzo per la difesa dell’Inter, arrivato dal Manchester City in prestito con diritto di riscatto che può diventare obbligo. Difensore duttile (di piede destro), può giocare sia come centrale che a destra nella linea a tre e sarà un elemento importante nello scacchiere di Chivu, con alto grado di titolarità. Sostanzialmente prende il posto di Pavard come braccetto destro titolare, però a differenza del francese può fare anche il centrale al posto di Acerbi o De Vrij. Al fantacalcio è un profilo più da modificatore che da bonus: non è un difensore prolifico, la sua miglior stagione è stata la 2023/24 con 2 gol in Premier e 2 in Champions, mentre in carriera non ha mai superato quota 4 gol stagionali (ai tempi del Basilea nel lontano 2017). Porta solidità e affidabilità nei voti, ma senza aspettarsi grandi exploit offensivi. Può essere un acquisto interessante alle giuste condizioni, avrà continuità."
       }
     },
     {
-      "nome": "TOMORI",
-      "team": "MIL",
+      "nome": "MANCINI",
+      "team": "ROM",
       "prezzi": {
-        "min": 8,
-        "max": 8,
-        "avg": 8.0
+        "min": 14,
+        "max": 20,
+        "avg": 16.2
+      },
+      "stats": {
+        "t": 5,
+        "a": 4,
+        "i": 4,
+        "f": 6.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 15,
+        "fantaclassic_2025": 16,
+        "profeta_2025": 20,
+        "sos_fanta_2025": 14,
+        "fantaboom_2024": 15,
+        "fantaclassic_2024": 16,
+        "profeta_2024": 20,
+        "sos_fanta_2024": 14
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 180,
+          "rating": 6.25
+        },
+        "2024_25": {
+          "goals": 2,
+          "assists": 1,
+          "minutes": 3144,
+          "rating": 6.18
+        }
+      },
+      "notes": {
+        "comm": "Gianluca Mancini ritrova Gasperini, che aveva avuto già all’Atalanta. Ora il difensore è più maturo e ultimamente sta giocando come centrale in una difesa a tre, non più da braccetto destro. Con Gasp era un difensore goleador da 7 reti in 48 partite, ora proverà a fare qualche gol in più. Da corner è sempre una soluzione con il suo colpo di testa. Sta leggermente migliorando sui cartellini gialli, ha avuto picchi di 14 in una stagione di Serie A e ora è sceso a 8."
+      }
+    },
+    {
+      "nome": "SOLET",
+      "team": "UDI",
+      "prezzi": {
+        "min": 15,
+        "max": 23,
+        "avg": 18.0
+      },
+      "stats": {
+        "t": 5,
+        "a": 4,
+        "i": 3,
+        "f": 6.25
+      },
+      "allPrices": {
+        "fantaboom_2025": 15,
+        "fantaclassic_2025": 16,
+        "profeta_2025": 23,
+        "sos_fanta_2025": 18,
+        "fantaboom_2024": 15,
+        "fantaclassic_2024": 16,
+        "profeta_2024": 23,
+        "sos_fanta_2024": 18
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 180,
+          "rating": 6.25
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 1,
+          "minutes": 1674,
+          "rating": 6.16
+        }
+      },
+      "notes": {
+        "comm": "Oumar Solet si presenta alla sua prima asta estiva con grandi aspettative. Il difensore dell’Udinese ha sorpreso tutto da gennaio in poi, è stato uno dei migliori nel reparto specialmente per chi ha il modificatore. I dubbi erano di natura fisica, ma ha avuto continuità giocandole tutte. Ora è un difensore di alto livello in vista dell’asta, perché oltre a ottimi voti può portare anche bonus, giocando bene sia da centrale che da braccetto."
+      }
+    },
+    {
+      "nome": "VALERI",
+      "team": "PAR",
+      "prezzi": {
+        "min": 12,
+        "max": 17,
+        "avg": 14.5
+      },
+      "stats": {
+        "t": 4,
+        "a": 3,
+        "i": 4,
+        "f": 5.75
+      },
+      "allPrices": {
+        "fantaboom_2025": 15,
+        "fantaclassic_2025": 14,
+        "profeta_2025": 17,
+        "sos_fanta_2025": 12,
+        "fantaboom_2024": 15,
+        "fantaclassic_2024": 14,
+        "profeta_2024": 17,
+        "sos_fanta_2024": 12
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 180,
+          "rating": 5.75
+        },
+        "2024_25": {
+          "goals": 2,
+          "assists": 5,
+          "minutes": 2878,
+          "rating": 5.94
+        }
+      },
+      "notes": {
+        "comm": "Emanuele Valeri è diventato un fedelissimo al fantacalcio e non ha tradito le attese nella passata stagione. Ora cambia l’allenatore ma si candida a essere ancora titolare sulla fascia sinistra. Dà il meglio in caso di 3-5-2, perché gioca più avanzato. I numeri lo dimostrano: 2 gol (uno a sorpresa su rigore) e 5 assist nella passata stagione. Già due assist in stagione col doppio +1 in Coppa Italia."
+      }
+    },
+    {
+      "nome": "KALULU",
+      "team": "JUV",
+      "prezzi": {
+        "min": 9,
+        "max": 15,
+        "avg": 12.5
+      },
+      "stats": {
+        "t": 4,
+        "a": 4,
+        "i": 3,
+        "f": 5.75
+      },
+      "allPrices": {
+        "fantaboom_2025": 14,
+        "fantaclassic_2025": 12,
+        "profeta_2025": 15,
+        "sos_fanta_2025": 9,
+        "fantaboom_2024": 14,
+        "fantaclassic_2024": 12,
+        "profeta_2024": 15,
+        "sos_fanta_2024": 9
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 180,
+          "rating": 5.75
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 0,
+          "minutes": 2335,
+          "rating": 6.02
+        }
+      },
+      "notes": {
+        "comm": "Pierre Kalulu ha fatto bene nella sua prima stagione alla Juventus, Thiago Motta non aveva avuto dubbi e gli aveva dato un ruolo importante. Questa importanza nella rosa è stata confermata da Tudor, che lo considera un titolare. Non ha molti gol di testa nel suo repertorio ma può fare qualche assist e soprattutto è costante nei voti positivi."
+      }
+    },
+    {
+      "nome": "GATTI",
+      "team": "JUV",
+      "prezzi": {
+        "min": 5,
+        "max": 13,
+        "avg": 9.8
       },
       "stats": {
         "t": 3,
@@ -4099,7 +3629,56 @@
         "f": 6.0
       },
       "allPrices": {
-        "profeta_2025": 8
+        "fantaboom_2025": 12,
+        "fantaclassic_2025": 13,
+        "profeta_2025": 5,
+        "sos_fanta_2025": 9,
+        "fantaboom_2024": 12,
+        "fantaclassic_2024": 13,
+        "profeta_2024": 5,
+        "sos_fanta_2024": 9
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 147,
+          "rating": 6.25
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 0,
+          "minutes": 2213,
+          "rating": 6.14
+        }
+      },
+      "notes": {
+        "comm": "Federico Gatti ha rinnovato con la Juve e sulla carta è un titolare di Tudor. Solo i problemi fisici lo hanno fermato nel finale della scorsa stagione, ma si riprenderà da subito il suo posto in difesa. A volte potrà star fuori per le rotazioni con la Champions, ma comunque avrà tanto spazio. È un centrale che unisce buoni voti (sufficienza piena) a qualche possibile bonus quando sale sui calci piazzati."
+      }
+    },
+    {
+      "nome": "TOMORI",
+      "team": "MIL",
+      "prezzi": {
+        "min": 8,
+        "max": 12,
+        "avg": 9.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 3,
+        "f": 6.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 12,
+        "fantaclassic_2025": 11,
+        "profeta_2025": 8,
+        "sos_fanta_2025": 8,
+        "fantaboom_2024": 12,
+        "fantaclassic_2024": 11,
+        "profeta_2024": 8,
+        "sos_fanta_2024": 8
       },
       "performance": {
         "2025_26": {
@@ -4110,223 +3689,139 @@
         },
         "2024_25": {
           "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "assists": 1,
+          "minutes": 1611,
+          "rating": 5.86
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Fikayo Tomori cerca il rilancio sotto la guida di Massimiliano Allegri. L’ultima stagione è stata molto deludente, lo dicono i numeri: solo 18 partite a voto, nessun gol, un assist e 5,81 di fanta-media. Decisamente non la sua versione migliore, anche perché è un centrale che un paio di gol a stagione su corner può farli. Il primo passo però è riprendere una maglia da titolare con costanza."
       }
     },
     {
-      "nome": "VITIK",
-      "team": "BOL",
+      "nome": "ACERBI",
+      "team": "INT",
       "prezzi": {
-        "min": 8,
-        "max": 8,
-        "avg": 8.0
+        "min": 7,
+        "max": 11,
+        "avg": 8.8
       },
       "stats": {
-        "t": 4,
-        "a": 3,
-        "i": 3,
-        "f": 5.75
+        "t": 3,
+        "a": 5,
+        "i": 2,
+        "f": 6.0
       },
       "allPrices": {
-        "profeta_2025": 8
+        "fantaboom_2025": 11,
+        "fantaclassic_2025": 7,
+        "profeta_2025": 10,
+        "sos_fanta_2025": 7,
+        "fantaboom_2024": 11,
+        "fantaclassic_2024": 7,
+        "profeta_2024": 10,
+        "sos_fanta_2024": 7
       },
       "performance": {
         "2025_26": {
           "goals": 0,
           "assists": 0,
-          "minutes": 90,
+          "minutes": 173,
           "rating": 6.0
         },
         "2024_25": {
           "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "assists": 1,
+          "minutes": 1714,
+          "rating": 6.07
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Francesco Acerbi ha un anno in più: avanza l’età e cala l’appeal al fantacalcio. L’anno scorso aveva saltato diversi mesi per infortunio, poi è tornato quello di sempre (o quasi). Al fantacalcio non fa la differenza perché i voti sono vicini al 6 o di poco superiori, di gol invece ce ne sono pochi o zero. Saranno sempre meno le partite che riuscirà a giocare, probabilmente 20-25. Al massimo si può pensare a una coppia low cost con De Vrij se la situazione in difesa rimarrà questa."
       }
     },
     {
-      "nome": "ZANOLI",
-      "team": "UDI",
+      "nome": "HIEN",
+      "team": "ATA",
       "prezzi": {
         "min": 8,
-        "max": 8,
-        "avg": 8.0
-      },
-      "stats": {
-        "t": 2,
-        "a": 3,
-        "i": 5,
-        "f": 0.0
-      },
-      "allPrices": {
-        "profeta_2025": 8
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0.0
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "COMUZZO",
-      "team": "FIO",
-      "prezzi": {
-        "min": 7,
-        "max": 7,
-        "avg": 7.0
-      },
-      "stats": {
-        "t": 3,
-        "a": 3,
-        "i": 5,
-        "f": 6.25
-      },
-      "allPrices": {
-        "profeta_2025": 7
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 107,
-          "rating": 6.25
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "DIEGO CARLOS",
-      "team": "COM",
-      "prezzi": {
-        "min": 7,
-        "max": 7,
-        "avg": 7.0
-      },
-      "stats": {
-        "t": 3,
-        "a": 3,
-        "i": 3,
-        "f": null
-      },
-      "allPrices": {
-        "profeta_2025": 7
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0.0
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "GASPAR K.",
-      "team": "LEC",
-      "prezzi": {
-        "min": 7,
-        "max": 7,
-        "avg": 7.0
+        "max": 14,
+        "avg": 10.8
       },
       "stats": {
         "t": 5,
         "a": 4,
-        "i": 2,
-        "f": 5.5
+        "i": 3,
+        "f": 4.0
       },
       "allPrices": {
-        "profeta_2025": 7
+        "fantaboom_2025": 11,
+        "fantaclassic_2025": 14,
+        "profeta_2025": 10,
+        "sos_fanta_2025": 8,
+        "fantaboom_2024": 11,
+        "fantaclassic_2024": 14,
+        "profeta_2024": 10,
+        "sos_fanta_2024": 8
       },
       "performance": {
         "2025_26": {
           "goals": 0,
           "assists": 0,
           "minutes": 180,
-          "rating": 5.75
+          "rating": 5.25
         },
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 2325,
+          "rating": 5.95
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Isak Hien resta il perno difensivo dell’Atalanta anche sotto la guida di Juric. È un difensore centrale da modificatore come caratteristiche, anche se non arriva da una stagione indimenticabile e all'esordio contro il Pisa ha fatto un autogol. Lui comunque può essere valorizzato dal nuovo allenatore, che in quel ruolo ha fatto esplodere giocatori come Bremer e Buongiorno nel Torino. Può quindi avere un rendimento superiore al prezzo all’asta, soprattutto dopo l'autogol alla prima."
       }
     },
     {
-      "nome": "ISMAJLI",
-      "team": "TOR",
+      "nome": "DELPRATO",
+      "team": "PAR",
       "prezzi": {
         "min": 7,
-        "max": 7,
-        "avg": 7.0
+        "max": 10,
+        "avg": 9.2
       },
       "stats": {
-        "t": 3,
-        "a": 5,
-        "i": 2,
-        "f": 0.0
+        "t": 4,
+        "a": 4,
+        "i": 5,
+        "f": 6.25
       },
       "allPrices": {
-        "profeta_2025": 7
+        "fantaboom_2025": 10,
+        "fantaclassic_2025": 10,
+        "profeta_2025": 10,
+        "sos_fanta_2025": 7,
+        "fantaboom_2024": 10,
+        "fantaclassic_2024": 10,
+        "profeta_2024": 10,
+        "sos_fanta_2024": 7
       },
       "performance": {
         "2025_26": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0.0
+          "minutes": 180,
+          "rating": 6.25
         },
         "2024_25": {
-          "goals": 0,
+          "goals": 4,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 2946,
+          "rating": 6.03
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Enrico Delprato è tra le sorprese in difesa della scorsa stagione. Nel Parma è capitano e titolare fisso, lo dimostrano le 34 partite a voto dell’anno scorso. Ma a sorprendere sono stati i 4 gol, sicuramente un buon bottino per un difensore. Ora si mette a disposizione di Cuesta e può fare diversi ruoli, principalmente il braccetto destro o il quinto in caso di difesa a tre e il terzino destro in caso di linea a quattro."
       }
     },
     {
@@ -4334,8 +3829,8 @@
       "team": "ROM",
       "prezzi": {
         "min": 7,
-        "max": 7,
-        "avg": 7.0
+        "max": 14,
+        "avg": 9.8
       },
       "stats": {
         "t": 4,
@@ -4344,7 +3839,14 @@
         "f": 6.5
       },
       "allPrices": {
-        "profeta_2025": 7
+        "fantaboom_2025": 10,
+        "fantaclassic_2025": 14,
+        "profeta_2025": 7,
+        "sos_fanta_2025": 8,
+        "fantaboom_2024": 10,
+        "fantaclassic_2024": 14,
+        "profeta_2024": 7,
+        "sos_fanta_2024": 8
       },
       "performance": {
         "2025_26": {
@@ -4356,327 +3858,54 @@
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 3420,
+          "rating": 6.05
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Evan Ndicka è stato uno dei quattro giocatori di movimento in Serie A ad andare a voto in 38 partite su 38. Una certezza in difesa, così sarà anche con Gasperini. A parte la parentesi con Juric, ha sempre giocato da braccetto sinistro e questo è il suo ruolo. Affidabilità e voti intorno al 6 sono i suoi marchi di fabbrica."
       }
     },
     {
-      "nome": "PALESTRA",
-      "team": "CAG",
-      "prezzi": {
-        "min": 7,
-        "max": 7,
-        "avg": 7.0
-      },
-      "stats": {
-        "t": 2,
-        "a": 3,
-        "i": 4,
-        "f": 6.5
-      },
-      "allPrices": {
-        "profeta_2025": 7
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 83,
-          "rating": 6.5
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "VALLE",
-      "team": "COM",
-      "prezzi": {
-        "min": 7,
-        "max": 7,
-        "avg": 7.0
-      },
-      "stats": {
-        "t": 3,
-        "a": 3,
-        "i": 3,
-        "f": 6.0
-      },
-      "allPrices": {
-        "profeta_2025": 7
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 180,
-          "rating": 6.0
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "ANGORI",
-      "team": "PIS",
-      "prezzi": {
-        "min": 5,
-        "max": 5,
-        "avg": 5.0
-      },
-      "stats": {
-        "t": 4,
-        "a": 3,
-        "i": 4,
-        "f": 6.0
-      },
-      "allPrices": {
-        "profeta_2025": 5
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 6.0
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "BASCHIROTTO",
-      "team": "CRE",
-      "prezzi": {
-        "min": 5,
-        "max": 5,
-        "avg": 5.0
-      },
-      "stats": {
-        "t": 4,
-        "a": 3,
-        "i": 5,
-        "f": 8.25
-      },
-      "allPrices": {
-        "profeta_2025": 5
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 1,
-          "assists": 0,
-          "minutes": 180,
-          "rating": 6.75
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "BISSECK",
-      "team": "INT",
-      "prezzi": {
-        "min": 5,
-        "max": 5,
-        "avg": 5.0
-      },
-      "stats": {
-        "t": 3,
-        "a": 5,
-        "i": 5,
-        "f": 5.0
-      },
-      "allPrices": {
-        "profeta_2025": 5
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 90,
-          "rating": 5.0
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "DE VRIJ",
-      "team": "INT",
-      "prezzi": {
-        "min": 5,
-        "max": 5,
-        "avg": 5.0
-      },
-      "stats": {
-        "t": 3,
-        "a": 4,
-        "i": 3,
-        "f": 0.0
-      },
-      "allPrices": {
-        "profeta_2025": 5
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0.0
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "GATTI",
-      "team": "JUV",
-      "prezzi": {
-        "min": 5,
-        "max": 5,
-        "avg": 5.0
-      },
-      "stats": {
-        "t": 3,
-        "a": 4,
-        "i": 3,
-        "f": 6.0
-      },
-      "allPrices": {
-        "profeta_2025": 5
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 147,
-          "rating": 6.25
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "MARIPAN",
+      "nome": "BIRAGHI",
       "team": "TOR",
       "prezzi": {
-        "min": 5,
-        "max": 5,
-        "avg": 5.0
+        "min": 4,
+        "max": 9,
+        "avg": 6.2
       },
       "stats": {
-        "t": 3,
-        "a": 4,
-        "i": 3,
-        "f": 6.5
-      },
-      "allPrices": {
-        "profeta_2025": 5
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 90,
-          "rating": 6.5
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "MINA",
-      "team": "CAG",
-      "prezzi": {
-        "min": 5,
-        "max": 5,
-        "avg": 5.0
-      },
-      "stats": {
-        "t": 5,
+        "t": 4,
         "a": 3,
-        "i": 3,
-        "f": 5.75
+        "i": 4,
+        "f": 5.5
       },
       "allPrices": {
-        "profeta_2025": 5
+        "fantaboom_2025": 9,
+        "fantaclassic_2025": 4,
+        "profeta_2025": 8,
+        "sos_fanta_2025": 4,
+        "fantaboom_2024": 9,
+        "fantaclassic_2024": 4,
+        "profeta_2024": 8,
+        "sos_fanta_2024": 4
       },
       "performance": {
         "2025_26": {
           "goals": 0,
           "assists": 0,
-          "minutes": 180,
-          "rating": 5.75
+          "minutes": 166,
+          "rating": 5.5
         },
         "2024_25": {
-          "goals": 0,
+          "goals": 1,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 1600,
+          "rating": 5.83
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Cristiano Biraghi è passato dalla Fiorentina al Torino nella scorsa finestra invernale di mercato, si è preso subito il posto da titolare a sinistra. Ha tutto per essere la prima scelta anche con Baroni su quella fascia e occhio a un fattore importante per il fanta: i calci piazzati. Col suo mancino, può battere sia punizioni che corner, è un aspetto da non sottovalutare all’asta. Può essere sul quarto/quinto slot per la vostra difesa. "
       }
     },
     {
@@ -4684,8 +3913,8 @@
       "team": "NAP",
       "prezzi": {
         "min": 5,
-        "max": 5,
-        "avg": 5.0
+        "max": 9,
+        "avg": 6.2
       },
       "stats": {
         "t": 3,
@@ -4694,7 +3923,14 @@
         "f": 6.0
       },
       "allPrices": {
-        "profeta_2025": 5
+        "fantaboom_2025": 9,
+        "fantaclassic_2025": 5,
+        "profeta_2025": 5,
+        "sos_fanta_2025": 6,
+        "fantaboom_2024": 9,
+        "fantaclassic_2024": 5,
+        "profeta_2024": 5,
+        "sos_fanta_2024": 6
       },
       "performance": {
         "2025_26": {
@@ -4705,101 +3941,38 @@
         },
         "2024_25": {
           "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "assists": 1,
+          "minutes": 2371,
+          "rating": 6.08
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Mathías Olivera è in partenza il titolare a sinistra nella difesa del Napoli, avrà più concorrenza perché oltre a Spinazzola c'è anche Miguel Gutierrez che però inizialmente è infortunato. Al fantacalcio non porta molti bonus, ma le sue prestazioni sono comunque in crescita. Resta però soggetto ad alcuni stop fisici durante la stagione, che negli ultimi due campionati gli hanno fatto saltare diverse partite per infortunio. E poi alla lunga rischia di perdere il posto se non darà garanzie."
       }
     },
     {
-      "nome": "BARBIERI",
-      "team": "CRE",
+      "nome": "VASQUEZ",
+      "team": "GEN",
       "prezzi": {
-        "min": 5,
-        "max": 5,
-        "avg": 5.0
+        "min": 9,
+        "max": 15,
+        "avg": 11.0
       },
       "stats": {
-        "t": 3,
+        "t": 5,
         "a": 3,
-        "i": 3,
-        "f": 0.0
-      },
-      "allPrices": {
-        "profeta_2025": 5
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0.0
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "BERTOLA",
-      "team": "UDI",
-      "prezzi": {
-        "min": 5,
-        "max": 5,
-        "avg": 5.0
-      },
-      "stats": {
-        "t": 3,
-        "a": 3,
-        "i": 4,
-        "f": 5.5
-      },
-      "allPrices": {
-        "profeta_2025": 5
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 135,
-          "rating": 6.0
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "CANESTRELLI",
-      "team": "PIS",
-      "prezzi": {
-        "min": 5,
-        "max": 5,
-        "avg": 5.0
-      },
-      "stats": {
-        "t": 3,
-        "a": 3,
-        "i": 4,
+        "i": 5,
         "f": 6.25
       },
       "allPrices": {
-        "profeta_2025": 5
+        "fantaboom_2025": 9,
+        "fantaclassic_2025": 10,
+        "profeta_2025": 15,
+        "sos_fanta_2025": 10,
+        "fantaboom_2024": 9,
+        "fantaclassic_2024": 10,
+        "profeta_2024": 15,
+        "sos_fanta_2024": 10
       },
       "performance": {
         "2025_26": {
@@ -4809,242 +3982,417 @@
           "rating": 6.25
         },
         "2024_25": {
-          "goals": 0,
+          "goals": 3,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 3041,
+          "rating": 6.06
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Johan Vasquez è una certezza per la difesa al fantacalcio, specialmente per chi ha il modificatore. Con Vieira c’è un’ottima intesa, il suo rendimento è stato molto positivo da quando il francese è arrivato sulla panchina del Genoa. Nella sua difesa a quattro fa il centrale ma riesce comunque a sganciarsi in avanti e segnare qualche gol."
       }
     },
     {
-      "nome": "CUADRADO",
-      "team": "PIS",
+      "nome": "PAVLOVIC",
+      "team": "MIL",
       "prezzi": {
-        "min": 5,
-        "max": 5,
-        "avg": 5.0
+        "min": 7,
+        "max": 15,
+        "avg": 10.8
       },
       "stats": {
         "t": 3,
         "a": 4,
-        "i": 2,
-        "f": 5.75
+        "i": 4,
+        "f": 8.0
       },
       "allPrices": {
-        "profeta_2025": 5
+        "fantaboom_2025": 7,
+        "fantaclassic_2025": 14,
+        "profeta_2025": 15,
+        "sos_fanta_2025": 7,
+        "fantaboom_2024": 7,
+        "fantaclassic_2024": 14,
+        "profeta_2024": 15,
+        "sos_fanta_2024": 7
       },
       "performance": {
         "2025_26": {
-          "goals": 0,
+          "goals": 1,
           "assists": 0,
-          "minutes": 55,
-          "rating": 5.75
+          "minutes": 180,
+          "rating": 6.5
         },
         "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "goals": 2,
+          "assists": 1,
+          "minutes": 1869,
+          "rating": 5.91
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Strahinja Pavlovic è uno dei difensori centrali a disposizione di Massimiliano Allegri. La gerarchia è ancora da definire, il serbo non si può considerare un titolare fisso. Nella scorsa stagione non ha giocato sempre, è andato a voto 22 volte. E ha avuto alti e bassi, con 3 bonus ma anche degli errori. È un centrale molto alto e bravo nel gioco aereo (ha infatti segnato subito all'esordio contro la Cremonese), ma che può fare delle disattenzioni cercando l’anticipo."
       }
     },
     {
-      "nome": "FRESE",
-      "team": "VER",
+      "nome": "GILA",
+      "team": "LAZ",
       "prezzi": {
-        "min": 5,
-        "max": 5,
-        "avg": 5.0
-      },
-      "stats": {
-        "t": 3,
-        "a": 3,
-        "i": 2,
-        "f": 5.25
-      },
-      "allPrices": {
-        "profeta_2025": 5
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 135,
-          "rating": 5.25
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "GALLO",
-      "team": "LEC",
-      "prezzi": {
-        "min": 5,
-        "max": 5,
-        "avg": 5.0
+        "min": 6,
+        "max": 10,
+        "avg": 8.5
       },
       "stats": {
         "t": 4,
-        "a": 3,
-        "i": 4,
-        "f": 6.0
+        "a": 4,
+        "i": 3,
+        "f": 5.75
       },
       "allPrices": {
-        "profeta_2025": 5
+        "fantaboom_2025": 8,
+        "fantaclassic_2025": 10,
+        "profeta_2025": 10,
+        "sos_fanta_2025": 6,
+        "fantaboom_2024": 8,
+        "fantaclassic_2024": 10,
+        "profeta_2024": 10,
+        "sos_fanta_2024": 6
       },
       "performance": {
         "2025_26": {
           "goals": 0,
           "assists": 0,
           "minutes": 180,
-          "rating": 6.0
+          "rating": 5.75
         },
         "2024_25": {
-          "goals": 0,
+          "goals": 1,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 2742,
+          "rating": 6.05
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Mario Gila può dare di più al fantacalcio. È un difensore centrale con ottime qualità: ha velocità, senso dell’anticipo ed è bravo nelle chiusure. I voti non lo hanno premiato troppo fin qui, solo 5,95 di fnata-media l’anno scorso. E non è molto da bonus, solo un gol. Con Sarri, con cui resta titolare, può crescere e migliorare soprattutto per il modificatore."
       }
     },
     {
-      "nome": "GHILARDI",
-      "team": "ROM",
-      "prezzi": {
-        "min": 5,
-        "max": 5,
-        "avg": 5.0
-      },
-      "stats": {
-        "t": 3,
-        "a": 4,
-        "i": 4,
-        "f": 0.0
-      },
-      "allPrices": {
-        "profeta_2025": 5
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0.0
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "HEGGEM",
+      "nome": "VITIK",
       "team": "BOL",
       "prezzi": {
-        "min": 5,
-        "max": 5,
-        "avg": 5.0
+        "min": 4,
+        "max": 8,
+        "avg": 6.8
       },
       "stats": {
-        "t": 3,
+        "t": 4,
         "a": 3,
-        "i": 5,
-        "f": 7.0
+        "i": 3,
+        "f": 5.75
       },
       "allPrices": {
-        "profeta_2025": 5
+        "fantaboom_2025": 8,
+        "fantaclassic_2025": 7,
+        "profeta_2025": 8,
+        "sos_fanta_2025": 4,
+        "fantaboom_2024": 8,
+        "fantaclassic_2024": 7,
+        "profeta_2024": 8,
+        "sos_fanta_2024": 4
       },
       "performance": {
         "2025_26": {
           "goals": 0,
           "assists": 0,
           "minutes": 90,
-          "rating": 7.0
+          "rating": 6.0
         },
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 2171,
+          "rating": 6.0
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Martin Vitik è il nuovo rinforzo difensivo per il Bologna ed è chiamato a raccogliere l’eredità di Beukema. Difensore centrale classe 2003, arriva dallo Sparta Praga con oltre 100 presenze tra campionato e coppe europee, due titoli cechi vinti e l’esordio nella nazionale maggiore. Nella scorsa stagione ha collezionato 42 partite e 4 gol, confermandosi come uno dei difensori più promettenti del calcio ceco. Fisico imponente (193 cm), è un destro naturale che spicca per forza nei duelli aerei. È abile nel gioco d’anticipo, ha buoni tempi d’intervento e sa anche impostare con pulizia, una qualità importante per il sistema di Italiano. Può essere l’erede di Beukema anche al fantacalcio: avrà un costo minore e qualche incognita legata all’adattamento al gioco di Italiano e alla Serie A."
       }
     },
     {
-      "nome": "HERMOSO",
-      "team": "ROM",
+      "nome": "ANGORI",
+      "team": "PIS",
       "prezzi": {
         "min": 5,
-        "max": 5,
-        "avg": 5.0
+        "max": 7,
+        "avg": 6.2
       },
       "stats": {
-        "t": 3,
-        "a": 4,
-        "i": 3,
-        "f": 6.5
+        "t": 4,
+        "a": 3,
+        "i": 4,
+        "f": 6.0
       },
       "allPrices": {
-        "profeta_2025": 5
+        "fantaboom_2025": 7,
+        "fantaclassic_2025": 6,
+        "profeta_2025": 5,
+        "sos_fanta_2025": 7,
+        "fantaboom_2024": 7,
+        "fantaclassic_2024": 6,
+        "profeta_2024": 5,
+        "sos_fanta_2024": 7
       },
       "performance": {
         "2025_26": {
           "goals": 0,
           "assists": 0,
-          "minutes": 172,
-          "rating": 6.5
+          "minutes": 0,
+          "rating": 6.0
         },
         "2024_25": {
           "goals": 0,
           "assists": 0,
           "minutes": 0,
-          "rating": 0
+          "rating": 7.0
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Samuele Angori è uno dei migliori low cost da prendere dalle neopromosse. Parliamo di un giocatore da ultimi slot, però garantisce il posto da titolare e può portare qualche bonus. Il grande vantaggio è che fa l’esterno di centrocampo (a sinistra), ma è listato difensore. Buoni numeri l’anno scorso in Serie B con 2 gol e 5 assist, ha un buon piede e può tirare anche qualche calcio piazzato. In più è del 2003 quindi ha ancora margini di crescita. "
       }
     },
     {
-      "nome": "HOLM",
-      "team": "BOL",
+      "nome": "VOJVODA",
+      "team": "COM",
       "prezzi": {
-        "min": 5,
-        "max": 5,
-        "avg": 5.0
+        "min": 7,
+        "max": 12,
+        "avg": 9.5
       },
       "stats": {
-        "t": 3,
+        "t": 4,
         "a": 4,
+        "i": 3,
+        "f": 6.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 7,
+        "fantaclassic_2025": 11,
+        "profeta_2025": 12,
+        "sos_fanta_2025": 8,
+        "fantaboom_2024": 7,
+        "fantaclassic_2024": 11,
+        "profeta_2024": 12,
+        "sos_fanta_2024": 8
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 147,
+          "rating": 6.5
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 2,
+          "minutes": 1826,
+          "rating": 5.96
+        }
+      },
+      "notes": {
+        "comm": "Mergim Vojvoda si sta facendo spazio nel Como di Fabregas. L’ex Torino può essere considerato un titolare, la fascia destra è sua. In pochi mesi ha conquistato la fiducia di tutti e si candida per fare una buona stagione, senza avere troppi riflettori puntati addosso. Buon terzino da voto positivo e qualche bonus, con il plus di giocare in una squadra che produrrà gioco. E può agire anche in posizione più avanzata, come si è visto in questo inizio di campionato."
+      }
+    },
+    {
+      "nome": "BASCHIROTTO",
+      "team": "CRE",
+      "prezzi": {
+        "min": 4,
+        "max": 8,
+        "avg": 5.8
+      },
+      "stats": {
+        "t": 4,
+        "a": 3,
+        "i": 5,
+        "f": 8.25
+      },
+      "allPrices": {
+        "fantaboom_2025": 6,
+        "fantaclassic_2025": 4,
+        "profeta_2025": 5,
+        "sos_fanta_2025": 8,
+        "fantaboom_2024": 6,
+        "fantaclassic_2024": 4,
+        "profeta_2024": 5,
+        "sos_fanta_2024": 8
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 1,
+          "assists": 0,
+          "minutes": 180,
+          "rating": 6.75
+        },
+        "2024_25": {
+          "goals": 2,
+          "assists": 0,
+          "minutes": 3420,
+          "rating": 5.86
+        }
+      },
+      "notes": {
+        "comm": "Federico Baschirotto sarà un po' meno low cost dopo la partita incredibile che ha fatto contro il Milan. Il difensore è passato in estate dal Lecce alla Cremonese ed è salito di livello, Nicola può valorizzarlo. Il prezzo è in ascesa, inevitabile dopo un gol a San Siro. Ma non è solo quello, perché il centrale ha fatto una grandissima partita con anche il tacco che ha portato al secondo gol. Da parte sua ha un grandissimo vantaggio: le gioca tutte. L'anno scorso ha giocato 38 partite su 38, con 2 gol all'attivo. Nelle precedenti, 37 e 37 presenze a Lecce, uno stakanovista insomma. All'affidabilità può aggiungere qualche bonus e anche diversi voti da modificatore. Ora il suo valore per l'asta sale."
+      }
+    },
+    {
+      "nome": "DOIG",
+      "team": "SAS",
+      "prezzi": {
+        "min": 4,
+        "max": 10,
+        "avg": 6.5
+      },
+      "stats": {
+        "t": 4,
+        "a": 3,
+        "i": 3,
+        "f": 5.25
+      },
+      "allPrices": {
+        "fantaboom_2025": 6,
+        "fantaclassic_2025": 6,
+        "profeta_2025": 10,
+        "sos_fanta_2025": 4,
+        "fantaboom_2024": 6,
+        "fantaclassic_2024": 6,
+        "profeta_2024": 10,
+        "sos_fanta_2024": 4
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 126,
+          "rating": 5.5
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 2192,
+          "rating": 6.0
+        }
+      },
+      "notes": {
+        "comm": "JoshDoig rimane il terzino sinistro titolare del Sassuolo, come lo era stato l’anno scorso in Serie B. Non un numero alto di bonus, soltanto un gol e un assist nella passata stagione. Il laterale scozzese, classe 2002, non ha più l’hype che aveva all’inizio della sua esperienza al Verona. La difesa a quattro lo penalizza un po’ in termini di bonus, ha caratteristiche più da 3-5-2."
+      }
+    },
+    {
+      "nome": "GASPAR K.",
+      "team": "LEC",
+      "prezzi": {
+        "min": 4,
+        "max": 7,
+        "avg": 5.5
+      },
+      "stats": {
+        "t": 5,
+        "a": 4,
+        "i": 2,
+        "f": 5.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 6,
+        "fantaclassic_2025": 5,
+        "profeta_2025": 7,
+        "sos_fanta_2025": 4,
+        "fantaboom_2024": 6,
+        "fantaclassic_2024": 5,
+        "profeta_2024": 7,
+        "sos_fanta_2024": 4
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 180,
+          "rating": 5.75
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 1,
+          "minutes": 2143,
+          "rating": 6.17
+        }
+      },
+      "notes": {
+        "comm": "Kialonda Gaspar è il riferimento difensivo del Lecce. Di Francesco si affida a lui per guidare la linea, l’angolano ha esperienza e un anno di Serie A. È un titolare fisso, l’anno scorso lo ha fermato soltanto un infortunio. Stranamente non ha segnato nessun gol, nonostante l’abilità di testa sui calci piazzati. Potrà rifarsi quest’anno. Buon difensore in provincia."
+      }
+    },
+    {
+      "nome": "LUPERTO",
+      "team": "CAG",
+      "prezzi": {
+        "min": 4,
+        "max": 10,
+        "avg": 6.8
+      },
+      "stats": {
+        "t": 5,
+        "a": 4,
+        "i": 4,
+        "f": 8.25
+      },
+      "allPrices": {
+        "fantaboom_2025": 6,
+        "fantaclassic_2025": 7,
+        "profeta_2025": 10,
+        "sos_fanta_2025": 4,
+        "fantaboom_2024": 6,
+        "fantaclassic_2024": 7,
+        "profeta_2024": 10,
+        "sos_fanta_2024": 4
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 1,
+          "assists": 0,
+          "minutes": 180,
+          "rating": 6.75
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 2,
+          "minutes": 3240,
+          "rating": 6.0
+        }
+      },
+      "notes": {
+        "comm": "Sebastiano Luperto incarna alla perfezione la definizione di titolarissimo al fantacalcio. Parliamo di un difensore low cost che porta sempre voto. È questa la sua caratteristica principale, essere sempre presente. Se non fa 38 su 38 poco ci manca: non ha praticamente infortuni, prende pochissimi cartellini e per ogni allenatore è intoccabile. In più è duttile, può fare sia il centrale di difesa che il braccetto, giocando indifferentemente a tre e a quattro. Può portare anche qualche bonus, ha segnato già all'esordio contro la Fiorentina."
+      }
+    },
+    {
+      "nome": "ROMAGNOLI",
+      "team": "LAZ",
+      "prezzi": {
+        "min": 3,
+        "max": 10,
+        "avg": 6.5
+      },
+      "stats": {
+        "t": 4,
+        "a": 3,
         "i": 2,
         "f": 0.0
       },
       "allPrices": {
-        "profeta_2025": 5
+        "fantaboom_2025": 6,
+        "fantaclassic_2025": 7,
+        "profeta_2025": 10,
+        "sos_fanta_2025": 3,
+        "fantaboom_2024": 6,
+        "fantaclassic_2024": 7,
+        "profeta_2024": 10,
+        "sos_fanta_2024": 3
       },
       "performance": {
         "2025_26": {
@@ -5054,58 +4402,23 @@
           "rating": 0.0
         },
         "2024_25": {
-          "goals": 0,
+          "goals": 2,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 2674,
+          "rating": 5.84
         }
       },
       "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "KEMPF",
-      "team": "COM",
-      "prezzi": {
-        "min": 5,
-        "max": 5,
-        "avg": 5.0
-      },
-      "stats": {
-        "t": 4,
-        "a": 3,
-        "i": 2,
-        "f": 6.0
-      },
-      "allPrices": {
-        "profeta_2025": 5
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 180,
-          "rating": 6.0
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
+        "comm": "Alessio Romagnoli può essere ancora utile al fantacalcio, anche se l’anno scorso con una media inferiore al 6 non è stato molto da modificatore. Non sono comunque mancati i gol su sviluppi di corner, ne ha segnati due. Con Sarri i voti possono migliorare, deve però stare attento alla crescita di Provstgaard."
       }
     },
     {
       "nome": "KOSSOUNOU",
       "team": "ATA",
       "prezzi": {
-        "min": 5,
+        "min": 2,
         "max": 5,
-        "avg": 5.0
+        "avg": 4.2
       },
       "stats": {
         "t": 3,
@@ -5114,7 +4427,14 @@
         "f": 0.0
       },
       "allPrices": {
-        "profeta_2025": 5
+        "fantaboom_2025": 5,
+        "fantaclassic_2025": 5,
+        "profeta_2025": 5,
+        "sos_fanta_2025": 2,
+        "fantaboom_2024": 5,
+        "fantaclassic_2024": 5,
+        "profeta_2024": 5,
+        "sos_fanta_2024": 2
       },
       "performance": {
         "2025_26": {
@@ -5126,56 +4446,273 @@
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 1125,
+          "rating": 5.94
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Odilon Kossounou è stato riscattato dall’Atalanta, che ha deciso di puntarci fortemente. Di ruolo è un braccetto destro nella difesa a tre, nel suo primo anno in Italia si è ambientato e non ha brillato in modo particolare, pur facendo vedere sprazzi di potenzialità. È stato anche fermato da un lungo infortunio. Il problema ora è rappresentato dalla concorrenza di Scalvini, Kossounou non è sicuro del posto. Uno dei due potrebbe anche giocare a sinistra finché non torna Kolasinac."
       }
     },
     {
-      "nome": "KRISTENSEN T.",
-      "team": "UDI",
+      "nome": "LUCUMÌ",
+      "team": "BOL",
       "prezzi": {
-        "min": 5,
+        "min": 2,
         "max": 5,
-        "avg": 5.0
+        "avg": 4.0
       },
       "stats": {
         "t": 3,
-        "a": 2,
+        "a": 3,
         "i": 3,
-        "f": 8.25
+        "f": 5.5
       },
       "allPrices": {
-        "profeta_2025": 5
+        "fantaboom_2025": 5,
+        "fantaclassic_2025": 5,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 4,
+        "fantaboom_2024": 5,
+        "fantaclassic_2024": 5,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 4
       },
       "performance": {
         "2025_26": {
-          "goals": 1,
+          "goals": 0,
+          "assists": 0,
+          "minutes": 135,
+          "rating": 5.75
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 1,
+          "minutes": 2613,
+          "rating": 5.83
+        }
+      },
+      "notes": {
+        "comm": "Jhon Lucumì per il momento è rimasto al Bologna. Il difensore è il titolare sul centro-sinistra della retroguardia di Italiano, ha chiuso la scorsa stagione con 32 partite a voto (1 assist). Ogni tanto riposa quando ci sono tante gare ravvicinate, ma è un titolare nella difesa rossoblù. 8 gialli e un rosso, è un aspetto su cui proverà a migliorare nella nuova stagione. Al fantacalcio rimane un difensore affidabile, utile per avere un titolare da 6 nel reparto."
+      }
+    },
+    {
+      "nome": "MINA",
+      "team": "CAG",
+      "prezzi": {
+        "min": 4,
+        "max": 6,
+        "avg": 5.0
+      },
+      "stats": {
+        "t": 5,
+        "a": 3,
+        "i": 3,
+        "f": 5.75
+      },
+      "allPrices": {
+        "fantaboom_2025": 5,
+        "fantaclassic_2025": 6,
+        "profeta_2025": 5,
+        "sos_fanta_2025": 4,
+        "fantaboom_2024": 5,
+        "fantaclassic_2024": 6,
+        "profeta_2024": 5,
+        "sos_fanta_2024": 4
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
           "assists": 0,
           "minutes": 180,
-          "rating": 6.75
+          "rating": 5.75
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 0,
+          "minutes": 2576,
+          "rating": 6.06
+        }
+      },
+      "notes": {
+        "comm": "Yerry Mina al fantacalcio è come andare sulle montagne russe: esuberante, imprevedibile, capace di alternare voti altissimi da modificatore a giornate negative. Addirittura ogni tanto può calciare un rigore. È un titolare fisso ma soggetto a qualche problema fisico. Nonostante questo, resta un profilo low cost che può regalare soddisfazioni con voti da modificatore nelle partite giuste o per chi cerca un difensore dal potenziale interessante."
+      }
+    },
+    {
+      "nome": "RAMON",
+      "team": "COM",
+      "prezzi": {
+        "min": 5,
+        "max": 15,
+        "avg": 10.2
+      },
+      "stats": {
+        "t": 4,
+        "a": 4,
+        "i": 4,
+        "f": 6.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 5,
+        "fantaclassic_2025": 11,
+        "profeta_2025": 15,
+        "sos_fanta_2025": 10,
+        "fantaboom_2024": 5,
+        "fantaclassic_2024": 11,
+        "profeta_2024": 15,
+        "sos_fanta_2024": 10
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 180,
+          "rating": 6.25
         },
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 203,
+          "rating": 7.0
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Jacobo Ramon è un difensore centrale classe 2005 di piede destro, è un rinforzo per la retroguardia del Como di Fabregas. Alto 196 cm, è bravo non solo di testa ma anche palla al piede. Può prendersi il posto e dovrebbe riuscirci, ha tutte le qualità per farlo. Per il Como è un'operazione in stile Nico Paz, sempre dal Real Madrid. E così diventa una scommessa anche al fantacalcio."
+      }
+    },
+    {
+      "nome": "ZANOLI",
+      "team": "UDI",
+      "prezzi": {
+        "min": 4,
+        "max": 8,
+        "avg": 5.2
+      },
+      "stats": {
+        "t": 2,
+        "a": 3,
+        "i": 5,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 5,
+        "fantaclassic_2025": 4,
+        "profeta_2025": 8,
+        "sos_fanta_2025": 4,
+        "fantaboom_2024": 5,
+        "fantaclassic_2024": 4,
+        "profeta_2024": 8,
+        "sos_fanta_2024": 4
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 0,
+          "minutes": 1714,
+          "rating": 5.91
+        }
+      },
+      "notes": {
+        "comm": "Alessandro Zanoli è un nuovo rinforzo per la difesa dell’Udinese e dovrebbe essere titolare sulla corsia destra nel 3-5-2 di Runjaic, la sfida è con Ehizibue e un po’ di alternanza potrebbe esserci. Reduce da una stagione abbastanza positiva al Genoa (27 presenze, 1 gol), ha dimostrato affidabilità ma pochi bonus. In ottica fantacalcio guadagna valore perché, pur essendo listato difensore, giocherà di fatto da esterno a tutta fascia con licenza di spinta. Ha avuto pochi problemi fisici in carriera e questo aumenta le garanzie di continuità. All’asta rimane una soluzione low cost, ma comunque interessante."
+      }
+    },
+    {
+      "nome": "COCO",
+      "team": "TOR",
+      "prezzi": {
+        "min": 2,
+        "max": 4,
+        "avg": 2.8
+      },
+      "stats": {
+        "t": 4,
+        "a": 4,
+        "i": 5,
+        "f": 5.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 4,
+        "fantaclassic_2025": 3,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 2,
+        "fantaboom_2024": 4,
+        "fantaclassic_2024": 3,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 2
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 180,
+          "rating": 5.5
+        },
+        "2024_25": {
+          "goals": 2,
+          "assists": 0,
+          "minutes": 2847,
+          "rating": 5.86
+        }
+      },
+      "notes": {
+        "comm": "Saul Coco è rimasto al Torino, dopo tante voci di mercato. Ora starà a lui convincere Baroni a dargli una maglia da titolare, può farcela. L’anno scorso con Vanoli alla fine è stato titolare per tutta la stagione, tranne le ultimissime partite. Era partito molto bene, poi è calato alla distanza. I 2 gol segnati non gli sono bastati per arrivare alla fanta-media del 6, si è fermato a 5,83. Tanti, troppi, i 10 cartellini gialli, un aspetto su cui dovrà lavorare."
+      }
+    },
+    {
+      "nome": "IDZES",
+      "team": "SAS",
+      "prezzi": {
+        "min": 2,
+        "max": 8,
+        "avg": 4.2
+      },
+      "stats": {
+        "t": 4,
+        "a": 4,
+        "i": 4,
+        "f": 5.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 4,
+        "fantaclassic_2025": 2,
+        "profeta_2025": 8,
+        "sos_fanta_2025": 3,
+        "fantaboom_2024": 4,
+        "fantaclassic_2024": 2,
+        "profeta_2024": 8,
+        "sos_fanta_2024": 3
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 90,
+          "rating": 5.5
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 0,
+          "minutes": 3128,
+          "rating": 5.96
+        }
+      },
+      "notes": {
+        "comm": "Jay Idzes è un nuovo difensore del Sassuolo, è stato preso per fare il titolare. E su questo non ci sono dubbi, anche perché per la società è un investimento importante. Il centrale resta quindi un titolare a basso costo al fanta, anche se uno di quelli di livello più alto tra i low cost. Arriva da una buona stagione al Venezia e può migliorare."
       }
     },
     {
       "nome": "MARUSIC",
       "team": "LAZ",
       "prezzi": {
-        "min": 5,
+        "min": 3,
         "max": 5,
-        "avg": 5.0
+        "avg": 3.8
       },
       "stats": {
         "t": 3,
@@ -5184,7 +4721,14 @@
         "f": 5.75
       },
       "allPrices": {
-        "profeta_2025": 5
+        "fantaboom_2025": 4,
+        "fantaclassic_2025": 3,
+        "profeta_2025": 5,
+        "sos_fanta_2025": 3,
+        "fantaboom_2024": 4,
+        "fantaclassic_2024": 3,
+        "profeta_2024": 5,
+        "sos_fanta_2024": 3
       },
       "performance": {
         "2025_26": {
@@ -5194,93 +4738,317 @@
           "rating": 5.75
         },
         "2024_25": {
-          "goals": 0,
+          "goals": 4,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 2341,
+          "rating": 5.85
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Adam Marusic arriva da una grande stagione al fantacalcio in termini realizzativi. Quattro i gol segnati dal terzino della Lazio, un bottino di reti inaspettato. Non sarà comunque in hype ma rimane low cost, si gioca il posto con Lazzari sulla corsia destra della squadra ora allenata da Sarri. Ripetersi in termini di gol sarà in ogni caso molto difficile."
       }
     },
     {
-      "nome": "MARÌ",
-      "team": "FIO",
+      "nome": "PEZZELLA GIU.",
+      "team": "CRE",
       "prezzi": {
-        "min": 5,
-        "max": 5,
-        "avg": 5.0
+        "min": 2,
+        "max": 4,
+        "avg": 3.0
       },
       "stats": {
         "t": 3,
         "a": 4,
-        "i": 3,
-        "f": 4.5
+        "i": 2,
+        "f": 6.75
       },
       "allPrices": {
-        "profeta_2025": 5
+        "fantaboom_2025": 4,
+        "fantaclassic_2025": 3,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 3,
+        "fantaboom_2024": 4,
+        "fantaclassic_2024": 3,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 3
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 1,
+          "minutes": 180,
+          "rating": 6.25
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 4,
+          "minutes": 2887,
+          "rating": 6.03
+        }
+      },
+      "notes": {
+        "comm": "Giuseppe Pezzella è un buon acquisto in chiave salvezza per la Cremonese. Si tratta di uno dei terzini più affidabili per quanto riguarda i low cost al fantacalcio, una garanzia sulla fascia sinistra. L'esterno basso ha lasciato l'Empoli per continuare in Serie A e ritrova Davide Nicola. L'anno scorso, in una stagione complicata per i toscani, è stato uno dei più positivi: per lui 4 assist in 35 partite, giocate tutte da titolare tranne una da subentrante. In più calcia corner e punizioni, un plus importante in ottica fantacalcio. Infine la sua fanta-media parla chiaro: nonostante abbia giocato in una squadra che è poi retrocessa, ha mantenuto un buon 6,04. Probabile titolare nel suo ruolo e giocatore affidabile: può essere dunque una chiamata sicura all'asta come low cost in difesa."
+      }
+    },
+    {
+      "nome": "RANIERI L.",
+      "team": "FIO",
+      "prezzi": {
+        "min": 3,
+        "max": 5,
+        "avg": 3.8
+      },
+      "stats": {
+        "t": 4,
+        "a": 3,
+        "i": 5,
+        "f": 6.25
+      },
+      "allPrices": {
+        "fantaboom_2025": 4,
+        "fantaclassic_2025": 3,
+        "profeta_2025": 5,
+        "sos_fanta_2025": 3,
+        "fantaboom_2024": 4,
+        "fantaclassic_2024": 3,
+        "profeta_2024": 5,
+        "sos_fanta_2024": 3
       },
       "performance": {
         "2025_26": {
           "goals": 0,
           "assists": 0,
-          "minutes": 28,
-          "rating": 5.0
+          "minutes": 135,
+          "rating": 6.25
         },
         "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "goals": 1,
+          "assists": 2,
+          "minutes": 3077,
+          "rating": 5.92
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Luca Ranieri è ormai a tutti gli effetti un punto fermo nella difesa della Fiorentina: ha titolarità e fascia da capitano. Qualche malus di troppo legato ai cartellini ha inciso sulla fanta-media, ma ha mostrato anche il potenziale per portare qualche bonus in fase offensiva. Un po’ di concorrenza c’è sempre (in particolare è arrivato un altro mancino come Viti) ma parte ancora come titolare."
       }
     },
     {
-      "nome": "NORTON-CUFFY",
-      "team": "GEN",
+      "nome": "EHIZIBUE",
+      "team": "UDI",
       "prezzi": {
-        "min": 5,
-        "max": 5,
-        "avg": 5.0
+        "min": 1,
+        "max": 3,
+        "avg": 1.8
       },
       "stats": {
-        "t": 3,
+        "t": 4,
         "a": 3,
-        "i": 2,
+        "i": 3,
         "f": 5.75
       },
       "allPrices": {
-        "profeta_2025": 5
+        "fantaboom_2025": 3,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 3,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 170,
+          "rating": 5.75
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 1,
+          "minutes": 2510,
+          "rating": 5.85
+        }
+      },
+      "notes": {
+        "comm": "Kingsley Ehizibue è il potenziale terzino destro titolare dell’Udinese, anche se con la difesa a quattro lo può fare pure Kristensen. Alto 189 cm, ha doti di spinta e per il fantacalcio si esprime meglio se fa il quinto in un 3-5-2. L’anno scorso non una grande fanta-media, solo 5,81."
+      }
+    },
+    {
+      "nome": "GALLO",
+      "team": "LEC",
+      "prezzi": {
+        "min": 1,
+        "max": 5,
+        "avg": 3.0
+      },
+      "stats": {
+        "t": 4,
+        "a": 3,
+        "i": 4,
+        "f": 6.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 3,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 5,
+        "sos_fanta_2025": 3,
+        "fantaboom_2024": 3,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 5,
+        "sos_fanta_2024": 3
       },
       "performance": {
         "2025_26": {
           "goals": 0,
           "assists": 0,
           "minutes": 180,
-          "rating": 5.75
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 2,
+          "minutes": 2615,
+          "rating": 5.79
+        }
+      },
+      "notes": {
+        "comm": "Antonino Gallo è il titolarissimo della corsia mancina del Lecce in difesa. Il posto sulla fascia sinistra è suo, ha chiuso la scorsa stagione con 2 assist in 31 partite a voto. Punta a migliorare ulteriormente il suo bottino di bonus, ha le potenzialità per riuscirci. 3 cartellini gialli sono pochi per un difensore, ha avuto però anche un’espulsione. È il classico colpo da una provinciale per la vostra difesa, da slot secondario e utilissimo come riserva. Se sta bene, gioca sempre."
+      }
+    },
+    {
+      "nome": "ISMAJLI",
+      "team": "TOR",
+      "prezzi": {
+        "min": 2,
+        "max": 7,
+        "avg": 3.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 5,
+        "i": 2,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 3,
+        "fantaclassic_2025": 3,
+        "profeta_2025": 7,
+        "sos_fanta_2025": 2,
+        "fantaboom_2024": 3,
+        "fantaclassic_2024": 3,
+        "profeta_2024": 7,
+        "sos_fanta_2024": 2
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
         },
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 2510,
+          "rating": 6.17
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Ardian Ismajli arriva al Torino dopo aver fatto bene all’Empoli. E anche al fantacalcio, dove si è messo in mostra come centrale da modificatore. L’albanese è un difensore dal rendimento costante, l’anno scorso ha mantenuto una fanta-media del 6,12, andando a voto per 29 gare su 38. Qualche infortunio l'ha avuto, ma la sua affidabilità non è mancata. E anche a livello di malus non ci si può lamentare: solo tre ammonizioni e nessuna espulsione nella stagione 2024/25. Deve però migliorare come bonus: nessun +3 di testa da corner. Ora in una squadra di livello più alto può essere ancora da modificatore, anche se avrà maggiori ballottaggi."
+      }
+    },
+    {
+      "nome": "KOLASINAC",
+      "team": "ATA",
+      "prezzi": {
+        "min": 0,
+        "max": 3,
+        "avg": 2.0
+      },
+      "stats": {
+        "t": 2,
+        "a": 4,
+        "i": 1,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 3,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 3,
+        "fantaboom_2024": 3,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 3
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 2,
+          "minutes": 1910,
+          "rating": 6.13
+        }
+      },
+      "notes": {
+        "comm": "Sead Kolasinac è un punto fermo dell’Atalanta e del fantacalcio, ma quest’anno c’è un problema. Il bosniaco si è rotto il crociato e tornerà soltanto verso ottobre. Le certezze non possono essere molte dopo questo tipo di infortunio così grave, qualche dubbio fisico rimarrà e per questo il suo prezzo all’asta sarà molto low cost, giustamente solo da ultimi slot in modo da avere davanti tanti titolari già pronti e a disposizione. Poi, una volta che sarà al 100%, potrà riprendersi il posto sul centro-sinistra."
+      }
+    },
+    {
+      "nome": "OBERT",
+      "team": "CAG",
+      "prezzi": {
+        "min": 0,
+        "max": 3,
+        "avg": 1.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 4,
+        "f": 5.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 3,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 3,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 165,
+          "rating": 5.75
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 1,
+          "minutes": 1076,
+          "rating": 5.95
+        }
+      },
+      "notes": {
+        "comm": "Scendiamo ancora verso leghe più numerose, non sono titolari ma opzioni jolly anche dalle big in alcuni casi. Il posto non è assicurato, si vedrà con la preseason se qualcuno di questi difensori riuscirà a emergere."
       }
     },
     {
       "nome": "OSTIGARD",
       "team": "GEN",
       "prezzi": {
-        "min": 5,
+        "min": 3,
         "max": 5,
-        "avg": 5.0
+        "avg": 3.8
       },
       "stats": {
         "t": 3,
@@ -5289,7 +5057,14 @@
         "f": 5.0
       },
       "allPrices": {
-        "profeta_2025": 5
+        "fantaboom_2025": 3,
+        "fantaclassic_2025": 4,
+        "profeta_2025": 5,
+        "sos_fanta_2025": 3,
+        "fantaboom_2024": 3,
+        "fantaclassic_2024": 4,
+        "profeta_2024": 5,
+        "sos_fanta_2024": 3
       },
       "performance": {
         "2025_26": {
@@ -5301,310 +5076,37 @@
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "POSCH",
-      "team": "COM",
-      "prezzi": {
-        "min": 5,
-        "max": 5,
-        "avg": 5.0
-      },
-      "stats": {
-        "t": 2,
-        "a": 3,
-        "i": 2,
-        "f": 0.0
-      },
-      "allPrices": {
-        "profeta_2025": 5
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
+          "minutes": 1228,
           "rating": 0.0
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Leo Ostigard è tornato in Italia e al Genoa. Conosce la piazza e non avrà problemi di inserimento né di adattamento. Può fare bene nella sua seconda esperienza genoana, è partito bene in amichevole ma c'è anche Marcandalli: sono loro due in partenza a giocarsi il posto. che era di De Winter. Vieira può valorizzare i difensori centrali."
       }
     },
     {
-      "nome": "RANIERI L.",
-      "team": "FIO",
-      "prezzi": {
-        "min": 5,
-        "max": 5,
-        "avg": 5.0
-      },
-      "stats": {
-        "t": 4,
-        "a": 3,
-        "i": 5,
-        "f": 6.25
-      },
-      "allPrices": {
-        "profeta_2025": 5
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 135,
-          "rating": 6.25
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "SCALVINI",
-      "team": "ATA",
-      "prezzi": {
-        "min": 5,
-        "max": 5,
-        "avg": 5.0
-      },
-      "stats": {
-        "t": 3,
-        "a": 4,
-        "i": 1,
-        "f": 5.5
-      },
-      "allPrices": {
-        "profeta_2025": 5
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 176,
-          "rating": 5.5
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "TIAGO GABRIEL",
-      "team": "LEC",
-      "prezzi": {
-        "min": 5,
-        "max": 5,
-        "avg": 5.0
-      },
-      "stats": {
-        "t": 3,
-        "a": 3,
-        "i": 5,
-        "f": 6.0
-      },
-      "allPrices": {
-        "profeta_2025": 5
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 180,
-          "rating": 6.0
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "AHANOR",
-      "team": "ATA",
-      "prezzi": {
-        "min": 2,
-        "max": 2,
-        "avg": 2.0
-      },
-      "stats": {
-        "t": 3,
-        "a": 4,
-        "i": 2,
-        "f": 0.0
-      },
-      "allPrices": {
-        "profeta_2025": 2
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0.0
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "CANDÈ",
-      "team": "SAS",
-      "prezzi": {
-        "min": 2,
-        "max": 2,
-        "avg": 2.0
-      },
-      "stats": {
-        "t": 3,
-        "a": 3,
-        "i": 5,
-        "f": 5.5
-      },
-      "allPrices": {
-        "profeta_2025": 2
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 54,
-          "rating": 5.5
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "CARACCIOLO A.",
+      "nome": "ALBIOL",
       "team": "PIS",
       "prezzi": {
-        "min": 2,
+        "min": 0,
         "max": 2,
-        "avg": 2.0
+        "avg": 1.0
       },
       "stats": {
-        "t": 3,
-        "a": 3,
-        "i": 2,
-        "f": 6.25
+        "t": null,
+        "a": null,
+        "i": null,
+        "f": null
       },
       "allPrices": {
-        "profeta_2025": 2
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 180,
-          "rating": 6.25
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "COCO",
-      "team": "TOR",
-      "prezzi": {
-        "min": 2,
-        "max": 2,
-        "avg": 2.0
-      },
-      "stats": {
-        "t": 4,
-        "a": 4,
-        "i": 5,
-        "f": 5.5
-      },
-      "allPrices": {
-        "profeta_2025": 2
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 180,
-          "rating": 5.5
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "DARMIAN",
-      "team": "INT",
-      "prezzi": {
-        "min": 2,
-        "max": 2,
-        "avg": 2.0
-      },
-      "stats": {
-        "t": 2,
-        "a": 5,
-        "i": 4,
-        "f": 0.0
-      },
-      "allPrices": {
-        "profeta_2025": 2
+        "fantaboom_2025": 2,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 2,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
       },
       "performance": {
         "2025_26": {
@@ -5617,19 +5119,103 @@
           "goals": 0,
           "assists": 0,
           "minutes": 0,
-          "rating": 0
+          "rating": 0.0
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Raul Albiol torna in Serie A e lo fa a 40 anni con la maglia del Pisa. In linea di massima sarà titolare al centro della difesa a tre, nonostante l’età avanzata. Difficile però che riesca a farne 36 su 36 da titolare, potrebbe essere gestito in alcune partite. L’anno scorso 15 partite col Villarreal e non gioca da dicembre, però non per infortunio: ha detto lui stesso che stava bene e ha avuto problemi con l’allenatore. Al fantacalcio è solo una scelta molto low cost da ultimi slot."
+      }
+    },
+    {
+      "nome": "BRADARIC",
+      "team": "VER",
+      "prezzi": {
+        "min": 0,
+        "max": 2,
+        "avg": 0.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 2,
+        "i": 3,
+        "f": 5.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 2,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 2,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 162,
+          "rating": 5.5
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 0,
+          "minutes": 1948,
+          "rating": 5.72
+        }
+      },
+      "notes": {
+        "comm": "Non è una prima scelta al fantacalcio, si tratta di un’opzione secondaria e principalmente per leghe numerose."
+      }
+    },
+    {
+      "nome": "DIEGO CARLOS",
+      "team": "COM",
+      "prezzi": {
+        "min": 1,
+        "max": 7,
+        "avg": 3.0
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 3,
+        "f": null
+      },
+      "allPrices": {
+        "fantaboom_2025": 2,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 7,
+        "sos_fanta_2025": 2,
+        "fantaboom_2024": 2,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 7,
+        "sos_fanta_2024": 2
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 828,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Diego Carlos è un nuovo difensore centrale del Como. Ha esperienza perché ha 32 anni e ha giocato in squadre come Fenerbahce, Aston Villa e Siviglia. In Turchia non ha fatto bene da gennaio in poi, solo 4 partite. Ha pagato due infortuni che l’hanno frenato. Ora cerca il rilancio in Serie A, se sarà titolare o no dipenderà anche dalle sue condizioni fisiche. Si può giocare il posto con Kempf, sicuramente ha esperienza e può dare leadership alla difesa. Al fantacalcio rimane un’opzione low cost nonostante il palmares."
       }
     },
     {
       "nome": "DJIMSITI",
       "team": "ATA",
       "prezzi": {
-        "min": 2,
-        "max": 2,
+        "min": 1,
+        "max": 3,
         "avg": 2.0
       },
       "stats": {
@@ -5639,7 +5225,14 @@
         "f": 5.5
       },
       "allPrices": {
-        "profeta_2025": 2
+        "fantaboom_2025": 2,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 3,
+        "fantaboom_2024": 2,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 3
       },
       "performance": {
         "2025_26": {
@@ -5649,137 +5242,81 @@
           "rating": 5.5
         },
         "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "goals": 1,
+          "assists": 2,
+          "minutes": 2652,
+          "rating": 5.88
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Berat Djimsiti rimane un giocatore prezioso nella difesa dell’Atalanta, anche dopo l’addio di Gasp. Bisognerà capire se sarà un titolare fisso della retroguardia, ma comunque la squadra di Juric avrà anche le coppe e nelle rotazioni sicuramente Djimsiti avrà spazio. L’anno scorso 33 partite a voto, con 1 gol, 2 assist e 6 ammonizioni. All’asta andrà via a condizioni simili rispetto a quelle della passata stagione, probabilmente anche a prezzi più bassi, la vera novità in difesa è il ritorno di Scalvini."
       }
     },
     {
-      "nome": "FLORIANI MUSSOLINI",
-      "team": "CRE",
+      "nome": "GABBIA",
+      "team": "MIL",
       "prezzi": {
         "min": 2,
-        "max": 2,
-        "avg": 2.0
+        "max": 10,
+        "avg": 5.5
       },
       "stats": {
         "t": 3,
-        "a": 3,
+        "a": 4,
         "i": 5,
-        "f": 6.5
-      },
-      "allPrices": {
-        "profeta_2025": 2
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 8,
-          "rating": 6.5
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "JUAN JESUS",
-      "team": "NAP",
-      "prezzi": {
-        "min": 2,
-        "max": 2,
-        "avg": 2.0
-      },
-      "stats": {
-        "t": 3,
-        "a": 2,
-        "i": 3,
         "f": 6.0
       },
       "allPrices": {
-        "profeta_2025": 2
+        "fantaboom_2025": 2,
+        "fantaclassic_2025": 7,
+        "profeta_2025": 10,
+        "sos_fanta_2025": 3,
+        "fantaboom_2024": 2,
+        "fantaclassic_2024": 7,
+        "profeta_2024": 10,
+        "sos_fanta_2024": 3
       },
       "performance": {
         "2025_26": {
           "goals": 0,
           "assists": 0,
-          "minutes": 158,
-          "rating": 6.25
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "KAMARA H.",
-      "team": "UDI",
-      "prezzi": {
-        "min": 2,
-        "max": 2,
-        "avg": 2.0
-      },
-      "stats": {
-        "t": 3,
-        "a": 3,
-        "i": 4,
-        "f": 6.0
-      },
-      "allPrices": {
-        "profeta_2025": 2
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 11,
+          "minutes": 180,
           "rating": 6.0
         },
         "2024_25": {
-          "goals": 0,
+          "goals": 2,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 2161,
+          "rating": 6.04
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Matteo Gabbia rimane un riferimento nel Milan, è il giocatore con il maggiore attaccamento alla maglia. Per il fantacalcio parliamo di un difensore attento e ordinato, che fa il suo compito senza strafare. È un centrale da 6 pulito, senza troppi cartellini (4 ammonizioni) e anche qualche gol (2 nella passata stagione). Ha sempre il suo spazio e lo avrà anche con Allegri, da capire se come titolare fisso o se a volte potrà anche stare fuori."
       }
     },
     {
-      "nome": "KELLY L.",
-      "team": "JUV",
+      "nome": "KEMPF",
+      "team": "COM",
       "prezzi": {
-        "min": 2,
-        "max": 2,
-        "avg": 2.0
+        "min": 1,
+        "max": 5,
+        "avg": 2.8
       },
       "stats": {
-        "t": 3,
+        "t": 4,
         "a": 3,
         "i": 2,
         "f": 6.0
       },
       "allPrices": {
-        "profeta_2025": 2
+        "fantaboom_2025": 2,
+        "fantaclassic_2025": 3,
+        "profeta_2025": 5,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 2,
+        "fantaclassic_2024": 3,
+        "profeta_2024": 5,
+        "sos_fanta_2024": 1
       },
       "performance": {
         "2025_26": {
@@ -5791,100 +5328,37 @@
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 2617,
+          "rating": 5.85
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Marco Oliver Kempf è un difensore del Como, di piede mancino. Classe ’95 e alto 186 cm, ha fatto esperienza nello scorso campionato e si è ambientato in Italia, giocando 31 partite. Nessun bonus, ma un voto sicuro. Per lui 4 cartellini gialli e uno rosso."
       }
     },
     {
-      "nome": "LUCUMÌ",
-      "team": "BOL",
+      "nome": "MARIPAN",
+      "team": "TOR",
       "prezzi": {
-        "min": 2,
-        "max": 2,
-        "avg": 2.0
+        "min": 1,
+        "max": 5,
+        "avg": 2.8
       },
       "stats": {
         "t": 3,
-        "a": 3,
+        "a": 4,
         "i": 3,
-        "f": 5.5
-      },
-      "allPrices": {
-        "profeta_2025": 2
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 135,
-          "rating": 5.75
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "LYKOGIANNIS",
-      "team": "BOL",
-      "prezzi": {
-        "min": 2,
-        "max": 2,
-        "avg": 2.0
-      },
-      "stats": {
-        "t": 3,
-        "a": 3,
-        "i": 4,
-        "f": 5.25
-      },
-      "allPrices": {
-        "profeta_2025": 2
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 172,
-          "rating": 5.25
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "MARCANDALLI",
-      "team": "GEN",
-      "prezzi": {
-        "min": 2,
-        "max": 2,
-        "avg": 2.0
-      },
-      "stats": {
-        "t": 3,
-        "a": 3,
-        "i": 5,
         "f": 6.5
       },
       "allPrices": {
-        "profeta_2025": 2
+        "fantaboom_2025": 2,
+        "fantaclassic_2025": 3,
+        "profeta_2025": 5,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 2,
+        "fantaclassic_2024": 3,
+        "profeta_2024": 5,
+        "sos_fanta_2024": 1
       },
       "performance": {
         "2025_26": {
@@ -5894,49 +5368,14 @@
           "rating": 6.5
         },
         "2024_25": {
-          "goals": 0,
+          "goals": 1,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 2341,
+          "rating": 5.93
         }
       },
       "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "MBAMBI",
-      "team": "PIS",
-      "prezzi": {
-        "min": 2,
-        "max": 2,
-        "avg": 2.0
-      },
-      "stats": {
-        "t": 2,
-        "a": 3,
-        "i": 4,
-        "f": 0.0
-      },
-      "allPrices": {
-        "profeta_2025": 2
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0.0
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
+        "comm": "Guillermo Maripan arriva da una discreta stagione al Torino, con un gol e 5,93 di fanta-media. Rendimento “normale”, da difensore centrale low cost che ti porta il voto. Da quando era diventato titolare non aveva più perso il posto. Anche quest’anno in partenza si gioca e il posto e vedremo se finirà come un anno fa, lui cerca la conferma."
       }
     },
     {
@@ -5954,7 +5393,14 @@
         "f": 5.25
       },
       "allPrices": {
-        "profeta_2025": 2
+        "fantaboom_2025": 2,
+        "fantaclassic_2025": 2,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 2,
+        "fantaboom_2024": 2,
+        "fantaclassic_2024": 2,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 2
       },
       "performance": {
         "2025_26": {
@@ -5966,100 +5412,499 @@
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 2085,
+          "rating": 5.5
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Tarik Muharemovic è uno dei due centrali titolari del Sassuolo. Non è una difesa particolarmente affidabile, come spesso capita con le neopromosse, però il giovane bosniaco è un giocatore che farà strada. Classe 2003 e cresciuto nella Juve, è alto 187 cm. Può fare un paio di gol a stagione, l’anno scorso 2 in Serie B."
       }
     },
     {
-      "nome": "PALMA",
-      "team": "UDI",
+      "nome": "TERRACCIANO F.",
+      "team": "CRE",
       "prezzi": {
-        "min": 2,
+        "min": 0,
         "max": 2,
-        "avg": 2.0
+        "avg": 1.0
       },
       "stats": {
-        "t": 1,
+        "t": 3,
         "a": 3,
         "i": 5,
-        "f": 0.0
+        "f": 7.75
       },
       "allPrices": {
-        "profeta_2025": 2
+        "fantaboom_2025": 2,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 2,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
       },
       "performance": {
         "2025_26": {
-          "goals": 0,
+          "goals": 1,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0.0
+          "minutes": 180,
+          "rating": 6.5
         },
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 550,
+          "rating": 5.71
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Filippo Terracciano riparte dalla Cremonese. Il terzino non ha avuto spazio al Milan, ma al Verona aveva fatto bene ed era titolare. Ora torna a essere una soluzione low cost e dovrebbe avere spazio, è utile specialmente in leghe abbastanza numerose."
       }
     },
     {
-      "nome": "PEZZELLA GIU.",
-      "team": "CRE",
+      "nome": "ZAPPA",
+      "team": "CAG",
       "prezzi": {
-        "min": 2,
+        "min": 1,
         "max": 2,
-        "avg": 2.0
+        "avg": 1.8
       },
       "stats": {
-        "t": 3,
-        "a": 4,
-        "i": 2,
-        "f": 6.75
+        "t": 4,
+        "a": 3,
+        "i": 5,
+        "f": 5.75
       },
       "allPrices": {
-        "profeta_2025": 2
+        "fantaboom_2025": 2,
+        "fantaclassic_2025": 2,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 2,
+        "fantaclassic_2024": 2,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 1
       },
       "performance": {
         "2025_26": {
           "goals": 0,
-          "assists": 1,
+          "assists": 0,
+          "minutes": 148,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 2,
+          "assists": 0,
+          "minutes": 3062,
+          "rating": 5.75
+        }
+      },
+      "notes": {
+        "comm": "Gabriele Zappa si prepara a un’altra stagione da titolare fisso nel Cagliari. Nella difesa a tre fa il braccetto di destra, altrimenti il terzino a quattro. Il ruolo di braccetto gli limita l’impatto in zona bonus rispetto al passato, ma resta utile come riserva da voto. Ogni tanto può sorprendere (come successo lo scorso anno con la doppietta al Milan), ma non è un profilo da modificatore né da bonus. Buona opzione low cost per chi cerca minutaggio garantito."
+      }
+    },
+    {
+      "nome": "CANESTRELLI",
+      "team": "PIS",
+      "prezzi": {
+        "min": 1,
+        "max": 5,
+        "avg": 2.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 4,
+        "f": 6.25
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 5,
+        "sos_fanta_2025": 2,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 5,
+        "sos_fanta_2024": 2
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
           "minutes": 180,
           "rating": 6.25
         },
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 3000,
+          "rating": 6.5
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Simone Canestrelli è un difensore interessante nel Pisa e tra i low cost. Centrale classe 2000, è alto 192 cm. Ha fatto bene in Serie B con tre gol e tre assist, uno dei migliori nella promozione dei nerazzurri. Al fanta si candida a essere il classico titolare low cost di una neopromossa."
       }
     },
     {
-      "nome": "PROVSTGAARD",
-      "team": "LAZ",
+      "nome": "CARACCIOLO A.",
+      "team": "PIS",
       "prezzi": {
-        "min": 2,
+        "min": 0,
         "max": 2,
+        "avg": 1.0
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 2,
+        "f": 6.25
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 180,
+          "rating": 6.25
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 2942,
+          "rating": 6.5
+        }
+      },
+      "notes": {
+        "comm": "Da qui potete pescare qualche titolare o voto sicuro, ma solo per leghe numerose. Non c’è la garanzia di voti alti o da modificatore, siamo in provincia."
+      }
+    },
+    {
+      "nome": "CIRCATI",
+      "team": "PAR",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 2,
+        "f": 5.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 180,
+          "rating": 5.5
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 540,
+          "rating": 5.83
+        }
+      },
+      "notes": {
+        "comm": "Arrivamo ai difensori low cost più economici, quelli da ultimissimi slot. Poi dipende anche dal numero di partecipanti della lega, se è numerosa possono essere decisamente più utili per non giocare in dieci."
+      }
+    },
+    {
+      "nome": "FRESE",
+      "team": "VER",
+      "prezzi": {
+        "min": 0,
+        "max": 5,
         "avg": 2.0
       },
       "stats": {
-        "t": 2,
+        "t": 3,
+        "a": 3,
+        "i": 2,
+        "f": 5.25
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 5,
+        "sos_fanta_2025": 2,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 5,
+        "sos_fanta_2024": 2
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 135,
+          "rating": 5.25
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 551,
+          "rating": 5.79
+        }
+      },
+      "notes": {
+        "comm": "Arrivamo ai difensori low cost più economici, quelli da ultimissimi slot. Poi dipende anche dal numero di partecipanti della lega, se è numerosa possono essere decisamente più utili per non giocare in dieci."
+      }
+    },
+    {
+      "nome": "KAMARA H.",
+      "team": "UDI",
+      "prezzi": {
+        "min": 1,
+        "max": 2,
+        "avg": 1.2
+      },
+      "stats": {
+        "t": 3,
         "a": 3,
         "i": 4,
         "f": 6.0
       },
       "allPrices": {
-        "profeta_2025": 2
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 11,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 4,
+          "minutes": 2006,
+          "rating": 5.93
+        }
+      },
+      "notes": {
+        "comm": "Hassane Kamara è il terzino sinistro dell’Udinese, si gioca la maglia da titolare con Zemura. Anche quest’anno si ripropone l’alternanza. Nella scorsa stagione il franco-gambiano è stato un difensore low cost affidabile al fantacalcio con 30 partite a voto, 6,03 di fanta-media, un gol e 4 assist, solo qualche cartellino di troppo."
+      }
+    },
+    {
+      "nome": "KRISTENSEN T.",
+      "team": "UDI",
+      "prezzi": {
+        "min": 1,
+        "max": 5,
+        "avg": 3.0
+      },
+      "stats": {
+        "t": 3,
+        "a": 2,
+        "i": 3,
+        "f": 8.25
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 3,
+        "profeta_2025": 5,
+        "sos_fanta_2025": 3,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 3,
+        "profeta_2024": 5,
+        "sos_fanta_2024": 3
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 1,
+          "assists": 0,
+          "minutes": 180,
+          "rating": 6.75
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 0,
+          "minutes": 1770,
+          "rating": 5.57
+        }
+      },
+      "notes": {
+        "comm": "Thomas Kristensen può decisamente migliorare il suo rendimento in questa stagione, dopo che l’anno scorso non aveva fatto bene al fantacalcio con 5,60 di fanta-media e 21 partite a voto. La società ci punta e l’ha tenuto, potrebbe cederlo tra un anno se farà bene. Con Runjaic può fare il braccetto, il terzino destro o il difensore centrale di una difesa a tre, ruolo che sta ricomprendo ora con ottimi risultati e ambizioni da nuovo Bijol."
+      }
+    },
+    {
+      "nome": "MARÌ",
+      "team": "FIO",
+      "prezzi": {
+        "min": 1,
+        "max": 5,
+        "avg": 2.0
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 3,
+        "f": 4.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 5,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 5,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 28,
+          "rating": 5.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 2727,
+          "rating": 5.84
+        }
+      },
+      "notes": {
+        "comm": "Pablo Marì è arrivato alla Fiorentina nella scorsa stagione, ora trova Pioli. Complessivamente è andato a voto 32 volte l’anno scorso, prima a Monza e poi a Firenze. È un difensore centrale che gioca in mezzo alla difesa a tre, si giocherà il posto da titolare e può avere spazio, senza portare voti alti."
+      }
+    },
+    {
+      "nome": "NELSSON",
+      "team": "VER",
+      "prezzi": {
+        "min": 0,
+        "max": 2,
+        "avg": 1.0
+      },
+      "stats": {
+        "t": 4,
+        "a": 3,
+        "i": 4,
+        "f": 4.75
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 2,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 2,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 180,
+          "rating": 4.75
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 185,
+          "rating": 6.0
+        }
+      },
+      "notes": {
+        "comm": "Victor Nelsson torna in Italia dopo la parentesi alla Roma. Ora giocherà nel Verona, dove sarà titolare: un tassello importante per Zanetti, che aveva problemi nella retroguardia dopo gli addii di Coppola e Ghilardi. Nelsson è un nazionale danese, ha esperienza internazionale e ha 26 anni. Titolare low cost, più per leghe numerose.\n"
+      }
+    },
+    {
+      "nome": "SABELLI",
+      "team": "GEN",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.5
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 5,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 2,
+          "minutes": 2069,
+          "rating": 5.87
+        }
+      },
+      "notes": {
+        "comm": "Stefano Sabelli rimane una soluzione per Vieira, un possibile titolare. Sulla fascia destra gioca spesso, vedremo se quest’anno riuscirà a replicare le 30 partite a voto della scorsa stagione. È possibile una maggiore concorrenza. Non è da bonus (solo 2 assist) ma solo da voto, con un 5,9 di fanta-media."
+      }
+    },
+    {
+      "nome": "TIAGO GABRIEL",
+      "team": "LEC",
+      "prezzi": {
+        "min": 1,
+        "max": 5,
+        "avg": 2.0
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 5,
+        "f": 6.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 5,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 5,
+        "sos_fanta_2024": 1
       },
       "performance": {
         "2025_26": {
@@ -6071,91 +5916,63 @@
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 94,
+          "rating": 6.25
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Scelte rischiose per la difesa, ci sono molte riserve e giocatori che non dovrebbero avere molto spazio."
       }
     },
     {
-      "nome": "RENSCH",
-      "team": "ROM",
+      "nome": "TROILO",
+      "team": "PAR",
       "prezzi": {
-        "min": 2,
-        "max": 2,
-        "avg": 2.0
+        "min": 0,
+        "max": 1,
+        "avg": 0.5
       },
       "stats": {
         "t": 3,
-        "a": 4,
-        "i": 2,
+        "a": 3,
+        "i": 5,
         "f": 0.0
       },
       "allPrices": {
-        "profeta_2025": 2
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
       },
       "performance": {
         "2025_26": {
           "goals": 0,
           "assists": 0,
-          "minutes": 9,
+          "minutes": 0,
           "rating": 0.0
         },
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 1155,
+          "rating": 0.0
         }
       },
       "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "SPINAZZOLA",
-      "team": "NAP",
-      "prezzi": {
-        "min": 2,
-        "max": 2,
-        "avg": 2.0
-      },
-      "stats": {
-        "t": 3,
-        "a": 4,
-        "i": 2,
-        "f": 6.0
-      },
-      "allPrices": {
-        "profeta_2025": 2
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 82,
-          "rating": 6.0
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
+        "comm": "Mariano Troilo è un nuovo difensore del Parma, quasi sicuramente sarà titolare. Si tratta di un acquisto importante e oneroso, di fatto è il sostituto di Leoni. Argentino classe 2003, è alto 194 cm ed è alto nel gioco aereo. Lo voleva anche il Pisa, ma l’ha preso il Parma e ora lo farà giocare. È un low cost, anche se interessante tra quelli per leghe abbastanza numerose."
       }
     },
     {
       "nome": "UNAI NUNEZ",
       "team": "VER",
       "prezzi": {
-        "min": 2,
+        "min": 1,
         "max": 2,
-        "avg": 2.0
+        "avg": 1.2
       },
       "stats": {
         "t": 4,
@@ -6164,7 +5981,14 @@
         "f": 5.0
       },
       "allPrices": {
-        "profeta_2025": 2
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 1
       },
       "performance": {
         "2025_26": {
@@ -6176,21 +6000,1155 @@
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 645,
+          "rating": 5.5
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Da qui potete pescare qualche titolare o voto sicuro, ma solo per leghe numerose. Non c’è la garanzia di voti alti o da modificatore, siamo in provincia."
       }
     },
     {
-      "nome": "VAN DER BREMPT",
-      "team": "COM",
+      "nome": "VALENTI",
+      "team": "PAR",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 2,
+        "f": 5.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 180,
+          "rating": 5.75
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 0,
+          "minutes": 1557,
+          "rating": 5.85
+        }
+      },
+      "notes": {
+        "comm": "Scendiamo ancora verso leghe più numerose, non sono titolari ma opzioni jolly anche dalle big in alcuni casi. Il posto non è assicurato, si vedrà con la preseason se qualcuno di questi difensori riuscirà a emergere."
+      }
+    },
+    {
+      "nome": "VEIGA D.",
+      "team": "LEC",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 5,
+        "f": 5.25
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 158,
+          "rating": 5.5
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 375,
+          "rating": 5.73
+        }
+      },
+      "notes": {
+        "comm": "Anche queste sono opzioni da leghe numerose, ma maggiormente jolly e senza il posto assicurato. In alcuni casi vi possono servire come copertura al titolare."
+      }
+    },
+    {
+      "nome": "WALUKIEWICZ",
+      "team": "SAS",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.5
+      },
+      "stats": {
+        "t": 3,
+        "a": 2,
+        "i": 4,
+        "f": 5.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 180,
+          "rating": 5.5
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 1848,
+          "rating": 5.73
+        }
+      },
+      "notes": {
+        "comm": "Sebastian Walukiewicz è arrivato al Sassuolo per essere titolare, questo l’obiettivo. E potrà farlo in un dubbio ruolo: da difensore centrale o da terzino destro. A Grosso la decisione, mentre al fantacalcio il ruolo non fa molta differenza perché la sua utilità sarà solo quella di prendere voto e giocarne il più possibile. Da ultimo slot."
+      }
+    },
+    {
+      "nome": "ZAPPACOSTA",
+      "team": "ATA",
+      "prezzi": {
+        "min": 5,
+        "max": 15,
+        "avg": 9.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 2,
+        "f": 6.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 15,
+        "fantaclassic_2025": 7,
+        "profeta_2025": 10,
+        "sos_fanta_2025": 5,
+        "fantaboom_2024": 15,
+        "fantaclassic_2024": 7,
+        "profeta_2024": 10,
+        "sos_fanta_2024": 5
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 25,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 4,
+          "assists": 2,
+          "minutes": 2076,
+          "rating": 5.98
+        }
+      },
+      "notes": {
+        "comm": "Davide Zappacosta non vuole mollare la fascia sinistra dell’Atalanta. È comunque duttile, può giocare anche a destra. In linea di massima resta un titolare della Dea. Gli anni passano e qualche bonus lo porterà ancora, almeno un paio di gol e di assist. Anche Juric tende a valorizzare gli esterni, anche se meno rispetto a Gasperini. Dal mercato è arrivato Zalewski e la sensazione è che il posto se lo contenderanno proprio loro due per tutta la stagione. Per ora ne ha giocate due l'ex Inter dal 1', ma Zappacosta alla lunga avrà comunque spazio, considerando anche gli impegni in Europa. Si può pagare meno all'asta rispetto alla passata stagione, questo sì. "
+      }
+    },
+    {
+      "nome": "CARLOS AUGUSTO",
+      "team": "INT",
+      "prezzi": {
+        "min": 11,
+        "max": 13,
+        "avg": 12.0
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 3,
+        "f": 6.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 12,
+        "fantaclassic_2025": 11,
+        "profeta_2025": 12,
+        "sos_fanta_2025": 13,
+        "fantaboom_2024": 12,
+        "fantaclassic_2024": 11,
+        "profeta_2024": 12,
+        "sos_fanta_2024": 13
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 37,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 3,
+          "assists": 3,
+          "minutes": 1681,
+          "rating": 6.2
+        }
+      },
+      "notes": {
+        "comm": "Carlos Augusto non andrà ancora sottovalutato al fantacalcio. L’errore è quello di considerarlo una riserva, perché alla fine l’ex Monza è andato a voto in 28 partite su 38. Anche perché ha avuto un infortunio, l’anno prima furono addirittura 35. La differenza da una stagione all’altra l’ha fatta nei gol, passati da 0 a 3. È vero che può fare anche il vice Bastoni, ma ci sono due punti da considerare: ha la possibilità di segnare pure da braccetto perché è bravo di testa, continuerà a fare spesso anche il vice Dimarco. Solo Dumfries e lo stesso Dimarco hanno avuto una fanta-media superiore."
+      }
+    },
+    {
+      "nome": "BEUKEMA",
+      "team": "NAP",
+      "prezzi": {
+        "min": 6,
+        "max": 10,
+        "avg": 8.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 4,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 10,
+        "fantaclassic_2025": 7,
+        "profeta_2025": 10,
+        "sos_fanta_2025": 6,
+        "fantaboom_2024": 10,
+        "fantaclassic_2024": 7,
+        "profeta_2024": 10,
+        "sos_fanta_2024": 6
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 1,
+          "minutes": 3016,
+          "rating": 5.93
+        }
+      },
+      "notes": {
+        "comm": "Sam Beukema è passato dal Bologna al Napoli e ci sono risvolti anche in chiave fantacalcio. Il difensore classe 1998 è stato fortemente voluto da Antonio Conte e dalla società, si giocherà con Rrahmani che parte avanti. Ma può giocare anche al posto di Buongiorno, non mancheranno le rotazioni. 35 presenze nell’ultimo campionato, un vero e proprio inamovibile nel Bologna di Italiano. Solo un gol in campionato con la maglia del Bologna, in due stagioni. Un solo cartellino giallo l'anno scorso, un dato quasi da record per un difensore centrale (nella stagione precedente erano stati 4 i gialli e un rosso). Il salto nella squadra campione d’Italia in carica può valorizzarlo come voti, l’unico aspetto da considerare è il posto da titolare: probabilmente inizialmente non sarà più fisso, ma comunque la sensazione è che si divideranno i minuti lo stesso Beukema, Rrahmani e Buongiorno nel corso della stagione. Bisogna infatti considerare squalifiche e soprattutto infortuni. Per il fantacalcio resta un giocatore da rendimento, decisamente più da modificatore che da bonus. Siamo sul terzo slot, non conviene per ragioni di prezzo la coppia con Rrahmani, saranno entrambi pagati."
+      }
+    },
+    {
+      "nome": "BISSECK",
+      "team": "INT",
+      "prezzi": {
+        "min": 4,
+        "max": 8,
+        "avg": 5.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 5,
+        "i": 5,
+        "f": 5.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 8,
+        "fantaclassic_2025": 6,
+        "profeta_2025": 5,
+        "sos_fanta_2025": 4,
+        "fantaboom_2024": 8,
+        "fantaclassic_2024": 6,
+        "profeta_2024": 5,
+        "sos_fanta_2024": 4
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 90,
+          "rating": 5.0
+        },
+        "2024_25": {
+          "goals": 3,
+          "assists": 2,
+          "minutes": 1645,
+          "rating": 6.0
+        }
+      },
+      "notes": {
+        "comm": "Yann Bisseck è uno dei jolly difensivi dell’Inter. Se la gioca con Pavard per il ruolo di braccetto destro nei tre di difesa di Chivu. Il ruolo è quello, non ci sono molte possibilità di variare. Il tedesco ha più bonus rispetto al francese, non stati pochi i 3 gol dell’anno scorso. C’è però anche qualche sbavatura in fase difensiva che dovrà limitare. Solo Zielinski e Taremi l’anno scorso hanno avuto una media-voto inferiore alla sua (6,00)."
+      }
+    },
+    {
+      "nome": "DE VRIJ",
+      "team": "INT",
+      "prezzi": {
+        "min": 5,
+        "max": 8,
+        "avg": 6.0
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 3,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 8,
+        "fantaclassic_2025": 5,
+        "profeta_2025": 5,
+        "sos_fanta_2025": 6,
+        "fantaboom_2024": 8,
+        "fantaclassic_2024": 5,
+        "profeta_2024": 5,
+        "sos_fanta_2024": 6
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 3,
+          "assists": 0,
+          "minutes": 1719,
+          "rating": 6.18
+        }
+      },
+      "notes": {
+        "comm": "Stefan De Vrij arriva da una buonissima stagione al fantacalcio. Non solo una media-voto di tutto rispetto, ma anche tre gol che per un difensore centrale sono un buon bottino. L’anno scorso si è diviso le partite con Acerbi, proprio al 50-50. Quest’anno potrebbe avere un po’ più di spazio, anche il prezzo all’asta potrebbe salire leggermente pur restando abbordabile."
+      }
+    },
+    {
+      "nome": "GUTIERREZ",
+      "team": "NAP",
+      "prezzi": {
+        "min": 5,
+        "max": 23,
+        "avg": 11.5
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 2,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 8,
+        "fantaclassic_2025": 10,
+        "profeta_2025": 23,
+        "sos_fanta_2025": 5,
+        "fantaboom_2024": 8,
+        "fantaclassic_2024": 10,
+        "profeta_2024": 23,
+        "sos_fanta_2024": 5
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 2464,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Miguel Gutierrez è un nuovo rinforzo del Napoli di Conte. Terzino sinistro classe 2001, arriva per giocarsi il posto con Olivera e c'è anche Spinazzola (che può agire anche più avanzato, come nella passata stagione). Cresciuto nel settore giovanile del Real Madrid, è passato al Girona nel 2022 e ora arriva al Napoli. Va segnalato che nella scorsa stagione ha realizzato 1 gol e 5 assist in 29 partite di Liga, ha giocato anche in Champions League (6 gare e 1 gol). Importante sottolineare che a inizio luglio è stato operato alla caviglia, un intervento di pulizia dopo una serie di fastidi. Non sarà pronto per inizio campionato, verosimilmente Conte lo avrà a piena disposizione dopo la sosta di settembre. Dovrà poi ritrovare miglior condizione e ritmo gara, nel frattempo anche entrare nei meccanismi del nuovo allenatore. Per questo almeno inizialmente il posto di Olivera non è in discussione, Gutierrez proverà a insidiarlo una volta che sarà al 100%. Più a gara in corso che dall'inizio in un primo momento, poi avrà anche le sue chance visti i tanti impegni della squadra di Conte. E alla lunga, per le sue qualità, potrebbe anche provare a diventare il titolare, anche se di fatto quest'anno non ci saranno gerarchie fisse ma tante rotazioni. 6 gol e 19 assist in 112 partite col Girona, in nazionale ha giocato con le giovanili e alle Olimpiadi, non ha ancora esordito con la nazionale maggiore invece. Prima di questo problema alla caviglia, non si era mai fermato (10 le gare saltate l'anno scorso, per questo ha deciso di farsi operare). 4 gialli l'anno scorso e 4 l'anno prima in Liga, il 'record' negativo è di 5 nella stagione 2022/23; solo un rosso, ma a livelli giovanili. Per l'asta, in partenza è un jolly di prima fascia visto che non ha il posto garantito, ma comunque nelle rotazioni troverà spazio e poi può emergere alla lunga."
+      }
+    },
+    {
+      "nome": "LAZARO",
+      "team": "TOR",
+      "prezzi": {
+        "min": 3,
+        "max": 8,
+        "avg": 5.5
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 3,
+        "f": 5.25
+      },
+      "allPrices": {
+        "fantaboom_2025": 7,
+        "fantaclassic_2025": 4,
+        "profeta_2025": 8,
+        "sos_fanta_2025": 3,
+        "fantaboom_2024": 7,
+        "fantaclassic_2024": 4,
+        "profeta_2024": 8,
+        "sos_fanta_2024": 3
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 93,
+          "rating": 5.5
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 6,
+          "minutes": 2322,
+          "rating": 5.98
+        }
+      },
+      "notes": {
+        "comm": "Valentino Lazaro l’anno scorso ha fornito addirittura 6 assist in 31 partite a voto. Giocava alto con Vanoli, da ala nel 4-2-3-1. È rimasto listato da difensore e può essere interessante per l’asta: tornerà a fare il terzino puro (a destra) con Baroni, ma ogni tanto potrebbe essere riproposto più avanti. Non va comunque pagato come se giocasse sempre da ala destra. In ogni caso resta il jolly dei calci piazzati come extra."
+      }
+    },
+    {
+      "nome": "KELLY L.",
+      "team": "JUV",
       "prezzi": {
         "min": 2,
-        "max": 2,
+        "max": 6,
+        "avg": 3.5
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 2,
+        "f": 6.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 3,
+        "fantaclassic_2025": 6,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 3,
+        "fantaboom_2024": 3,
+        "fantaclassic_2024": 6,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 3
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 180,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 1015,
+          "rating": 5.67
+        }
+      },
+      "notes": {
+        "comm": "Lloyd Kelly è arrivato alla Juventus lo scorso gennaio e ha collezionato 12 presenze, con un cartellino giallo (nessun bonus). Le gerarchie sono ancora in divenire nella difesa bianconera, ma comunque potrà trovare spazio nelle rotazioni visto che ci sono le coppe. Non un titolare fisso a oggi, ma può fare le sue presenze. Classico jolly difensivo di una big, va preso alle giuste condizioni all’asta, ovvero solo a un prezzo molto basso."
+      }
+    },
+    {
+      "nome": "SPINAZZOLA",
+      "team": "NAP",
+      "prezzi": {
+        "min": 1,
+        "max": 3,
         "avg": 2.0
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 2,
+        "f": 6.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 3,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 2,
+        "fantaboom_2024": 3,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 2
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 82,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 1,
+          "minutes": 1536,
+          "rating": 6.07
+        }
+      },
+      "notes": {
+        "comm": "Leonardo Spinazzola al momento non parte come titolare nel Napoli di Conte, ha Olivera davanti ed è arrivato anche Gutierrez. Può essere impiegato sia da terzino sinistro che da esterno alto, ma la concorrenza è forte ed è destinata ad aumentare. Nella scorsa stagione il suo rendimento non è stato esaltante, alla fine ha portato un gol e un assist ma con 23 partite a voto, non molte."
+      }
+    },
+    {
+      "nome": "DARMIAN",
+      "team": "INT",
+      "prezzi": {
+        "min": 0,
+        "max": 2,
+        "avg": 1.5
+      },
+      "stats": {
+        "t": 2,
+        "a": 5,
+        "i": 4,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 2,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 2,
+        "fantaboom_2024": 2,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 2
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 3,
+          "assists": 2,
+          "minutes": 1793,
+          "rating": 6.08
+        }
+      },
+      "notes": {
+        "comm": "Matteo Darmian è un jolly difensivo che è destinato ad avere sempre meno spazio con il passare degli anni. L’ultima stagione è stata anche tutto sommato positiva, perché è riuscito a portare a casa 3 gol e 2 assist. Un numero di bonus, così come il numero delle partite, che è destinato a calare sempre di più. Rimane comunque un jolly, ma più low cost e senza una coppia fissa."
+      }
+    },
+    {
+      "nome": "LYKOGIANNIS",
+      "team": "BOL",
+      "prezzi": {
+        "min": 0,
+        "max": 2,
+        "avg": 1.5
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 4,
+        "f": 5.25
+      },
+      "allPrices": {
+        "fantaboom_2025": 2,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 2,
+        "fantaboom_2024": 2,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 2
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 172,
+          "rating": 5.25
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 4,
+          "minutes": 1050,
+          "rating": 6.0
+        }
+      },
+      "notes": {
+        "comm": "Charalampos Lykogiannis resta un jolly nel Bologna, è il vice di Miranda a sinistra ma ha giocato da titolare le prime due (la prima perché Miranda era squalificato, la seconda per scelta tecnica). La scorsa stagione è stata positiva, ha portato 4 assist grazie al suo mancino. Ha infatti un piede educato e oltre ai cross tira anche i calci piazzati. Il suo problema è la titolarità non fissa, non è la prima scelta sulla fascia sinistra e l’anno scorso ha chiuso con sole 16 partite a voto. Ma garantisce comunque affidabilità quando viene impiegato."
+      }
+    },
+    {
+      "nome": "ZEMURA",
+      "team": "UDI",
+      "prezzi": {
+        "min": 0,
+        "max": 3,
+        "avg": 1.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 3,
+        "f": 5.75
+      },
+      "allPrices": {
+        "fantaboom_2025": 2,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 3,
+        "fantaboom_2024": 2,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 3
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 169,
+          "rating": 5.75
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 2,
+          "minutes": 1415,
+          "rating": 5.81
+        }
+      },
+      "notes": {
+        "comm": "Jordan Zemura rinnova la sfida a Kamara sulla fascia sinistra dell’Udinese. Nella scorsa stagione ha avuto alti e bassi, riuscendo ad arrivare alla fanta-media del 6,00 solo grazie a un gol e due assist. A sinistra ci sarà un ballottaggio continuo e la coppia con Kamara ha senso solo in un fantacalcio numeroso. Zemura ha probabilmente più potenzialità del compagno, vedremo se quest’anno riuscirà a imporsi."
+      }
+    },
+    {
+      "nome": "LAZZARI",
+      "team": "LAZ",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.5
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 3,
+        "f": 5.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 61,
+          "rating": 5.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 1,
+          "minutes": 1415,
+          "rating": 5.89
+        }
+      },
+      "notes": {
+        "comm": "Anche queste sono opzioni da leghe numerose, ma maggiormente jolly e senza il posto assicurato. In alcuni casi vi possono servire come copertura al titolare."
+      }
+    },
+    {
+      "nome": "POSCH",
+      "team": "COM",
+      "prezzi": {
+        "min": 0,
+        "max": 5,
+        "avg": 2.0
+      },
+      "stats": {
+        "t": 2,
+        "a": 3,
+        "i": 2,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 5,
+        "sos_fanta_2025": 2,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 5,
+        "sos_fanta_2024": 2
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 1110,
+          "rating": 5.81
+        }
+      },
+      "notes": {
+        "comm": "Stefan Posch è un nuovo difensore del Como. Fabregas trova un jolly, perché in una difesa a quattro può giocare sia da terzino destro che come difensore centrale. Al Bologna ha fatto più il terzino, dove avrebbe la concorrenza di Vojvoda e Van der Brempt. C’è abbondanza, quindi il posto da titolare non è certo. È dunque un’opzione da leghe abbastanza numerose."
+      }
+    },
+    {
+      "nome": "RENSCH",
+      "team": "ROM",
+      "prezzi": {
+        "min": 1,
+        "max": 2,
+        "avg": 1.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 2,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 9,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 1,
+          "minutes": 470,
+          "rating": 6.06
+        }
+      },
+      "notes": {
+        "comm": "Devyne Rensch ha una collocazione chiara in questo fantacalcio e alla Roma. Il terzino olandese, classe 2003, è la riserva di Wesley, che sulla carta è il titolare. In un fanta numeroso si possono prendere in coppia, per avere titolare e vice. Nei mesi in Italia l’ex Ajax ha fatto vedere una buona affidabilità, è un laterale completo nelle due fasi."
+      }
+    },
+    {
+      "nome": "SCALVINI",
+      "team": "ATA",
+      "prezzi": {
+        "min": 3,
+        "max": 7,
+        "avg": 5.5
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 1,
+        "f": 5.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 7,
+        "fantaclassic_2025": 7,
+        "profeta_2025": 5,
+        "sos_fanta_2025": 3,
+        "fantaboom_2024": 7,
+        "fantaclassic_2024": 7,
+        "profeta_2024": 5,
+        "sos_fanta_2024": 3
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 176,
+          "rating": 5.5
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 273,
+          "rating": 5.5
+        }
+      },
+      "notes": {
+        "comm": "Giorgio Scalvini l’anno scorso non si è praticamente mai visto. 4 partite a voto, 2 gialli, un’annata veramente da dimenticare causa infortuni. Quest’anno vuole riscattarsi, anche se rimane qualche dubbio sulla tenuta fisica, servirà un minimo di prudenza ma ha giocato da titolare le prime due di campionato. Alla lunga comunque Scalvini può essere il titolare fisso come braccetto destro, al momento il suo prezzo è decisamente basso perché alle prime due ha preso 5,5 e 5,5. "
+      }
+    },
+    {
+      "nome": "COMUZZO",
+      "team": "FIO",
+      "prezzi": {
+        "min": 2,
+        "max": 7,
+        "avg": 4.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 5,
+        "f": 6.25
+      },
+      "allPrices": {
+        "fantaboom_2025": 5,
+        "fantaclassic_2025": 5,
+        "profeta_2025": 7,
+        "sos_fanta_2025": 2,
+        "fantaboom_2024": 5,
+        "fantaclassic_2024": 5,
+        "profeta_2024": 7,
+        "sos_fanta_2024": 2
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 107,
+          "rating": 6.25
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 0,
+          "minutes": 2202,
+          "rating": 5.91
+        }
+      },
+      "notes": {
+        "comm": "Pietro Comuzzo vuole riprendersi il suo spazio e tornare a essere importante per la Fiorentina. È molto giovane perché è un 2005, l’anno scorso sembrava in rampa di lancio tanto da attirare l’interesse del Napoli poi è un po’ calato. I giovani possono avere alti e bassi, ora però Pioli lo può rilanciare e pensa di schierarlo da braccetto destro in una difesa a tre. Alto 185 cm, Comuzzo ha come caratteristiche principali il senso dell’anticipo e l’attenzione difensiva."
+      }
+    },
+    {
+      "nome": "CUADRADO",
+      "team": "PIS",
+      "prezzi": {
+        "min": 5,
+        "max": 6,
+        "avg": 5.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 2,
+        "f": 5.75
+      },
+      "allPrices": {
+        "fantaboom_2025": 5,
+        "fantaclassic_2025": 5,
+        "profeta_2025": 5,
+        "sos_fanta_2025": 6,
+        "fantaboom_2024": 5,
+        "fantaclassic_2024": 5,
+        "profeta_2024": 5,
+        "sos_fanta_2024": 6
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 55,
+          "rating": 5.75
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 2,
+          "minutes": 825,
+          "rating": 6.08
+        }
+      },
+      "notes": {
+        "comm": "Juan Cuadrado è di nuovo al fantacalcio, probabilmente per la sua last dance. Il colombiano, a 37 anni, riparte dal Pisa e se sta bene sarà titolare, anche se a destra come esterno del 3-4-2-1 c’è pure Touré che è un ottimo giocatore. Per questo il Panita potrebbe pure avanzare alle spalle della punta. Questo lo rende interessante, perché è listato da difensore. Già all’Atalanta l’anno scorso aveva giocato alcune partite più avanzato, le altre da quinto a destra. All’occorrenza può giocare pure a sinistra. Non ha grande integrità fisica, anche vista l’età: questo è il principale difetto. Va quindi considerato un jolly, l’anno scorso ha chiuso con 23 partite. Di positivo c’è che se sta bene gioca e nel Pisa ha un ruolo importante, può calciare anche i piazzati."
+      }
+    },
+    {
+      "nome": "DE WINTER",
+      "team": "MIL",
+      "prezzi": {
+        "min": 2,
+        "max": 10,
+        "avg": 5.0
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 2,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 5,
+        "fantaclassic_2025": 3,
+        "profeta_2025": 10,
+        "sos_fanta_2025": 2,
+        "fantaboom_2024": 5,
+        "fantaclassic_2024": 3,
+        "profeta_2024": 10,
+        "sos_fanta_2024": 2
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 3,
+          "assists": 0,
+          "minutes": 2133,
+          "rating": 5.85
+        }
+      },
+      "notes": {
+        "comm": "Koni De Winter è passato dal Genoa al Milan. L’olandese arriva da una buonissima stagione con 3 gol segnati, un ottimo bottino per un difensore centrale. Non le ha giocate tutte perché ha avuto un infortunio, ma quando è tornato è stato intoccabile con Vieira. Adesso avrà qualche ballottaggio in più nel Milan, ma è stato preso per prendere il posto di Thiaw ed essere un potenziale titolare. La società ha investito 20 milioni e lo ritiene un acquisto importante, piace ad Allegri che è un allenatore che può valorizzare i difensori. Occhio dunque al mod e anche a qualche bonus di testa."
+      }
+    },
+    {
+      "nome": "HOLM",
+      "team": "BOL",
+      "prezzi": {
+        "min": 2,
+        "max": 5,
+        "avg": 3.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 2,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 5,
+        "fantaclassic_2025": 2,
+        "profeta_2025": 5,
+        "sos_fanta_2025": 3,
+        "fantaboom_2024": 5,
+        "fantaclassic_2024": 2,
+        "profeta_2024": 5,
+        "sos_fanta_2024": 3
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 1,
+          "minutes": 1137,
+          "rating": 5.94
+        }
+      },
+      "notes": {
+        "comm": "Emil Holm cala come valutazione al fantacalcio per due motivi: parte con un infortunio (tornerà a metà settembre) ed è arrivato Zortea. Non parte battuto, si giocheranno il posto, però l'ex Cagliari gode di più appeal e di un prezzo maggiore all'asta dopo quanto fatto nella scorsa stagione. Holm può fare bene ma ha il problema enorme degli infortuni, che si è ripresentato subito anche quest'anno. L'anno scorso solo 16 partite a voto."
+      }
+    },
+    {
+      "nome": "VALLE",
+      "team": "COM",
+      "prezzi": {
+        "min": 3,
+        "max": 7,
+        "avg": 4.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 3,
+        "f": 6.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 5,
+        "fantaclassic_2025": 4,
+        "profeta_2025": 7,
+        "sos_fanta_2025": 3,
+        "fantaboom_2024": 5,
+        "fantaclassic_2024": 4,
+        "profeta_2024": 7,
+        "sos_fanta_2024": 3
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 180,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 1034,
+          "rating": 5.81
+        }
+      },
+      "notes": {
+        "comm": "Alex Valle è in rampa di lancio nel Como. Il giovane spagnolo, classe 2004, può essere il titolare sulla corsia mancina. È un terzino più di spinta che difensivo, anche se sta migliorando in copertura. Non ha ancora portato bonus in Serie A, ma può migliorare e ormai sembra aver messo la freccia su Alberto Moreno (che resta comunque un'alternativa affidabile e di grande esperienza). "
+      }
+    },
+    {
+      "nome": "BARBIERI",
+      "team": "CRE",
+      "prezzi": {
+        "min": 1,
+        "max": 5,
+        "avg": 2.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 3,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 4,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 5,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 4,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 5,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 1784,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Tommaso Barbieri è uno dei giocatori più interessanti della Cremonese. Opzione low cost in provincia, laterale destro che in un 3-5-2 può fare sia il braccetto che l’esterno. L’anno scorso 3 gol e 5 assist in Serie B per il classe 2002, che si giocherà il posto."
+      }
+    },
+    {
+      "nome": "AHANOR",
+      "team": "ATA",
+      "prezzi": {
+        "min": 1,
+        "max": 3,
+        "avg": 2.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 2,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 3,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 3,
+        "fantaboom_2024": 3,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 3
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 270,
+          "rating": 6.0
+        }
+      },
+      "notes": {
+        "comm": "Honest Ahanor è arrivato all’Atalanta come rinforzo per il presente e per il futuro. È giovanissimo, perché è un 2008, ma al Genoa ha già avuto spazio ed è in rampa di lancio. Un 17enne da 20 milioni bonus compresi. Chi ha le conferme deve provare a prenderlo senza dubbi, il futuro è suo. Resta da capire quanto spazio potrà avere già in questa stagione, parte come alternativa. È un esterno sinistro, può giocare a tutta fascia ma anche da braccetto, ruolo in cui potrebbe sostituire l’infortunato Kolasinac. Scommessa dunque da ultimo slot per chi punta sui giovani."
+      }
+    },
+    {
+      "nome": "GHILARDI",
+      "team": "ROM",
+      "prezzi": {
+        "min": 1,
+        "max": 5,
+        "avg": 2.5
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 4,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 2,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 5,
+        "sos_fanta_2025": 2,
+        "fantaboom_2024": 2,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 5,
+        "sos_fanta_2024": 2
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 2031,
+          "rating": 5.73
+        }
+      },
+      "notes": {
+        "comm": "Daniele Ghilardi è passato dal Verona alla Roma. Ora è atteso alla consacrazione, toccherà a Gasperini farlo crescere. Difensore centrale classe 2003 e alto 189 cm, è di piede destro e in una linea a tre può giocare in mezzo e da braccetto. Al fanta non ha fatto bene nella scorsa stagione, nessun bonus e una fanta-media molto bassa del 5,54, penalizzato dalla difesa del Verona che subiva troppo. Alla Roma sarà diverso: più ballottaggi e non più il posto fisso come al Verona, ma voti molto più alti. Il potenziale c’è, se preso a poco può essere un buon acquisto al fantacalcio. Ma tutto passerà da Gasperini."
+      }
+    },
+    {
+      "nome": "NORTON-CUFFY",
+      "team": "GEN",
+      "prezzi": {
+        "min": 2,
+        "max": 5,
+        "avg": 3.5
       },
       "stats": {
         "t": 3,
@@ -6199,182 +7157,560 @@
         "f": 5.75
       },
       "allPrices": {
-        "profeta_2025": 2
+        "fantaboom_2025": 2,
+        "fantaclassic_2025": 4,
+        "profeta_2025": 5,
+        "sos_fanta_2025": 3,
+        "fantaboom_2024": 2,
+        "fantaclassic_2024": 4,
+        "profeta_2024": 5,
+        "sos_fanta_2024": 3
       },
       "performance": {
         "2025_26": {
           "goals": 0,
           "assists": 0,
-          "minutes": 97,
-          "rating": 6.0
+          "minutes": 180,
+          "rating": 5.75
         },
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 721,
+          "rating": 5.7
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Brooke Norton-Cuffy ha trovato spazio nel Genoa di Vieira nella seconda parte della seconda stagione, chiudendo con 10 partite a voto. Nessun bonus, ma potenzialmente può portarne: sia da terzino che in posizione più avanzata, può ricoprire entrambi i ruoli anche se la sensazione è che si giocherà una maglia con Sabelli in difesa, perché dietro c’è meno concorrenza. Non è un titolare fisso comunque, la cosa positiva è che rimane listato coi difensori. Può essere una scommessa low cost da ultimi slot per completare il reparto."
       }
     },
     {
-      "nome": "ZAPPA",
-      "team": "CAG",
+      "nome": "BELGHALI",
+      "team": "VER",
       "prezzi": {
-        "min": 2,
-        "max": 2,
-        "avg": 2.0
-      },
-      "stats": {
-        "t": 4,
-        "a": 3,
-        "i": 5,
-        "f": 5.75
-      },
-      "allPrices": {
-        "profeta_2025": 2
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 148,
-          "rating": 6.0
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "CELIK",
-      "team": "ROM",
-      "prezzi": {
-        "min": 2,
-        "max": 2,
-        "avg": 2.0
+        "min": 0,
+        "max": 1,
+        "avg": 0.8
       },
       "stats": {
         "t": 3,
-        "a": 2,
-        "i": 3,
+        "a": 3,
+        "i": 2,
+        "f": 5.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 240,
+          "rating": 5.75
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 2410,
+          "rating": 6.0
+        }
+      },
+      "notes": {
+        "comm": "Rafik Belghali è il nuovo terzino destro del Verona. Prende il posto di Tchatchoua, che è andato al Wolves. Si tratta di un laterale algerino (convocato solo dall’Under 23, quindi potrebbe non andare in Coppa d’Africa), è un classe 2002. Arriva dal Belgio dove ha giocato nel Mechelen con un 36 partite, un gol e due assist nella passata stagione. Al fanta è solo un’opzione low cost da leghe abbastanza numerose, ha meno appeal di Tchatchoua."
+      }
+    },
+    {
+      "nome": "BELLA-KOTCHAP",
+      "team": "VER",
+      "prezzi": {
+        "min": 0,
+        "max": 4,
+        "avg": 1.5
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 2,
+        "f": 5.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 4,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 4,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 5.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 329,
+          "rating": 5.0
+        }
+      },
+      "notes": {
+        "comm": "Armel Bella-Kotchap è un nuovo difensore del Verona. Si tratta di un centrale di 23 anni alto 190 cm, nato a Parigi ma tedesco di nazionalità e con due presenze in nazionale maggiore (era stato convocato per il Mondiale). Dopo aver fatto bene al Bochum e al Southampton tra il 2021 e il 2023, ha avuto una serie di problemi e infortuni che gli hanno permesso di giocare pochissimo al PSV e poi di nuovo al Southampton l’anno scorso. Parliamo di una decina di presenze in due anni. Al Verona la chance per riscattarsi, non sarebbe il primo giocatore a farlo. Scommessa da leghe numerose, pedina molto low cost."
+      }
+    },
+    {
+      "nome": "BERTOLA",
+      "team": "UDI",
+      "prezzi": {
+        "min": 1,
+        "max": 5,
+        "avg": 2.5
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 4,
+        "f": 5.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 2,
+        "profeta_2025": 5,
+        "sos_fanta_2025": 2,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 2,
+        "profeta_2024": 5,
+        "sos_fanta_2024": 2
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 135,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 2101,
+          "rating": 6.0
+        }
+      },
+      "notes": {
+        "comm": "Nicolò Bertola rinforza la difesa dell’Udinese, che ha perso Bijol per il trasferimento al Leeds. Si tratta di un centrale di 192 cm, alto ma bravo in conduzione e con la palla. Nell’ultima stagione ha fatto anche 2 assist, oltre a tre gol visto che è molto bravo di testa sui piazzati. È un 2003, allo Spezia in Serie B ha fatto bene e ora deve confermarsi in Serie A. Scommessa per la difesa a prezzi bassi."
+      }
+    },
+    {
+      "nome": "BONFANTI",
+      "team": "PIS",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.5
+      },
+      "stats": {
+        "t": 2,
+        "a": 3,
+        "i": 5,
         "f": 0.0
       },
       "allPrices": {
-        "profeta_2025": 2
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Scelte rischiose per la difesa, ci sono molte riserve e giocatori che non dovrebbero avere molto spazio."
+      }
+    },
+    {
+      "nome": "COULIBALY W.",
+      "team": "SAS",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 5,
+        "f": null
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 1,
+          "minutes": 1085,
+          "rating": 5.54
+        }
+      },
+      "notes": {
+        "comm": "Woyo Coulibaly è tornato in Italia e giocherà nel Sassuolo. È un terzino destro classe ’99, aveva già giocato in Serie A con il Parma l’anno scorso tra alti e bassi. Male in Premier con sole 4 partite in Premier da gennaio. Al Sassuolo si candida per una maglia da terzino destro, sarà in concorrenza con Walukiewicz. Non è un’opzione di prima fascia al fantacalcio, solo molto low cost."
+      }
+    },
+    {
+      "nome": "FLORIANI MUSSOLINI",
+      "team": "CRE",
+      "prezzi": {
+        "min": 1,
+        "max": 4,
+        "avg": 2.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 5,
+        "f": 6.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 2,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 4,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 2,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 4
       },
       "performance": {
         "2025_26": {
           "goals": 0,
           "assists": 0,
           "minutes": 8,
-          "rating": 0.0
+          "rating": 6.5
         },
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 2731,
+          "rating": 0.0
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Romano Floriani Mussolini si metterà alla prova in Serie A. Dopo aver giocato in B alla Juve Stabia nella passata stagione, la Lazio lo ha infatti ceduto nuovamente in prestito ma questa volta alla Cremonese. Con la neopromossa il classe 2003 potrà così crescere nel massimo campionato, anche se resta da capire se sarà o meno un titolare per Nicola. C’è infatti la forte concorrenza di Zerbin come esterno destro. Floriani nasce terzino destro, ma è stato impiegato anche in posizione più avanzata, sia a destra che a sinistra come esterno di centrocampo. Al fantacalcio è una scommessa low cost da ultimi slot, sfruttando il ruolo di difensore nel listone."
       }
     },
     {
-      "nome": "EHIZIBUE",
-      "team": "UDI",
+      "nome": "HEGGEM",
+      "team": "BOL",
       "prezzi": {
-        "min": 2,
-        "max": 2,
-        "avg": 2.0
+        "min": 1,
+        "max": 5,
+        "avg": 3.2
       },
       "stats": {
-        "t": 4,
+        "t": 3,
         "a": 3,
-        "i": 3,
-        "f": 5.75
+        "i": 5,
+        "f": 7.0
       },
       "allPrices": {
-        "profeta_2025": 2
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 2,
+        "profeta_2025": 5,
+        "sos_fanta_2025": 5,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 2,
+        "profeta_2024": 5,
+        "sos_fanta_2024": 5
       },
       "performance": {
         "2025_26": {
           "goals": 0,
           "assists": 0,
-          "minutes": 170,
+          "minutes": 90,
+          "rating": 7.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 4014,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Torbjorn Heggem è un nuovo difensore del Bologna. Il classe 1999 arriva dal West Bromwich per circa 7,5 milioni di euro e va ad inserirsi un reparto che ha perso Beukema ed Erlic. Alto 192 cm, il norvegese nella scorsa stagione ha collezionato 45 presenze mettendo a segno 1 gol e 2 assist. Anche a livello di cartellini i numeri sono buoni: solo 3 gialli e nessuna espulsione. L'impatto col Bologna è stato ottimo, adesso si candida per una maglia da titolare e sfida soprattutto Vitik. Al fantacalcio può essere una scommessa."
+      }
+    },
+    {
+      "nome": "HERMOSO",
+      "team": "ROM",
+      "prezzi": {
+        "min": 1,
+        "max": 6,
+        "avg": 4.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 3,
+        "f": 6.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 5,
+        "profeta_2025": 5,
+        "sos_fanta_2025": 6,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 5,
+        "profeta_2024": 5,
+        "sos_fanta_2024": 6
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 172,
+          "rating": 6.5
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 255,
+          "rating": 5.12
+        }
+      },
+      "notes": {
+        "comm": "Mario Hermoso è tornato alla Roma ed è rimasto, Gasperini per ora lo considera un giocatore importante. Da capire se riuscirà a tenersi sempre il posto da titolare, ma è partito più che positivamente. Lo spagnolo è un braccetto sinistro, con il nuovo allenatore può anche avere una nuova chance dopo il flop della scorsa stagione. È partito titolare come braccetto destro nelle prime due di campionato e ha convinto pienamente, farà di tutto per tenersi il posto o comunque per avere spazio nelle rotazioni considerando che ci sono anche le coppe europee."
+      }
+    },
+    {
+      "nome": "IDRISSI R.",
+      "team": "CAG",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.5
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 4,
+        "f": 6.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 29,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 1299,
+          "rating": 6.0
+        }
+      },
+      "notes": {
+        "comm": "Anche queste sono opzioni da leghe numerose, ma maggiormente jolly e senza il posto assicurato. In alcuni casi vi possono servire come copertura al titolare."
+      }
+    },
+    {
+      "nome": "LOVIK",
+      "team": "PAR",
+      "prezzi": {
+        "min": 0,
+        "max": 2,
+        "avg": 0.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 4,
+        "f": 5.75
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 2,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 2
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 178,
           "rating": 5.75
         },
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 105,
+          "rating": 5.75
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Anche queste sono opzioni da leghe numerose, ma maggiormente jolly e senza il posto assicurato. In alcuni casi vi possono servire come copertura al titolare."
       }
     },
     {
-      "nome": "KOLASINAC",
-      "team": "ATA",
+      "nome": "MARCANDALLI",
+      "team": "GEN",
       "prezzi": {
-        "min": 2,
+        "min": 0,
         "max": 2,
-        "avg": 2.0
+        "avg": 1.0
       },
       "stats": {
-        "t": 2,
-        "a": 4,
-        "i": 1,
-        "f": 0.0
+        "t": 3,
+        "a": 3,
+        "i": 5,
+        "f": 6.5
       },
       "allPrices": {
-        "profeta_2025": 2
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 1
       },
       "performance": {
         "2025_26": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0.0
+          "minutes": 90,
+          "rating": 6.5
         },
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 403,
+          "rating": 5.88
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Alessandro Marcandalli è il nuovo che avanza in difesa nel Genoa. Sfida Ostigard per una maglia ed è partito bene giocando a inizio stagione, visto che il norvegese è arrivato in ritardo di condizione. È il primo cambio in difesa."
       }
     },
     {
-      "nome": "ALBIOL",
+      "nome": "MATEUS LUSUARDI",
       "team": "PIS",
       "prezzi": {
         "min": 0,
-        "max": 0,
-        "avg": 0.0
+        "max": 1,
+        "avg": 0.8
       },
       "stats": {
-        "t": null,
-        "a": null,
-        "i": null,
-        "f": null
+        "t": 3,
+        "a": 4,
+        "i": 3,
+        "f": 6.0
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 64,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 929,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Scendiamo ancora verso leghe più numerose, non sono titolari ma opzioni jolly anche dalle big in alcuni casi. Il posto non è assicurato, si vedrà con la preseason se qualcuno di questi difensori riuscirà a emergere."
+      }
+    },
+    {
+      "nome": "NDIAYE",
+      "team": "PAR",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 5,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
       },
       "performance": {
         "2025_26": {
@@ -6386,12 +7722,96 @@
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 1712,
+          "rating": 0.0
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Abdoulaye Ndiaye è un rinforzo del Parma per la difesa. Si tratta di un centrale senegalese classe 2002, è alto 192 cm. Quello che lo rende interessante è il piede mancino, per quello potrebbe giocare. La società l’ha pagato 6,5 milioni quindi ci punta, potrebbe essere titolare. La scelta al fantacalcio è comunque molto low cost, si riesce a prendere da ultimi slot."
+      }
+    },
+    {
+      "nome": "PALESTRA",
+      "team": "CAG",
+      "prezzi": {
+        "min": 1,
+        "max": 7,
+        "avg": 4.8
+      },
+      "stats": {
+        "t": 2,
+        "a": 3,
+        "i": 4,
+        "f": 6.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 6,
+        "profeta_2025": 7,
+        "sos_fanta_2025": 5,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 6,
+        "profeta_2024": 7,
+        "sos_fanta_2024": 5
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 83,
+          "rating": 6.5
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 218,
+          "rating": 6.0
+        }
+      },
+      "notes": {
+        "comm": "Marco Palestra è passato in prestito al Cagliari e spera di seguire le orme di Zortea, che va a sostituire. La curiosità è che ha fatto proprio lo stesso percorso. Il terzino, alto 186 cm, è giovane perché è soltanto un 2005, ma promette bene. Al Cagliari può essere una scommessa perché può giocare sia da terzino che anche più alto. Non è un titolare fisso in partenza però potrà andare spesso a voto e magari ritagliarsi una maglia, aveva molte richieste e nel corso della stagione potrà emergere, è un giovane che ha ottime credenziali e Pisacane lo ha lanciato subito dal 1' a Napoli. Come scommessina da ultimi slot ci può stare, in Primavera era arrivato a fare 10 assist in una stagione."
+      }
+    },
+    {
+      "nome": "VALENTINI N.",
+      "team": "VER",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 2,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 1132,
+          "rating": 5.61
+        }
+      },
+      "notes": {
+        "comm": "Da qui potete pescare qualche titolare o voto sicuro, ma solo per leghe numerose. Non c’è la garanzia di voti alti o da modificatore, siamo in provincia."
       }
     },
     {
@@ -6399,8 +7819,8 @@
       "team": "MIL",
       "prezzi": {
         "min": 0,
-        "max": 0,
-        "avg": 0.0
+        "max": 1,
+        "avg": 0.5
       },
       "stats": {
         "t": 3,
@@ -6409,7 +7829,14 @@
         "f": 0.0
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
       },
       "performance": {
         "2025_26": {
@@ -6421,12 +7848,12 @@
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 1761,
+          "rating": 0.0
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Zachary Athekame è un nuovo terzino del Milan. Lo svizzero arriva dallo Young Boys per una cifra vicina ai 10 milioni di euro e va a riempire una casella mancante nella rosa rossonera. In una difesa a 4, si giocherà il posto in quel ruolo a destra con Alex Jimenez (se resterà, occhio al mercato) e, all'occorrenza, con De Winter e Tomori. Oppure Saelemaekers in caso di 3-5-2. Non titolare fisso, ma si giocherà una maglia. È un giocatore che, nonostante sia del 2004, ha già una discreta esperienza: la scorsa stagione ha collezionato 30 presenze in campionato e 8 in Champions League, giocando tutte le partite del girone eliminatorio. Per lui, tra tutte le competizioni, 1 gol e 3 assist in 43 gare totali. È per il futuro, ma anche per il presente."
       }
     },
     {
@@ -6434,8 +7861,8 @@
       "team": "PAR",
       "prezzi": {
         "min": 0,
-        "max": 0,
-        "avg": 0.0
+        "max": 1,
+        "avg": 0.2
       },
       "stats": {
         "t": 3,
@@ -6444,7 +7871,14 @@
         "f": 0.0
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
       },
       "performance": {
         "2025_26": {
@@ -6455,13 +7889,13 @@
         },
         "2024_25": {
           "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "assists": 1,
+          "minutes": 2053,
+          "rating": 5.78
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Scendiamo ancora verso leghe più numerose, non sono titolari ma opzioni jolly anche dalle big in alcuni casi. Il posto non è assicurato, si vedrà con la preseason se qualcuno di questi difensori riuscirà a emergere."
       }
     },
     {
@@ -6479,7 +7913,14 @@
         "f": 0
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 0,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 0
       },
       "performance": {
         "2025_26": {
@@ -6491,82 +7932,12 @@
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 123,
+          "rating": 5.33
         }
       },
       "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "BELGHALI",
-      "team": "VER",
-      "prezzi": {
-        "min": 0,
-        "max": 0,
-        "avg": 0.0
-      },
-      "stats": {
-        "t": 3,
-        "a": 3,
-        "i": 2,
-        "f": 5.5
-      },
-      "allPrices": {
-        "profeta_2025": 0
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 240,
-          "rating": 5.75
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "BELLA-KOTCHAP",
-      "team": "VER",
-      "prezzi": {
-        "min": 0,
-        "max": 0,
-        "avg": 0.0
-      },
-      "stats": {
-        "t": 3,
-        "a": 4,
-        "i": 2,
-        "f": 5.0
-      },
-      "allPrices": {
-        "profeta_2025": 0
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 5.0
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
+        "comm": "Scelte rischiose per la difesa, ci sono molte riserve e giocatori che non dovrebbero avere molto spazio."
       }
     },
     {
@@ -6574,8 +7945,8 @@
       "team": "CRE",
       "prezzi": {
         "min": 0,
-        "max": 0,
-        "avg": 0.0
+        "max": 1,
+        "avg": 0.5
       },
       "stats": {
         "t": 3,
@@ -6584,7 +7955,14 @@
         "f": 6.25
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
       },
       "performance": {
         "2025_26": {
@@ -6596,82 +7974,12 @@
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 3074,
+          "rating": 6.5
         }
       },
       "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "BONFANTI",
-      "team": "PIS",
-      "prezzi": {
-        "min": 0,
-        "max": 0,
-        "avg": 0.0
-      },
-      "stats": {
-        "t": 2,
-        "a": 3,
-        "i": 5,
-        "f": 0.0
-      },
-      "allPrices": {
-        "profeta_2025": 0
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0.0
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "BRADARIC",
-      "team": "VER",
-      "prezzi": {
-        "min": 0,
-        "max": 0,
-        "avg": 0.0
-      },
-      "stats": {
-        "t": 3,
-        "a": 2,
-        "i": 3,
-        "f": 5.5
-      },
-      "allPrices": {
-        "profeta_2025": 0
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 162,
-          "rating": 5.5
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
+        "comm": "Scendiamo ancora verso leghe più numerose, non sono titolari ma opzioni jolly anche dalle big in alcuni casi. Il posto non è assicurato, si vedrà con la preseason se qualcuno di questi difensori riuscirà a emergere."
       }
     },
     {
@@ -6679,8 +7987,8 @@
       "team": "PAR",
       "prezzi": {
         "min": 0,
-        "max": 0,
-        "avg": 0.0
+        "max": 1,
+        "avg": 0.2
       },
       "stats": {
         "t": 1,
@@ -6689,7 +7997,14 @@
         "f": 0.0
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
       },
       "performance": {
         "2025_26": {
@@ -6701,12 +8016,12 @@
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 246,
+          "rating": 0.0
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Scendiamo ancora verso leghe più numerose, non sono titolari ma opzioni jolly anche dalle big in alcuni casi. Il posto non è assicurato, si vedrà con la preseason se qualcuno di questi difensori riuscirà a emergere."
       }
     },
     {
@@ -6714,8 +8029,8 @@
       "team": "JUV",
       "prezzi": {
         "min": 0,
-        "max": 0,
-        "avg": 0.0
+        "max": 1,
+        "avg": 0.2
       },
       "stats": {
         "t": 1,
@@ -6724,7 +8039,14 @@
         "f": 0.0
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
       },
       "performance": {
         "2025_26": {
@@ -6736,12 +8058,12 @@
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 461,
+          "rating": 6.33
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Anche queste sono opzioni da leghe numerose, ma maggiormente jolly e senza il posto assicurato. In alcuni casi vi possono servire come copertura al titolare."
       }
     },
     {
@@ -6749,8 +8071,8 @@
       "team": "PIS",
       "prezzi": {
         "min": 0,
-        "max": 0,
-        "avg": 0.0
+        "max": 1,
+        "avg": 0.2
       },
       "stats": {
         "t": 3,
@@ -6759,7 +8081,14 @@
         "f": 6.0
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
       },
       "performance": {
         "2025_26": {
@@ -6771,12 +8100,54 @@
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 1107,
+          "rating": 6.0
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Scendiamo ancora verso leghe più numerose, non sono titolari ma opzioni jolly anche dalle big in alcuni casi. Il posto non è assicurato, si vedrà con la preseason se qualcuno di questi difensori riuscirà a emergere."
+      }
+    },
+    {
+      "nome": "CANDÈ",
+      "team": "SAS",
+      "prezzi": {
+        "min": 0,
+        "max": 2,
+        "avg": 0.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 5,
+        "f": 5.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 54,
+          "rating": 5.5
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 0,
+          "minutes": 1530,
+          "rating": 5.76
+        }
+      },
+      "notes": {
+        "comm": "Da qui potete pescare qualche titolare o voto sicuro, ma solo per leghe numerose. Non c’è la garanzia di voti alti o da modificatore, siamo in provincia."
       }
     },
     {
@@ -6784,8 +8155,8 @@
       "team": "BOL",
       "prezzi": {
         "min": 0,
-        "max": 0,
-        "avg": 0.0
+        "max": 1,
+        "avg": 0.2
       },
       "stats": {
         "t": 2,
@@ -6794,7 +8165,14 @@
         "f": 5.5
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
       },
       "performance": {
         "2025_26": {
@@ -6805,13 +8183,13 @@
         },
         "2024_25": {
           "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "assists": 1,
+          "minutes": 1046,
+          "rating": 5.63
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Anche queste sono opzioni da leghe numerose, ma maggiormente jolly e senza il posto assicurato. In alcuni casi vi possono servire come copertura al titolare."
       }
     },
     {
@@ -6819,8 +8197,8 @@
       "team": "CRE",
       "prezzi": {
         "min": 0,
-        "max": 0,
-        "avg": 0.0
+        "max": 1,
+        "avg": 0.2
       },
       "stats": {
         "t": 2,
@@ -6829,7 +8207,14 @@
         "f": 0.0
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
       },
       "performance": {
         "2025_26": {
@@ -6841,12 +8226,54 @@
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 12,
+          "rating": 0.0
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Scendiamo ancora verso leghe più numerose, non sono titolari ma opzioni jolly anche dalle big in alcuni casi. Il posto non è assicurato, si vedrà con la preseason se qualcuno di questi difensori riuscirà a emergere."
+      }
+    },
+    {
+      "nome": "CELIK",
+      "team": "ROM",
+      "prezzi": {
+        "min": 0,
+        "max": 2,
+        "avg": 1.0
+      },
+      "stats": {
+        "t": 3,
+        "a": 2,
+        "i": 3,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 8,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 2,
+          "minutes": 2261,
+          "rating": 5.78
+        }
+      },
+      "notes": {
+        "comm": "Zeki Celik si è trasformato in un braccetto, ruolo che può ricoprire anche con Gasperini. Poi può anche giocare nel suo vecchio ruolo di laterale destro, dove però ci sono Wesley e Rensch. Da braccetto potrà giocare di più, avrà la concorrenza di Ghilardi."
       }
     },
     {
@@ -6854,8 +8281,8 @@
       "team": "VER",
       "prezzi": {
         "min": 0,
-        "max": 0,
-        "avg": 0.0
+        "max": 1,
+        "avg": 0.2
       },
       "stats": {
         "t": 3,
@@ -6864,7 +8291,14 @@
         "f": 5.5
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
       },
       "performance": {
         "2025_26": {
@@ -6876,47 +8310,12 @@
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 127,
+          "rating": 0.0
         }
       },
       "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "CIRCATI",
-      "team": "PAR",
-      "prezzi": {
-        "min": 0,
-        "max": 0,
-        "avg": 0.0
-      },
-      "stats": {
-        "t": 3,
-        "a": 3,
-        "i": 2,
-        "f": 5.5
-      },
-      "allPrices": {
-        "profeta_2025": 0
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 180,
-          "rating": 5.5
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
+        "comm": "Scendiamo ancora verso leghe più numerose, non sono titolari ma opzioni jolly anche dalle big in alcuni casi. Il posto non è assicurato, si vedrà con la preseason se qualcuno di questi difensori riuscirà a emergere."
       }
     },
     {
@@ -6934,7 +8333,14 @@
         "f": 0
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 0,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 0
       },
       "performance": {
         "2025_26": {
@@ -6946,47 +8352,12 @@
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "COULIBALY W.",
-      "team": "SAS",
-      "prezzi": {
-        "min": 0,
-        "max": 0,
-        "avg": 0.0
-      },
-      "stats": {
-        "t": 3,
-        "a": 3,
-        "i": 5,
-        "f": null
-      },
-      "allPrices": {
-        "profeta_2025": 0
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
+          "minutes": 2470,
           "rating": 0.0
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Potete evitare questi difensori, non sono giocatori su cui puntare al fantacalcio."
       }
     },
     {
@@ -6994,8 +8365,8 @@
       "team": "BOL",
       "prezzi": {
         "min": 0,
-        "max": 0,
-        "avg": 0.0
+        "max": 1,
+        "avg": 0.2
       },
       "stats": {
         "t": 2,
@@ -7004,7 +8375,14 @@
         "f": 6.0
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
       },
       "performance": {
         "2025_26": {
@@ -7014,14 +8392,14 @@
           "rating": 6.0
         },
         "2024_25": {
-          "goals": 0,
+          "goals": 1,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 1065,
+          "rating": 5.91
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Scendiamo ancora verso leghe più numerose, non sono titolari ma opzioni jolly anche dalle big in alcuni casi. Il posto non è assicurato, si vedrà con la preseason se qualcuno di questi difensori riuscirà a emergere."
       }
     },
     {
@@ -7039,7 +8417,14 @@
         "f": 0
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 0,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 0
       },
       "performance": {
         "2025_26": {
@@ -7049,14 +8434,14 @@
           "rating": 0.0
         },
         "2024_25": {
-          "goals": 0,
+          "goals": 1,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 402,
+          "rating": 5.67
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Scelte rischiose per la difesa, ci sono molte riserve e giocatori che non dovrebbero avere molto spazio."
       }
     },
     {
@@ -7064,8 +8449,8 @@
       "team": "PIS",
       "prezzi": {
         "min": 0,
-        "max": 0,
-        "avg": 0.0
+        "max": 1,
+        "avg": 0.5
       },
       "stats": {
         "t": 3,
@@ -7074,7 +8459,14 @@
         "f": 5.5
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
       },
       "performance": {
         "2025_26": {
@@ -7086,12 +8478,12 @@
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 683,
+          "rating": 5.5
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Scendiamo ancora verso leghe più numerose, non sono titolari ma opzioni jolly anche dalle big in alcuni casi. Il posto non è assicurato, si vedrà con la preseason se qualcuno di questi difensori riuscirà a emergere."
       }
     },
     {
@@ -7109,7 +8501,14 @@
         "f": 0
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 0,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 0
       },
       "performance": {
         "2025_26": {
@@ -7121,12 +8520,12 @@
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 14,
+          "rating": 0.0
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Scelte rischiose per la difesa, ci sono molte riserve e giocatori che non dovrebbero avere molto spazio."
       }
     },
     {
@@ -7144,7 +8543,14 @@
         "f": 0
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 0,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 0
       },
       "performance": {
         "2025_26": {
@@ -7155,13 +8561,13 @@
         },
         "2024_25": {
           "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "assists": 2,
+          "minutes": 1829,
+          "rating": 5.8
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Scelte rischiose per la difesa, ci sono molte riserve e giocatori che non dovrebbero avere molto spazio."
       }
     },
     {
@@ -7169,8 +8575,8 @@
       "team": "VER",
       "prezzi": {
         "min": 0,
-        "max": 0,
-        "avg": 0.0
+        "max": 1,
+        "avg": 0.2
       },
       "stats": {
         "t": 2,
@@ -7179,7 +8585,14 @@
         "f": 5.0
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
       },
       "performance": {
         "2025_26": {
@@ -7191,12 +8604,12 @@
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 90,
+          "rating": 5.5
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Da qui potete pescare qualche titolare o voto sicuro, ma solo per leghe numerose. Non c’è la garanzia di voti alti o da modificatore, siamo in provincia."
       }
     },
     {
@@ -7214,7 +8627,14 @@
         "f": 0
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 0,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 0
       },
       "performance": {
         "2025_26": {
@@ -7227,11 +8647,11 @@
           "goals": 0,
           "assists": 0,
           "minutes": 0,
-          "rating": 0
+          "rating": 0.0
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Potete evitare questi difensori, non sono giocatori su cui puntare al fantacalcio."
       }
     },
     {
@@ -7239,8 +8659,8 @@
       "team": "CRE",
       "prezzi": {
         "min": 0,
-        "max": 0,
-        "avg": 0.0
+        "max": 1,
+        "avg": 0.2
       },
       "stats": {
         "t": 2,
@@ -7249,7 +8669,14 @@
         "f": null
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
       },
       "performance": {
         "2025_26": {
@@ -7261,12 +8688,12 @@
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 693,
+          "rating": 0.0
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Mikayil Faye è il nuovo acquisto della Cremonese per la difesa. È un difensore centrale del 2004 alto 183 cm, acquistato dal Rennes. Prima della Ligue 1 ha avuto un’esperienza al Barcellona B. Giovane prospetto interessante, preso in prestito con un diritto di riscatto fissato a 10 milioni di euro, dunque un investimento potenzialmente importante per i grigiorossi. Proverà alla lunga a conquistarsi una maglia da titolare, parte come jolly ma ha talento e può provare a imporsi. Scommessa da lega abbastanza numerosa."
       }
     },
     {
@@ -7284,7 +8711,14 @@
         "f": 0
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 0,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 0
       },
       "performance": {
         "2025_26": {
@@ -7296,12 +8730,12 @@
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 1736,
+          "rating": 0.0
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Scelte rischiose per la difesa, ci sono molte riserve e giocatori che non dovrebbero avere molto spazio."
       }
     },
     {
@@ -7309,8 +8743,8 @@
       "team": "FIO",
       "prezzi": {
         "min": 0,
-        "max": 0,
-        "avg": 0.0
+        "max": 1,
+        "avg": 0.2
       },
       "stats": {
         "t": 2,
@@ -7319,7 +8753,14 @@
         "f": 0.0
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
       },
       "performance": {
         "2025_26": {
@@ -7331,12 +8772,12 @@
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 1961,
+          "rating": 0.0
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Scendiamo ancora verso leghe più numerose, non sono titolari ma opzioni jolly anche dalle big in alcuni casi. Il posto non è assicurato, si vedrà con la preseason se qualcuno di questi difensori riuscirà a emergere."
       }
     },
     {
@@ -7354,7 +8795,14 @@
         "f": 0
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 0,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 0
       },
       "performance": {
         "2025_26": {
@@ -7364,14 +8812,14 @@
           "rating": 0.0
         },
         "2024_25": {
-          "goals": 0,
+          "goals": 2,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 688,
+          "rating": 6.2
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Anche queste sono opzioni da leghe numerose, ma maggiormente jolly e senza il posto assicurato. In alcuni casi vi possono servire come copertura al titolare."
       }
     },
     {
@@ -7379,8 +8827,8 @@
       "team": "UDI",
       "prezzi": {
         "min": 0,
-        "max": 0,
-        "avg": 0.0
+        "max": 1,
+        "avg": 0.2
       },
       "stats": {
         "t": 3,
@@ -7389,7 +8837,14 @@
         "f": 6.0
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
       },
       "performance": {
         "2025_26": {
@@ -7400,13 +8855,13 @@
         },
         "2024_25": {
           "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "assists": 1,
+          "minutes": 2546,
+          "rating": 5.76
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Saba Goglichidze è passato all’Udinese dopo l’ultima stagione all’Empoli. Il difensore georgiano era partito bene, poi è calato. Ha comunque chiuso con 33 presenze a voto, però con 5,71 di fanta. All’Udinese può essere sempre sulle 30 presenze stagionali, si gioca il posto ma può andare a voto spesso. E può avere una fanta-media leggermente superiore. Opzione molto low cost."
       }
     },
     {
@@ -7414,8 +8869,8 @@
       "team": "COM",
       "prezzi": {
         "min": 0,
-        "max": 0,
-        "avg": 0.0
+        "max": 1,
+        "avg": 0.2
       },
       "stats": {
         "t": 2,
@@ -7424,7 +8879,14 @@
         "f": 0.0
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
       },
       "performance": {
         "2025_26": {
@@ -7434,14 +8896,14 @@
           "rating": 0.0
         },
         "2024_25": {
-          "goals": 0,
+          "goals": 1,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 2543,
+          "rating": 5.83
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Edoardo Goldaniga è diventato un pilastro del Como, ha anche rinnovato il suo contratto. Il difensore centrale di Fabregas è stato titolare nella scorsa stagione, andando a voto in 30 occasioni. La fanta-media non è stata alta, solo del 5,73, nonostante un gol segnato. Troppe le 10 ammonizioni."
       }
     },
     {
@@ -7449,8 +8911,8 @@
       "team": "LAZ",
       "prezzi": {
         "min": 0,
-        "max": 0,
-        "avg": 0.0
+        "max": 1,
+        "avg": 0.2
       },
       "stats": {
         "t": 2,
@@ -7459,7 +8921,14 @@
         "f": 0.0
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
       },
       "performance": {
         "2025_26": {
@@ -7470,48 +8939,13 @@
         },
         "2024_25": {
           "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "assists": 3,
+          "minutes": 422,
+          "rating": 5.88
         }
       },
       "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "IDRISSI R.",
-      "team": "CAG",
-      "prezzi": {
-        "min": 0,
-        "max": 0,
-        "avg": 0.0
-      },
-      "stats": {
-        "t": 3,
-        "a": 3,
-        "i": 4,
-        "f": 6.0
-      },
-      "allPrices": {
-        "profeta_2025": 0
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 29,
-          "rating": 6.0
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
+        "comm": "Scendiamo ancora verso leghe più numerose, non sono titolari ma opzioni jolly anche dalle big in alcuni casi. Il posto non è assicurato, si vedrà con la preseason se qualcuno di questi difensori riuscirà a emergere."
       }
     },
     {
@@ -7529,7 +8963,14 @@
         "f": 0
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 0,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 0
       },
       "performance": {
         "2025_26": {
@@ -7542,11 +8983,11 @@
           "goals": 0,
           "assists": 0,
           "minutes": 0,
-          "rating": 0
+          "rating": 0.0
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Potete evitare questi difensori, non sono giocatori su cui puntare al fantacalcio."
       }
     },
     {
@@ -7564,7 +9005,14 @@
         "f": 0
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 0,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 0
       },
       "performance": {
         "2025_26": {
@@ -7576,12 +9024,54 @@
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 1387,
+          "rating": 5.75
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Scelte rischiose per la difesa, ci sono molte riserve e giocatori che non dovrebbero avere molto spazio."
+      }
+    },
+    {
+      "nome": "JUAN JESUS",
+      "team": "NAP",
+      "prezzi": {
+        "min": 0,
+        "max": 2,
+        "avg": 1.0
+      },
+      "stats": {
+        "t": 3,
+        "a": 2,
+        "i": 3,
+        "f": 6.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 2,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 2
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 158,
+          "rating": 6.25
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 1,
+          "minutes": 1075,
+          "rating": 5.81
+        }
+      },
+      "notes": {
+        "comm": "Juan Jesus è il quarto difensore centrale del Napoli, davanti a lui ci sono Buongiorno, Rrahmani e Beukema. È di piede mancino, quindi sulla carta è il sostituto dell’ex Torino come lo è stato l’anno scorso. Conte si fida e quando l’ha chiamato in causa è stato ripagato da buone prestazioni. Quest’anno perderà un po’ di spazio."
       }
     },
     {
@@ -7599,7 +9089,14 @@
         "f": 0
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 0,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 0
       },
       "performance": {
         "2025_26": {
@@ -7609,14 +9106,14 @@
           "rating": 0.0
         },
         "2024_25": {
-          "goals": 0,
+          "goals": 2,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 1163,
+          "rating": 5.84
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Scelte rischiose per la difesa, ci sono molte riserve e giocatori che non dovrebbero avere molto spazio."
       }
     },
     {
@@ -7624,8 +9121,8 @@
       "team": "LEC",
       "prezzi": {
         "min": 0,
-        "max": 0,
-        "avg": 0.0
+        "max": 1,
+        "avg": 0.2
       },
       "stats": {
         "t": 3,
@@ -7634,7 +9131,14 @@
         "f": 6.0
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
       },
       "performance": {
         "2025_26": {
@@ -7646,12 +9150,12 @@
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 2920,
+          "rating": 6.0
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Scendiamo ancora verso leghe più numerose, non sono titolari ma opzioni jolly anche dalle big in alcuni casi. Il posto non è assicurato, si vedrà con la preseason se qualcuno di questi difensori riuscirà a emergere."
       }
     },
     {
@@ -7659,8 +9163,8 @@
       "team": "FIO",
       "prezzi": {
         "min": 0,
-        "max": 0,
-        "avg": 0.0
+        "max": 1,
+        "avg": 0.5
       },
       "stats": {
         "t": 2,
@@ -7669,7 +9173,14 @@
         "f": null
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
       },
       "performance": {
         "2025_26": {
@@ -7679,84 +9190,14 @@
           "rating": 0.0
         },
         "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "goals": 2,
+          "assists": 2,
+          "minutes": 869,
+          "rating": 0.0
         }
       },
       "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "LAZZARI",
-      "team": "LAZ",
-      "prezzi": {
-        "min": 0,
-        "max": 0,
-        "avg": 0.0
-      },
-      "stats": {
-        "t": 3,
-        "a": 4,
-        "i": 3,
-        "f": 5.0
-      },
-      "allPrices": {
-        "profeta_2025": 0
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 61,
-          "rating": 5.0
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "LOVIK",
-      "team": "PAR",
-      "prezzi": {
-        "min": 0,
-        "max": 0,
-        "avg": 0.0
-      },
-      "stats": {
-        "t": 3,
-        "a": 3,
-        "i": 4,
-        "f": 5.75
-      },
-      "allPrices": {
-        "profeta_2025": 0
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 178,
-          "rating": 5.75
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
+        "comm": "Tariq Lamptey è l’ultimo rinforzo della Fiorentina per la fascia: arriva dal Brighton a titolo definitivo e sarà il vice Dodo sulla corsia destra. Classe 2000, cresciuto nel Chelsea, porta con sé oltre 100 presenze in Premier League ma con pochi bonus all’attivo (3 gol e 11 assist). Può giocare su tutta la fascia destra (in caso di necessità anche a sinistra), ma resta una seconda scelta nelle gerarchie di Pioli, perché Dodo è un punto fermo. Da considerare anche la sua fragilità fisica, con diversi infortuni negli ultimi anni, incluso quello alla caviglia che lo sta tenendo fermo da diverso tempo. Al fantacalcio è un profilo da ultimi slot, specialmente per leghe abbastanza numerose come vice Dodo."
       }
     },
     {
@@ -7774,7 +9215,14 @@
         "f": 0
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 0,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 0
       },
       "performance": {
         "2025_26": {
@@ -7786,12 +9234,12 @@
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 1068,
+          "rating": 5.81
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Luca Marianucci parte come quinto centrale nel Napoli, come giovane da far crescere. Classe 2004, è un difensore centrale che arriva dall’Empoli. È venuto fuori l’anno scorso giocando 24 partite tra Serie A e Coppa Italia. Il Napoli lo ha voluto per il presente e per il futuro spendendo quasi 10 milioni di euro. Non è molto da fantacalcio, perché con Conte non sarà titolare. Parte come riserva, quindi dovrebbe giocare poco."
       }
     },
     {
@@ -7799,8 +9247,8 @@
       "team": "TOR",
       "prezzi": {
         "min": 0,
-        "max": 0,
-        "avg": 0.0
+        "max": 1,
+        "avg": 0.2
       },
       "stats": {
         "t": 3,
@@ -7809,7 +9257,14 @@
         "f": 4.5
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
       },
       "performance": {
         "2025_26": {
@@ -7819,49 +9274,14 @@
           "rating": 4.5
         },
         "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "goals": 1,
+          "assists": 3,
+          "minutes": 1926,
+          "rating": 5.96
         }
       },
       "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "MATEUS LUSUARDI",
-      "team": "PIS",
-      "prezzi": {
-        "min": 0,
-        "max": 0,
-        "avg": 0.0
-      },
-      "stats": {
-        "t": 3,
-        "a": 4,
-        "i": 3,
-        "f": 6.0
-      },
-      "allPrices": {
-        "profeta_2025": 0
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 64,
-          "rating": 6.0
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
+        "comm": "Scendiamo ancora verso leghe più numerose, non sono titolari ma opzioni jolly anche dalle big in alcuni casi. Il posto non è assicurato, si vedrà con la preseason se qualcuno di questi difensori riuscirà a emergere."
       }
     },
     {
@@ -7869,8 +9289,8 @@
       "team": "NAP",
       "prezzi": {
         "min": 0,
-        "max": 0,
-        "avg": 0.0
+        "max": 1,
+        "avg": 0.2
       },
       "stats": {
         "t": 2,
@@ -7879,7 +9299,56 @@
         "f": 0.0
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 735,
+          "rating": 5.7
+        }
+      },
+      "notes": {
+        "comm": "Scelte rischiose per la difesa, ci sono molte riserve e giocatori che non dovrebbero avere molto spazio."
+      }
+    },
+    {
+      "nome": "MBAMBI",
+      "team": "PIS",
+      "prezzi": {
+        "min": 0,
+        "max": 2,
+        "avg": 0.8
+      },
+      "stats": {
+        "t": 2,
+        "a": 3,
+        "i": 4,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 1
       },
       "performance": {
         "2025_26": {
@@ -7892,11 +9361,11 @@
           "goals": 0,
           "assists": 0,
           "minutes": 0,
-          "rating": 0
+          "rating": 0.0
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Scendiamo ancora verso leghe più numerose, non sono titolari ma opzioni jolly anche dalle big in alcuni casi. Il posto non è assicurato, si vedrà con la preseason se qualcuno di questi difensori riuscirà a emergere."
       }
     },
     {
@@ -7904,8 +9373,8 @@
       "team": "COM",
       "prezzi": {
         "min": 0,
-        "max": 0,
-        "avg": 0.0
+        "max": 1,
+        "avg": 0.2
       },
       "stats": {
         "t": 2,
@@ -7914,7 +9383,14 @@
         "f": 0.0
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
       },
       "performance": {
         "2025_26": {
@@ -7926,12 +9402,12 @@
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 1741,
+          "rating": 5.96
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Scendiamo ancora verso leghe più numerose, non sono titolari ma opzioni jolly anche dalle big in alcuni casi. Il posto non è assicurato, si vedrà con la preseason se qualcuno di questi difensori riuscirà a emergere."
       }
     },
     {
@@ -7949,7 +9425,14 @@
         "f": 0
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 0,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 0
       },
       "performance": {
         "2025_26": {
@@ -7961,82 +9444,12 @@
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "NDIAYE",
-      "team": "PAR",
-      "prezzi": {
-        "min": 0,
-        "max": 0,
-        "avg": 0.0
-      },
-      "stats": {
-        "t": 3,
-        "a": 3,
-        "i": 5,
-        "f": 0.0
-      },
-      "allPrices": {
-        "profeta_2025": 0
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
+          "minutes": 3108,
           "rating": 0.0
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
         }
       },
       "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "NELSSON",
-      "team": "VER",
-      "prezzi": {
-        "min": 0,
-        "max": 0,
-        "avg": 0.0
-      },
-      "stats": {
-        "t": 4,
-        "a": 3,
-        "i": 4,
-        "f": 4.75
-      },
-      "allPrices": {
-        "profeta_2025": 0
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 180,
-          "rating": 4.75
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
+        "comm": "Scelte rischiose per la difesa, ci sono molte riserve e giocatori che non dovrebbero avere molto spazio."
       }
     },
     {
@@ -8044,8 +9457,8 @@
       "team": "TOR",
       "prezzi": {
         "min": 0,
-        "max": 0,
-        "avg": 0.0
+        "max": 1,
+        "avg": 0.5
       },
       "stats": {
         "t": 2,
@@ -8054,7 +9467,14 @@
         "f": null
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
       },
       "performance": {
         "2025_26": {
@@ -8066,47 +9486,12 @@
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 392,
+          "rating": 0.0
         }
       },
       "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "OBERT",
-      "team": "CAG",
-      "prezzi": {
-        "min": 0,
-        "max": 0,
-        "avg": 0.0
-      },
-      "stats": {
-        "t": 3,
-        "a": 3,
-        "i": 4,
-        "f": 5.5
-      },
-      "allPrices": {
-        "profeta_2025": 0
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 165,
-          "rating": 5.75
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
+        "comm": "Niels Nkounkou è il nuovo rinforzo in difesa del Torino per la fascia sinistra, arrivato in prestito dall’Eintracht Francoforte. Classe 2000, sarà l’alternativa a Biraghi. Difficilmente partirà subito come titolare, ma avrà spazio nel corso della stagione. In Bundesliga ha trovato poco minutaggio nell’ultima annata, mentre nel 2023/24 si era messo in mostra con 3 gol e 3 assist in 29 presenze. È un giocatore che può dare spunti interessanti in proiezione offensiva, ma al fantacalcio resta un’opzione secondaria al momento, parte come alternativa a Biraghi."
       }
     },
     {
@@ -8124,7 +9509,14 @@
         "f": 0
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 0,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 0
       },
       "performance": {
         "2025_26": {
@@ -8136,12 +9528,12 @@
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 1687,
+          "rating": 0.0
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Scelte rischiose per la difesa, ci sono molte riserve e giocatori che non dovrebbero avere molto spazio."
       }
     },
     {
@@ -8149,8 +9541,8 @@
       "team": "MIL",
       "prezzi": {
         "min": 0,
-        "max": 0,
-        "avg": 0.0
+        "max": 1,
+        "avg": 0.5
       },
       "stats": {
         "t": 1,
@@ -8159,7 +9551,14 @@
         "f": null
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
       },
       "performance": {
         "2025_26": {
@@ -8171,12 +9570,12 @@
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 194,
+          "rating": 0.0
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "David Odogu è la scommessa che ha fatto il Milan per la difesa. È un centrale del 2006 e alto 191 cm, è molto giovane. Arriva dal Wolfsburg dove ha giocato solo 3 partite l’anno scorso. È più per il futuro per il presente, per il fantacalcio può essere ancora acerbo."
       }
     },
     {
@@ -8184,8 +9583,8 @@
       "team": "GEN",
       "prezzi": {
         "min": 0,
-        "max": 0,
-        "avg": 0.0
+        "max": 1,
+        "avg": 0.2
       },
       "stats": {
         "t": 1,
@@ -8194,7 +9593,14 @@
         "f": 0.0
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
       },
       "performance": {
         "2025_26": {
@@ -8206,12 +9612,12 @@
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 180,
+          "rating": 5.17
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Scendiamo ancora verso leghe più numerose, non sono titolari ma opzioni jolly anche dalle big in alcuni casi. Il posto non è assicurato, si vedrà con la preseason se qualcuno di questi difensori riuscirà a emergere."
       }
     },
     {
@@ -8229,7 +9635,14 @@
         "f": 0
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 0,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 0
       },
       "performance": {
         "2025_26": {
@@ -8241,12 +9654,54 @@
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 110,
+          "rating": 5.83
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Scelte rischiose per la difesa, ci sono molte riserve e giocatori che non dovrebbero avere molto spazio."
+      }
+    },
+    {
+      "nome": "PALMA",
+      "team": "UDI",
+      "prezzi": {
+        "min": 0,
+        "max": 2,
+        "avg": 1.0
+      },
+      "stats": {
+        "t": 1,
+        "a": 3,
+        "i": 5,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 2,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 2
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 2045,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Matteo Palma è un giovanissimo talento dell'Udinese, è un difensore centrale (nato in Germania) che può fare il braccetto destro in una difesa a tre. È del 2008 e probabilmente è ancora acerbo per il fantacalcio, però in preseason ha fatto bene segnando anche un gol quindi andrà tenuto d'occhio come scommessa. Vedremo se potrà avere spazio già quest'anno, consigliato specialmente per chi ha le conferme."
       }
     },
     {
@@ -8254,8 +9709,8 @@
       "team": "FIO",
       "prezzi": {
         "min": 0,
-        "max": 0,
-        "avg": 0.0
+        "max": 1,
+        "avg": 0.5
       },
       "stats": {
         "t": 2,
@@ -8264,7 +9719,14 @@
         "f": 5.5
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
       },
       "performance": {
         "2025_26": {
@@ -8274,14 +9736,14 @@
           "rating": 5.5
         },
         "2024_25": {
-          "goals": 0,
+          "goals": 2,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 1140,
+          "rating": 6.0
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Anche queste sono opzioni da leghe numerose, ma maggiormente jolly e senza il posto assicurato. In alcuni casi vi possono servire come copertura al titolare."
       }
     },
     {
@@ -8299,7 +9761,14 @@
         "f": 0
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 0,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 0
       },
       "performance": {
         "2025_26": {
@@ -8309,14 +9778,14 @@
           "rating": 0.0
         },
         "2024_25": {
-          "goals": 0,
+          "goals": 1,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 604,
+          "rating": 5.62
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Scelte rischiose per la difesa, ci sono molte riserve e giocatori che non dovrebbero avere molto spazio."
       }
     },
     {
@@ -8324,8 +9793,8 @@
       "team": "SAS",
       "prezzi": {
         "min": 0,
-        "max": 0,
-        "avg": 0.0
+        "max": 1,
+        "avg": 0.2
       },
       "stats": {
         "t": 3,
@@ -8334,7 +9803,14 @@
         "f": 0.0
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
       },
       "performance": {
         "2025_26": {
@@ -8346,12 +9822,12 @@
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 440,
+          "rating": 0.0
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Scendiamo ancora verso leghe più numerose, non sono titolari ma opzioni jolly anche dalle big in alcuni casi. Il posto non è assicurato, si vedrà con la preseason se qualcuno di questi difensori riuscirà a emergere."
       }
     },
     {
@@ -8359,8 +9835,8 @@
       "team": "TOR",
       "prezzi": {
         "min": 0,
-        "max": 0,
-        "avg": 0.0
+        "max": 2,
+        "avg": 0.5
       },
       "stats": {
         "t": 3,
@@ -8369,7 +9845,14 @@
         "f": 6.0
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 2,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 2
       },
       "performance": {
         "2025_26": {
@@ -8381,12 +9864,12 @@
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 1377,
+          "rating": 5.61
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Marcus Pedersen l’anno scorso ha deluso le aspettative: 0 bonus in 23 partite a voto. Ha trovato meno spazio del previsto, Vanoli gli preferiva spesso e volentieri Walukiewicz o anche altre soluzioni. In compenso ora con Baroni arretrerà il raggio d’azione Lazaro, che da terzino destro è favorito su Pedersen stesso. Per l’asta, potete trovare di meglio in termini di titolarità."
       }
     },
     {
@@ -8394,8 +9877,8 @@
       "team": "LAZ",
       "prezzi": {
         "min": 0,
-        "max": 0,
-        "avg": 0.0
+        "max": 1,
+        "avg": 0.2
       },
       "stats": {
         "t": 2,
@@ -8404,7 +9887,14 @@
         "f": 5.75
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
       },
       "performance": {
         "2025_26": {
@@ -8415,13 +9905,13 @@
         },
         "2024_25": {
           "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "assists": 3,
+          "minutes": 1074,
+          "rating": 6.08
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Scendiamo ancora verso leghe più numerose, non sono titolari ma opzioni jolly anche dalle big in alcuni casi. Il posto non è assicurato, si vedrà con la preseason se qualcuno di questi difensori riuscirà a emergere."
       }
     },
     {
@@ -8439,7 +9929,14 @@
         "f": 0
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 0,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 0
       },
       "performance": {
         "2025_26": {
@@ -8452,11 +9949,11 @@
           "goals": 0,
           "assists": 0,
           "minutes": 0,
-          "rating": 0
+          "rating": 0.0
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Potete evitare questi difensori, non sono giocatori su cui puntare al fantacalcio."
       }
     },
     {
@@ -8474,7 +9971,14 @@
         "f": 0
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 0,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 0
       },
       "performance": {
         "2025_26": {
@@ -8486,12 +9990,12 @@
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 1204,
+          "rating": 0.0
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Potete evitare questi difensori, non sono giocatori su cui puntare al fantacalcio."
       }
     },
     {
@@ -8499,8 +10003,8 @@
       "team": "FIO",
       "prezzi": {
         "min": 0,
-        "max": 0,
-        "avg": 0.0
+        "max": 1,
+        "avg": 0.5
       },
       "stats": {
         "t": 3,
@@ -8509,7 +10013,14 @@
         "f": 5.5
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
       },
       "performance": {
         "2025_26": {
@@ -8521,12 +10032,54 @@
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 1368,
+          "rating": 5.85
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Anche queste sono opzioni da leghe numerose, ma maggiormente jolly e senza il posto assicurato. In alcuni casi vi possono servire come copertura al titolare."
+      }
+    },
+    {
+      "nome": "PROVSTGAARD",
+      "team": "LAZ",
+      "prezzi": {
+        "min": 0,
+        "max": 3,
+        "avg": 1.5
+      },
+      "stats": {
+        "t": 2,
+        "a": 3,
+        "i": 4,
+        "f": 6.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 3,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 3
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 180,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 33,
+          "rating": 6.5
+        }
+      },
+      "notes": {
+        "comm": "Oliver Provstgaard è il nuovo che avanza in casa Lazio. Sarri lo sta studiando ed è tra le sorprese positive della preseason. È ancora presto per capire se potrà diventare titolare o no, ma intanto sta crescendo. È un difensore centrale danese classe 2003, è alto 194 cm e ha grande fisicità. È mancino e quindi insidia Romagnoli da quella parte. L’anno scorso con Baroni si è ambientato ma non ha avuto spazio."
       }
     },
     {
@@ -8534,8 +10087,8 @@
       "team": "CAG",
       "prezzi": {
         "min": 0,
-        "max": 0,
-        "avg": 0.0
+        "max": 1,
+        "avg": 0.2
       },
       "stats": {
         "t": 1,
@@ -8544,7 +10097,14 @@
         "f": null
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
       },
       "performance": {
         "2025_26": {
@@ -8556,12 +10116,12 @@
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 979,
+          "rating": 0.0
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Juan Rodriguez è un difensore del Cagliari. Si tratta di un giovane uruguaiano di 20 anni, arriva come acquisto in prospettiva. Ancora acerbo per il fantacalcio."
       }
     },
     {
@@ -8569,8 +10129,8 @@
       "team": "SAS",
       "prezzi": {
         "min": 0,
-        "max": 0,
-        "avg": 0.0
+        "max": 1,
+        "avg": 0.2
       },
       "stats": {
         "t": 2,
@@ -8579,7 +10139,14 @@
         "f": 5.0
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
       },
       "performance": {
         "2025_26": {
@@ -8591,12 +10158,12 @@
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 1870,
+          "rating": 5.0
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Da qui potete pescare qualche titolare o voto sicuro, ma solo per leghe numerose. Non c’è la garanzia di voti alti o da modificatore, siamo in provincia."
       }
     },
     {
@@ -8614,7 +10181,14 @@
         "f": 0
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 0,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 0
       },
       "performance": {
         "2025_26": {
@@ -8626,12 +10200,12 @@
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 208,
+          "rating": 5.62
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Scelte rischiose per la difesa, ci sono molte riserve e giocatori che non dovrebbero avere molto spazio."
       }
     },
     {
@@ -8639,8 +10213,8 @@
       "team": "JUV",
       "prezzi": {
         "min": 0,
-        "max": 0,
-        "avg": 0.0
+        "max": 1,
+        "avg": 0.2
       },
       "stats": {
         "t": 2,
@@ -8649,7 +10223,14 @@
         "f": 0.0
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
       },
       "performance": {
         "2025_26": {
@@ -8662,11 +10243,11 @@
           "goals": 0,
           "assists": 0,
           "minutes": 0,
-          "rating": 0
+          "rating": 0.0
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Scendiamo ancora verso leghe più numerose, non sono titolari ma opzioni jolly anche dalle big in alcuni casi. Il posto non è assicurato, si vedrà con la preseason se qualcuno di questi difensori riuscirà a emergere."
       }
     },
     {
@@ -8674,8 +10255,8 @@
       "team": "UDI",
       "prezzi": {
         "min": 0,
-        "max": 0,
-        "avg": 0.0
+        "max": 1,
+        "avg": 0.2
       },
       "stats": {
         "t": 2,
@@ -8684,7 +10265,14 @@
         "f": 0.0
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
       },
       "performance": {
         "2025_26": {
@@ -8695,48 +10283,13 @@
         },
         "2024_25": {
           "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "assists": 1,
+          "minutes": 612,
+          "rating": 5.96
         }
       },
       "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "SABELLI",
-      "team": "GEN",
-      "prezzi": {
-        "min": 0,
-        "max": 0,
-        "avg": 0.0
-      },
-      "stats": {
-        "t": 3,
-        "a": 3,
-        "i": 5,
-        "f": 0.0
-      },
-      "allPrices": {
-        "profeta_2025": 0
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0.0
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
+        "comm": "Scendiamo ancora verso leghe più numerose, non sono titolari ma opzioni jolly anche dalle big in alcuni casi. Il posto non è assicurato, si vedrà con la preseason se qualcuno di questi difensori riuscirà a emergere."
       }
     },
     {
@@ -8744,8 +10297,8 @@
       "team": "TOR",
       "prezzi": {
         "min": 0,
-        "max": 0,
-        "avg": 0.0
+        "max": 1,
+        "avg": 0.2
       },
       "stats": {
         "t": 1,
@@ -8754,7 +10307,14 @@
         "f": 0.0
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
       },
       "performance": {
         "2025_26": {
@@ -8767,11 +10327,11 @@
           "goals": 0,
           "assists": 0,
           "minutes": 0,
-          "rating": 0
+          "rating": 0.0
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Scendiamo ancora verso leghe più numerose, non sono titolari ma opzioni jolly anche dalle big in alcuni casi. Il posto non è assicurato, si vedrà con la preseason se qualcuno di questi difensori riuscirà a emergere."
       }
     },
     {
@@ -8789,7 +10349,14 @@
         "f": 0
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 0,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 0
       },
       "performance": {
         "2025_26": {
@@ -8801,12 +10368,12 @@
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 1746,
+          "rating": 0.0
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Scelte rischiose per la difesa, ci sono molte riserve e giocatori che non dovrebbero avere molto spazio."
       }
     },
     {
@@ -8814,8 +10381,8 @@
       "team": "LEC",
       "prezzi": {
         "min": 0,
-        "max": 0,
-        "avg": 0.0
+        "max": 1,
+        "avg": 0.2
       },
       "stats": {
         "t": 1,
@@ -8824,7 +10391,14 @@
         "f": 0.0
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
       },
       "performance": {
         "2025_26": {
@@ -8836,12 +10410,12 @@
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 1763,
+          "rating": 0.0
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Samil Siebert arriva dal Lecce per fare il titolare in difesa, proverà a prendersi una maglia al fianco di Gaspar. Alto 193 cm, ha fatto bene con l’Under 21 tedesca e arriva dal Fortuna Dusseldorf, con cui ha fatto 24 partite l’anno scorso. Opzione solo da ultimi slot in leghe numerose."
       }
     },
     {
@@ -8859,7 +10433,14 @@
         "f": 0
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 0,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 0
       },
       "performance": {
         "2025_26": {
@@ -8872,11 +10453,11 @@
           "goals": 0,
           "assists": 0,
           "minutes": 0,
-          "rating": 0
+          "rating": 0.0
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Potete evitare questi difensori, non sono giocatori su cui puntare al fantacalcio."
       }
     },
     {
@@ -8894,7 +10475,14 @@
         "f": 0
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 0,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 0
       },
       "performance": {
         "2025_26": {
@@ -8906,82 +10494,12 @@
         "2024_25": {
           "goals": 0,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 635,
+          "rating": 5.81
         }
       },
       "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "TERRACCIANO F.",
-      "team": "CRE",
-      "prezzi": {
-        "min": 0,
-        "max": 0,
-        "avg": 0.0
-      },
-      "stats": {
-        "t": 3,
-        "a": 3,
-        "i": 5,
-        "f": 7.75
-      },
-      "allPrices": {
-        "profeta_2025": 0
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 1,
-          "assists": 0,
-          "minutes": 180,
-          "rating": 6.5
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "TROILO",
-      "team": "PAR",
-      "prezzi": {
-        "min": 0,
-        "max": 0,
-        "avg": 0.0
-      },
-      "stats": {
-        "t": 3,
-        "a": 3,
-        "i": 5,
-        "f": 0.0
-      },
-      "allPrices": {
-        "profeta_2025": 0
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0.0
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
+        "comm": "Scelte rischiose per la difesa, ci sono molte riserve e giocatori che non dovrebbero avere molto spazio."
       }
     },
     {
@@ -8989,8 +10507,8 @@
       "team": "ROM",
       "prezzi": {
         "min": 0,
-        "max": 0,
-        "avg": 0.0
+        "max": 4,
+        "avg": 1.5
       },
       "stats": {
         "t": 2,
@@ -8999,7 +10517,14 @@
         "f": 0.0
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 4,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 2,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 4,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 2
       },
       "performance": {
         "2025_26": {
@@ -9010,118 +10535,55 @@
         },
         "2024_25": {
           "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "VALENTI",
-      "team": "PAR",
-      "prezzi": {
-        "min": 0,
-        "max": 0,
-        "avg": 0.0
-      },
-      "stats": {
-        "t": 3,
-        "a": 3,
-        "i": 2,
-        "f": 5.5
-      },
-      "allPrices": {
-        "profeta_2025": 0
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 180,
-          "rating": 5.75
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "VALENTINI N.",
-      "team": "VER",
-      "prezzi": {
-        "min": 0,
-        "max": 0,
-        "avg": 0.0
-      },
-      "stats": {
-        "t": 3,
-        "a": 3,
-        "i": 2,
-        "f": 0.0
-      },
-      "allPrices": {
-        "profeta_2025": 0
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
+          "assists": 1,
+          "minutes": 849,
           "rating": 0.0
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Konstantinos Tsimikas è il nuovo rinforzo della Roma per la fascia sinistra, arrivato in prestito dal Liverpool. Classe 1996, porterà esperienza e affidabilità come vice di Angelino, che resta però il titolare nelle gerarchie di Gasperini. Con i Reds ha collezionato oltre 100 presenze senza mai segnare, ma con ben 18 assist: un giocatore che può portare qualche bonus e soprattutto +1. Al fantacalcio si può prendere a basso costo come vice di Angelino in lega abbastanza numerosa oppure da solo come jolly da ultimi slot. Sul piano fisico, negli ultimi anni ha avuto qualche problema traumatico, ma non è particolarmente soggetto a infortuni muscolari."
       }
     },
     {
-      "nome": "VEIGA D.",
-      "team": "LEC",
+      "nome": "VAN DER BREMPT",
+      "team": "COM",
       "prezzi": {
         "min": 0,
-        "max": 0,
-        "avg": 0.0
+        "max": 2,
+        "avg": 0.8
       },
       "stats": {
         "t": 3,
         "a": 3,
-        "i": 5,
-        "f": 5.25
+        "i": 2,
+        "f": 5.75
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 1
       },
       "performance": {
         "2025_26": {
           "goals": 0,
           "assists": 0,
-          "minutes": 158,
-          "rating": 5.5
+          "minutes": 97,
+          "rating": 6.0
         },
         "2024_25": {
           "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "assists": 1,
+          "minutes": 1264,
+          "rating": 5.94
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Ignace Van Der Brempt è un bel jolly difensivo per il Como. Fabregas lo prova anche da difensore centrale, pur nascendo come terzino destro. In questa stagione potrà giocare nel doppio ruolo, non ha però il posto assicurato. L’anno scorso è andato a voto 18 volte e ha avuto qualche stop di troppo."
       }
     },
     {
@@ -9129,8 +10591,8 @@
       "team": "FIO",
       "prezzi": {
         "min": 0,
-        "max": 0,
-        "avg": 0.0
+        "max": 1,
+        "avg": 0.5
       },
       "stats": {
         "t": 3,
@@ -9139,7 +10601,14 @@
         "f": 6.0
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
       },
       "performance": {
         "2025_26": {
@@ -9149,84 +10618,14 @@
           "rating": 6.0
         },
         "2024_25": {
-          "goals": 0,
+          "goals": 1,
           "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "minutes": 2576,
+          "rating": 6.02
         }
       },
       "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "WALUKIEWICZ",
-      "team": "SAS",
-      "prezzi": {
-        "min": 0,
-        "max": 0,
-        "avg": 0.0
-      },
-      "stats": {
-        "t": 3,
-        "a": 2,
-        "i": 4,
-        "f": 5.5
-      },
-      "allPrices": {
-        "profeta_2025": 0
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 180,
-          "rating": 5.5
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
-      }
-    },
-    {
-      "nome": "ZEMURA",
-      "team": "UDI",
-      "prezzi": {
-        "min": 0,
-        "max": 0,
-        "avg": 0.0
-      },
-      "stats": {
-        "t": 3,
-        "a": 3,
-        "i": 3,
-        "f": 5.75
-      },
-      "allPrices": {
-        "profeta_2025": 0
-      },
-      "performance": {
-        "2025_26": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 169,
-          "rating": 5.75
-        },
-        "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
-        }
-      },
-      "notes": {
-        "comm": ""
+        "comm": "Mattia Viti arriva alla Fiorentina con poche aspettative in chiave fantacalcio, all’Empoli era solo un low cost. Ora perde titolarità e avrà ballottaggi, potrebbe fare il vice Ranieri ma giocare anche da centrale. Nell’ultima stagione 1 gol in 30 partite, da difensore una discreta fanta-media del 6,07. Centrale attento e pulito, non porta tanti cartellini (3 gialli e 0 rossi). Non sarà titolare fisso alla Fiorentina, ma si giocherà il posto. In campionato potrà andare a voto almeno in 20-25 partite, garantendo magari anche un 6,2 di fanta-media, leggermente più alta dell’anno scorso."
       }
     },
     {
@@ -9234,8 +10633,8 @@
       "team": "ROM",
       "prezzi": {
         "min": 0,
-        "max": 0,
-        "avg": 0.0
+        "max": 1,
+        "avg": 0.2
       },
       "stats": {
         "t": 2,
@@ -9244,7 +10643,14 @@
         "f": 0.0
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
       },
       "performance": {
         "2025_26": {
@@ -9254,14 +10660,14 @@
           "rating": 0.0
         },
         "2024_25": {
-          "goals": 0,
-          "assists": 0,
-          "minutes": 0,
-          "rating": 0
+          "goals": 1,
+          "assists": 2,
+          "minutes": 1373,
+          "rating": 0.0
         }
       },
       "notes": {
-        "comm": ""
+        "comm": "Jan Ziolkowski è una giovane scommessa della Roma per la difesa. Si tratta di un centrale di prospettiva, classe 2005. Polacco, è alto 194 cm ed è bravo nel gioco aereo, ma anche negli interventi in tackle. Al Legia Varsavia ha giocato 19 partite con 1 gol nello scorso campionato. È molto giovane quindi non sarà titolare, al fantacalcio è una scelta più da leghe numerose e specialmente per chi ha le conferme, perché promette molto bene. E poi Gasperini sa lanciare i giovani."
       }
     },
     {
@@ -9269,8 +10675,8 @@
       "team": "CAG",
       "prezzi": {
         "min": 0,
-        "max": 0,
-        "avg": 0.0
+        "max": 1,
+        "avg": 0.2
       },
       "stats": {
         "t": 1,
@@ -9279,7 +10685,5308 @@
         "f": null
       },
       "allPrices": {
-        "profeta_2025": 0
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 1494,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Ze Pedro è un nuovo difensore del Cagliari. Di piede destro, è stato preso per fare il braccetto in una difesa a tre oppure il centrale di destra in una difesa a quattro. Con una linea a quattro parte dietro alla coppia Mina-Luperto, mentre a tre può prendersi una maglia da titolare. Alto 187 cm, portoghese, arriva dal Porto dove ha fatto 20 presenze l’anno scorso. Opzione solo da leghe numerose al fantacalcio."
+      }
+    }
+  ],
+  "C": [
+    {
+      "nome": "ORSOLINI",
+      "team": "BOL",
+      "prezzi": {
+        "min": 72,
+        "max": 78,
+        "avg": 75.0
+      },
+      "stats": {
+        "t": 5,
+        "a": 5,
+        "i": 2,
+        "f": 8.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 75,
+        "fantaclassic_2025": 72,
+        "profeta_2025": 75,
+        "sos_fanta_2025": 78,
+        "fantaboom_2024": 75,
+        "fantaclassic_2024": 72,
+        "profeta_2024": 75,
+        "sos_fanta_2024": 78
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 1,
+          "assists": 0,
+          "minutes": 180,
+          "rating": 6.5
+        },
+        "2024_25": {
+          "goals": 15,
+          "assists": 4,
+          "minutes": 1885,
+          "rating": 6.53
+        }
+      },
+      "notes": {
+        "comm": "Riccardo Orsolini è una leggenda vivente del fantacalcio. Stiamo parlando di un centrocampista che arriva da tre stagioni in doppia cifra, nell’ultima ha fatto esattamente un gol ogni due partite. Numeri tondi: 30 partite, 15 gol, 5 assist. Segna come un attaccante e ha dalla sua rigori, punizioni e corner. Per i rigori avrà la concorrenza di Immobile, che potrebbe anche diventare la prima scelta ma parte comunque infortunato per i primi due mesi. Ma Orsolini, che ama accentrarsi col suo mancino, può segnare in tanti modi e avrà anche lo stimolo della Nazionale. A secco all'esordio a Roma, si è subito sbloccato alla seconda contro il Como con un gol."
+      }
+    },
+    {
+      "nome": "PULISIC",
+      "team": "MIL",
+      "prezzi": {
+        "min": 70,
+        "max": 73,
+        "avg": 71.0
+      },
+      "stats": {
+        "t": 5,
+        "a": 5,
+        "i": 2,
+        "f": 8.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 73,
+        "fantaclassic_2025": 70,
+        "profeta_2025": 70,
+        "sos_fanta_2025": 71,
+        "fantaboom_2024": 73,
+        "fantaclassic_2024": 70,
+        "profeta_2024": 70,
+        "sos_fanta_2024": 71
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 1,
+          "assists": 0,
+          "minutes": 103,
+          "rating": 6.5
+        },
+        "2024_25": {
+          "goals": 11,
+          "assists": 8,
+          "minutes": 2489,
+          "rating": 6.38
+        }
+      },
+      "notes": {
+        "comm": "Christian Pulisic è uno dei migliori centrocampisti al fantacalcio degli ultimi anni. L’americano ha fatto due stagioni praticamente uguali in termini realizzativi, da 12 e 11 gol in campionato. In più può fare tranquillamente 8-9 assist a stagione. Si temevano gli infortuni, che ci sono stati però solo in piccola parte: 36 e 34 partite su 38 in due anni. Al fantacalcio resta un top di ruolo anche con Allegri, che lo vede ancora come titolare, anche più accentrato e vicino alla porta dunque in alcune circostanze. A secco all'esordio, ha segnato alla seconda di campionato a Lecce, partendo dalla panchina. "
+      }
+    },
+    {
+      "nome": "ZACCAGNI",
+      "team": "LAZ",
+      "prezzi": {
+        "min": 60,
+        "max": 70,
+        "avg": 66.0
+      },
+      "stats": {
+        "t": 5,
+        "a": 4,
+        "i": 3,
+        "f": 7.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 70,
+        "fantaclassic_2025": 66,
+        "profeta_2025": 60,
+        "sos_fanta_2025": 68,
+        "fantaboom_2024": 70,
+        "fantaclassic_2024": 66,
+        "profeta_2024": 60,
+        "sos_fanta_2024": 68
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 1,
+          "assists": 0,
+          "minutes": 156,
+          "rating": 6.25
+        },
+        "2024_25": {
+          "goals": 8,
+          "assists": 6,
+          "minutes": 2705,
+          "rating": 6.28
+        }
+      },
+      "notes": {
+        "comm": "\n3 di 4\nCENTROCAMPISTI\n✅ CENTROCAMPISTI\n\n➡️ Qui tutti i tiratori di punizioni e corner\n\nTOP - McTominay, Orsolini, Paz, Pulisic, Zaccagni, De Bruyne, Gudmundsson\n\nScott McTominay ha avuto un impatto devastante col Napoli e il fantacalcio: 12 gol e 3 assist in 34 partite a voto, è salito in cattedra soprattutto nel finale di stagione grazie ai suoi inserimenti. Riparte da questi numeri, fare meglio non sarà facile, anche solo raggiungere ancora quota 15 tra gol e a assist sarebbe un risultato enorme. È arrivato De Bruyne, ma Conte lavora per far coesistere i due. È un top assoluto a centrocampo e viene da una super stagione: sarà tra i più pagati del reparto ed è ripartito subito con un gol all'esordio in campionato contro il Sassuolo.\n\nRiccardo Orsolini è una leggenda vivente del fantacalcio. Stiamo parlando di un centrocampista che arriva da tre stagioni in doppia cifra, nell’ultima ha fatto esattamente un gol ogni due partite. Numeri tondi: 30 partite, 15 gol, 5 assist. Segna come un attaccante e ha dalla sua rigori, punizioni e corner. Per i rigori avrà la concorrenza di Immobile, che potrebbe anche diventare la prima scelta ma parte comunque infortunato per i primi due mesi. Ma Orsolini, che ama accentrarsi col suo mancino, può segnare in tanti modi e avrà anche lo stimolo della Nazionale. A secco all'esordio a Roma, si è subito sbloccato alla seconda contro il Como con un gol.\n\nNico Paz si merita grandi palcoscenici, anche al fantacalcio. L’argentino entra di diritto tra i top di reparto dopo l’ultima stagione, in cui ha portato sia gol che assist. Ma non solo, perché è stato anche titolare fisso e ha regalato ottimi voti. Tutte caratteristiche che avrà anche quest’anno e che lo rendono uno dei centrocampisti migliori sulla carta. Occhio anche ai rigori, che sta iniziando a calciare con più continuità. All'esordio è partito subito con un gol da cineteca su punizione e con un assist al bacio.\n\nChristian Pulisic è uno dei migliori centrocampisti al fantacalcio degli ultimi anni. L’americano ha fatto due stagioni praticamente uguali in termini realizzativi, da 12 e 11 gol in campionato. In più può fare tranquillamente 8-9 assist a stagione. Si temevano gli infortuni, che ci sono stati però solo in piccola parte: 36 e 34 partite su 38 in due anni. Al fantacalcio resta un top di ruolo anche con Allegri, che lo vede ancora come titolare, anche più accentrato e vicino alla porta dunque in alcune circostanze. A secco all'esordio, ha segnato alla seconda di campionato a Lecce, partendo dalla panchina.\n\nMattia Zaccagni alla fine porta sempre bonus, ma possono non essere sufficienti se la spesa all’asta è troppo alta. I fantallenatori gli chiedono di più rispetto ai 6 gol di due anni fa e agli 8 dell’anno scorso. Nella memoria restano ancora i 10 da supertop del 2022-23. C’è anche un grande difetto da limare: sono troppi 10 cartellini gialli per un esterno d’attacco. Quest’anno non parte con un hype eccessivo e allora puntare su di lui può diventare una mossa intelligente, considerando che avrà una sola partita a settimana e che tira i piazzati (tra cui i rigori). Già col Verona alla seconda è subito riuscito a sbloccarsi su azione."
+      }
+    },
+    {
+      "nome": "PAZ N.",
+      "team": "COM",
+      "prezzi": {
+        "min": 65,
+        "max": 77,
+        "avg": 70.0
+      },
+      "stats": {
+        "t": 5,
+        "a": 5,
+        "i": 4,
+        "f": 8.75
+      },
+      "allPrices": {
+        "fantaboom_2025": 68,
+        "fantaclassic_2025": 65,
+        "profeta_2025": 70,
+        "sos_fanta_2025": 77,
+        "fantaboom_2024": 68,
+        "fantaclassic_2024": 65,
+        "profeta_2024": 70,
+        "sos_fanta_2024": 77
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 1,
+          "assists": 1,
+          "minutes": 169,
+          "rating": 7.0
+        },
+        "2024_25": {
+          "goals": 6,
+          "assists": 7,
+          "minutes": 2699,
+          "rating": 6.38
+        }
+      },
+      "notes": {
+        "comm": "Nico Paz si merita grandi palcoscenici, anche al fantacalcio. L’argentino entra di diritto tra i top di reparto dopo l’ultima stagione, in cui ha portato sia gol che assist. Ma non solo, perché è stato anche titolare fisso e ha regalato ottimi voti. Tutte caratteristiche che avrà anche quest’anno e che lo rendono uno dei centrocampisti migliori sulla carta. Occhio anche ai rigori, che sta iniziando a calciare con più continuità. All'esordio è partito subito con un gol da cineteca su punizione e con un assist al bacio."
+      }
+    },
+    {
+      "nome": "MCTOMINAY",
+      "team": "NAP",
+      "prezzi": {
+        "min": 66,
+        "max": 80,
+        "avg": 71.0
+      },
+      "stats": {
+        "t": 5,
+        "a": 5,
+        "i": 5,
+        "f": 8.25
+      },
+      "allPrices": {
+        "fantaboom_2025": 66,
+        "fantaclassic_2025": 68,
+        "profeta_2025": 70,
+        "sos_fanta_2025": 80,
+        "fantaboom_2024": 66,
+        "fantaclassic_2024": 68,
+        "profeta_2024": 70,
+        "sos_fanta_2024": 80
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 1,
+          "assists": 0,
+          "minutes": 179,
+          "rating": 6.75
+        },
+        "2024_25": {
+          "goals": 12,
+          "assists": 3,
+          "minutes": 2941,
+          "rating": 6.56
+        }
+      },
+      "notes": {
+        "comm": "Scott McTominay ha avuto un impatto devastante col Napoli e il fantacalcio: 12 gol e 3 assist in 34 partite a voto, è salito in cattedra soprattutto nel finale di stagione grazie ai suoi inserimenti. Riparte da questi numeri, fare meglio non sarà facile, anche solo raggiungere ancora quota 15 tra gol e a assist sarebbe un risultato enorme. È arrivato De Bruyne, ma Conte lavora per far coesistere i due. È un top assoluto a centrocampo e viene da una super stagione: sarà tra i più pagati del reparto ed è ripartito subito con un gol all'esordio in campionato contro il Sassuolo."
+      }
+    },
+    {
+      "nome": "GUDMUNDSSON A.",
+      "team": "FIO",
+      "prezzi": {
+        "min": 50,
+        "max": 63,
+        "avg": 56.5
+      },
+      "stats": {
+        "t": 4,
+        "a": 4,
+        "i": 3,
+        "f": 6.25
+      },
+      "allPrices": {
+        "fantaboom_2025": 63,
+        "fantaclassic_2025": 55,
+        "profeta_2025": 50,
+        "sos_fanta_2025": 58,
+        "fantaboom_2024": 63,
+        "fantaclassic_2024": 55,
+        "profeta_2024": 50,
+        "sos_fanta_2024": 58
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 1,
+          "minutes": 155,
+          "rating": 5.75
+        },
+        "2024_25": {
+          "goals": 6,
+          "assists": 1,
+          "minutes": 1285,
+          "rating": 6.12
+        }
+      },
+      "notes": {
+        "comm": "Albert Gudmundsson è una delle grandi novità di questo fantacalcio. L’islandese torna a essere centrocampista, ruolo in cui era stato dominante al Genoa due anni fa. L’anno scorso invece ha deluso, da attaccante ha fatto solo 6 gol. In una stagione negativa con anche diversi infortuni e solo 21 partite avrebbe comunque fatto più gol di quasi tutti i centrocampisti, solo in 8 meglio di lui (e due sono andati via). A centrocampo torna top anche perché è il rigorista della Fiorentina, insieme a Kean. Pioli lo può schierare sia in coppia con Moise che in un tridente con Dzeko, sarà quasi sempre titolare se gli infortuni (punto debole) quest’anno gli daranno tregua."
+      }
+    },
+    {
+      "nome": "DE BRUYNE",
+      "team": "NAP",
+      "prezzi": {
+        "min": 59,
+        "max": 65,
+        "avg": 61.8
+      },
+      "stats": {
+        "t": 4,
+        "a": 5,
+        "i": 3,
+        "f": 7.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 60,
+        "fantaclassic_2025": 59,
+        "profeta_2025": 65,
+        "sos_fanta_2025": 63,
+        "fantaboom_2024": 60,
+        "fantaclassic_2024": 59,
+        "profeta_2024": 65,
+        "sos_fanta_2024": 63
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 1,
+          "assists": 0,
+          "minutes": 171,
+          "rating": 6.25
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 0,
+          "minutes": 1715,
+          "rating": 7.0
+        }
+      },
+      "notes": {
+        "comm": "Kevin De Bruyne è stato il grande colpo del mercato del Napoli. Classe 1991, può vantare un palmares importante specialmente al Manchester City e una carriera internazionale di altissimo livello, nazionale belga inclusa. Al Napoli può fare sia la mezzala offensiva che il trequartista puro, dipende dal modulo scelto da Conte. Qualche infortunio negli ultimi anni ma nella scorsa stagione ha avuto buona continuità, saltando 12 partite. Non uno specialista assoluto dal dischetto, ma un maestro sui calci di punizione. All’asta è un primissimo slot e sarà uno dei più pagati a centrocampo. È partito subito con un gol all'esordio, proprio su punizione dalla distanza."
+      }
+    },
+    {
+      "nome": "CALHANOGLU",
+      "team": "INT",
+      "prezzi": {
+        "min": 30,
+        "max": 50,
+        "avg": 39.5
+      },
+      "stats": {
+        "t": 4,
+        "a": 5,
+        "i": 2,
+        "f": 5.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 50,
+        "fantaclassic_2025": 42,
+        "profeta_2025": 30,
+        "sos_fanta_2025": 36,
+        "fantaboom_2024": 50,
+        "fantaclassic_2024": 42,
+        "profeta_2024": 30,
+        "sos_fanta_2024": 36
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 68,
+          "rating": 5.0
+        },
+        "2024_25": {
+          "goals": 5,
+          "assists": 6,
+          "minutes": 1961,
+          "rating": 6.34
+        }
+      },
+      "notes": {
+        "comm": "Hakan Calhanoglu è rimasto all’Inter dopo una lunga telenovela. Uno degli aspetti principali è che rimarrà il rigorista dell’Inter. I rigori sono una variabile importantissima ma anche imprevedibile al fantacalcio. Si può così passare da 13 gol a 5, molto meno della metà. E i tre assist in più, il doppio, non riescono a compensare. L’ultima stagione fa calare il suo prezzo rispetto all’asta di un anno fa, ma resta comunque un big del reparto di centrocampo proprio per via dello status di rigorista."
+      }
+    },
+    {
+      "nome": "CONCEICAO",
+      "team": "JUV",
+      "prezzi": {
+        "min": 30,
+        "max": 43,
+        "avg": 34.5
+      },
+      "stats": {
+        "t": 4,
+        "a": 5,
+        "i": 3,
+        "f": 6.25
+      },
+      "allPrices": {
+        "fantaboom_2025": 43,
+        "fantaclassic_2025": 30,
+        "profeta_2025": 30,
+        "sos_fanta_2025": 35,
+        "fantaboom_2024": 43,
+        "fantaclassic_2024": 30,
+        "profeta_2024": 30,
+        "sos_fanta_2024": 35
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 163,
+          "rating": 6.25
+        },
+        "2024_25": {
+          "goals": 3,
+          "assists": 3,
+          "minutes": 1342,
+          "rating": 6.12
+        }
+      },
+      "notes": {
+        "comm": "Francisco Conceicao è tornato alla Juve per provare a esplodere. Nella prima stagione bianconera ci è riuscito solo in parte, non trovando piena continuità. A qualche lampo ha alternato panchine e pause. I segnali arrivati dal Mondiale per Club sono stati positivi e forse anche per questo la società ha deciso di acquistarlo da titolo definito, in accordo con Tudor. Ora starà a Conceicao fare meglio, portando anche più bonus al fantacalcio: può fare più gol e più assist della scorsa stagione, rimanendo comunque un jolly sia come status che come ruolo. E dal mercato è arrivato Zhegrova, che inizialmente parte dietro ma proverà a insidiarlo nel corso della stagione."
+      }
+    },
+    {
+      "nome": "ODGAARD",
+      "team": "BOL",
+      "prezzi": {
+        "min": 21,
+        "max": 38,
+        "avg": 29.8
+      },
+      "stats": {
+        "t": 4,
+        "a": 4,
+        "i": 3,
+        "f": 5.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 38,
+        "fantaclassic_2025": 30,
+        "profeta_2025": 30,
+        "sos_fanta_2025": 21,
+        "fantaboom_2024": 38,
+        "fantaclassic_2024": 30,
+        "profeta_2024": 30,
+        "sos_fanta_2024": 21
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 97,
+          "rating": 5.5
+        },
+        "2024_25": {
+          "goals": 6,
+          "assists": 2,
+          "minutes": 1975,
+          "rating": 6.14
+        }
+      },
+      "notes": {
+        "comm": "Jens Odgaard è una delle buone notizie dal listone al fantacalcio, perché per la prima volta è diventato un centrocampista. Un cambiamento non da poco, ora è completamente diversa la percezione su di lui. L’anno scorso solo otto centrocampisti avrebbero segnato più di lui, che ha fatto 6 gol. È vero che nel Bologna ci sono sempre concorrenza e rotazioni, però il danese è un giocatore cardine per il gioco di Italiano. E da centrocampista, per i numeri che ha avuto (anche 2 assist) merita di essere tra i big."
+      }
+    },
+    {
+      "nome": "BARELLA",
+      "team": "INT",
+      "prezzi": {
+        "min": 25,
+        "max": 35,
+        "avg": 28.8
+      },
+      "stats": {
+        "t": 5,
+        "a": 5,
+        "i": 4,
+        "f": 6.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 35,
+        "fantaclassic_2025": 28,
+        "profeta_2025": 25,
+        "sos_fanta_2025": 27,
+        "fantaboom_2024": 35,
+        "fantaclassic_2024": 28,
+        "profeta_2024": 25,
+        "sos_fanta_2024": 27
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 1,
+          "minutes": 173,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 3,
+          "assists": 6,
+          "minutes": 2462,
+          "rating": 6.26
+        }
+      },
+      "notes": {
+        "comm": "Nicolò Barella resta il punto fermo del centrocampo dell’Inter e un riferimento anche al fantacalcio. Negli ultimi anni il suo apporto in zona bonus è calato, ma rimane sempre un centrocampista molto pagato all’asta, non gli mancano qualità e continuità. Con Chivu in panchina proverà tornare a incidere di più anche a livello offensivo, è questa la sfida e solo così può valere i fantamilioni spesi. Sia mezzala che anche regista, il nuovo allenatore lo sta provando in tutti i ruoli in mediana ed è un'alternativa importante anche a Calhanoglu sui piazzati (in particolare sui corner)."
+      }
+    },
+    {
+      "nome": "RABIOT",
+      "team": "MIL",
+      "prezzi": {
+        "min": 25,
+        "max": 35,
+        "avg": 30.2
+      },
+      "stats": {
+        "t": 4,
+        "a": 4,
+        "i": 3,
+        "f": null
+      },
+      "allPrices": {
+        "fantaboom_2025": 35,
+        "fantaclassic_2025": 26,
+        "profeta_2025": 25,
+        "sos_fanta_2025": 35,
+        "fantaboom_2024": 35,
+        "fantaclassic_2024": 26,
+        "profeta_2024": 25,
+        "sos_fanta_2024": 35
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 9,
+          "assists": 4,
+          "minutes": 2483,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Adrien Rabiot torna in Serie A, questa volta al Milan di Allegri dopo una stagione super dal punto di vista realizzativo al Marsiglia di De Zerbi: 32 presenze, 10 gol tra tutte le competizioni e 6 assist. Numeri che lo proiettano tra i centrocampisti migliori al fantacalcio, considerando che già in Italia aveva mostrato qualità importanti in zona gol (8 reti e 4 assist nel 22/23 con la Juve). Nel 3-5-2 avrà il ruolo di mezzala, con compiti chiari di riempire l’area e cercare il bonus. È un centrocampista affidabile e che conosce già bene la Serie A, pronto a essere titolare fisso nello scacchiere di Allegri. Da segnalare però la tendenza ai cartellini gialli: 8 e 9 ammonizioni nelle ultime due stagioni in Italia. Al fantacalcio va considerato come un semitop, come prezzo è inferiore ai top ma è comunque una scelta di livello assoluto. È da bonus e c’è da ricordare che non avrà l’Europa e quindi le giocherà tutte, è un pupillo dell’allenatore. Anche sul piano fisico offre buone garanzie, con zero partite saltate nell’ultima stagione."
+      }
+    },
+    {
+      "nome": "POLITANO",
+      "team": "NAP",
+      "prezzi": {
+        "min": 20,
+        "max": 32,
+        "avg": 27.0
+      },
+      "stats": {
+        "t": 4,
+        "a": 4,
+        "i": 3,
+        "f": 7.25
+      },
+      "allPrices": {
+        "fantaboom_2025": 32,
+        "fantaclassic_2025": 26,
+        "profeta_2025": 20,
+        "sos_fanta_2025": 30,
+        "fantaboom_2024": 32,
+        "fantaclassic_2024": 26,
+        "profeta_2024": 20,
+        "sos_fanta_2024": 30
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 1,
+          "minutes": 166,
+          "rating": 6.75
+        },
+        "2024_25": {
+          "goals": 3,
+          "assists": 4,
+          "minutes": 2828,
+          "rating": 6.11
+        }
+      },
+      "notes": {
+        "comm": "Matteo Politano è una costante, si rivela sempre utile al fantacalcio. Anche se nella scorsa stagione è stato più da rendimento che da bonus, si è sacrificato molto. Con Antonio Conte parte con fiducia, ha giocato sia da esterno offensivo che da quinto a tutta fascia. Anche quest’anno prenderà voto sempre, se non da titolare almeno a gara in corso. Resta un giocatore potenzialmente da bonus, vedremo se al secondo anno di Conte riuscirà a portarne di più. È partito subito con un assist all'esordio contro il Sassuolo."
+      }
+    },
+    {
+      "nome": "ISAKSEN",
+      "team": "LAZ",
+      "prezzi": {
+        "min": 20,
+        "max": 30,
+        "avg": 23.5
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 3,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 30,
+        "fantaclassic_2025": 23,
+        "profeta_2025": 20,
+        "sos_fanta_2025": 21,
+        "fantaboom_2024": 30,
+        "fantaclassic_2024": 23,
+        "profeta_2024": 20,
+        "sos_fanta_2024": 21
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 4,
+          "assists": 1,
+          "minutes": 2226,
+          "rating": 6.05
+        }
+      },
+      "notes": {
+        "comm": "Gustav Isaksen è una delle novità dal listone in questo fantacalcio. Dopo due anni da attaccante, è stato listato centrocampista. L’anno scorso era migliorato, ma non abbastanza per essere incisivo al fanta: da 3 gol è passato a 4. Come attaccante, troppo poco. Ma un bottino da almeno 5-6 gol diventerebbe buono per un centrocampista, quindi occhio. Anche Sarri ci punterà. Può andare a prezzi contenuti per l'inizio di stagione ai box causa mononucleosi, ma già a inizio settembre tornerà pienamente a disposizione."
+      }
+    },
+    {
+      "nome": "NERES",
+      "team": "NAP",
+      "prezzi": {
+        "min": 13,
+        "max": 29,
+        "avg": 18.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 2,
+        "f": 6.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 29,
+        "fantaclassic_2025": 18,
+        "profeta_2025": 15,
+        "sos_fanta_2025": 13,
+        "fantaboom_2024": 29,
+        "fantaclassic_2024": 18,
+        "profeta_2024": 15,
+        "sos_fanta_2024": 13
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 14,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 2,
+          "assists": 5,
+          "minutes": 1294,
+          "rating": 6.32
+        }
+      },
+      "notes": {
+        "comm": "David Neres ha chiuso la scorsa stagione con 2 gol e 5 assist in 25 partite a voto. Ci si aspettava di più al fantacalcio, non ha rispettato le attese (nemmeno dopo l’addio di Kvaratskhelia a gennaio). Col mercato è aumentata la concorrenza offensiva, è arrivato un giocatore importante come Lang. Però Neres non molla e si giocherà le sue carte su entrambe le fasce, a volte partirà dal 1’ e altre subentrerà, a seconda degli impegni e del momento. Si paga meno all’asta rispetto alla scorsa stagione, potete portarlo via a una cifra interessante. Ma dovete essere consapevoli che non giocherà sempre dall'inizio.\n\n"
+      }
+    },
+    {
+      "nome": "VLASIC",
+      "team": "TOR",
+      "prezzi": {
+        "min": 15,
+        "max": 28,
+        "avg": 20.8
+      },
+      "stats": {
+        "t": 4,
+        "a": 4,
+        "i": 3,
+        "f": 5.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 28,
+        "fantaclassic_2025": 20,
+        "profeta_2025": 20,
+        "sos_fanta_2025": 15,
+        "fantaboom_2024": 28,
+        "fantaclassic_2024": 20,
+        "profeta_2024": 20,
+        "sos_fanta_2024": 15
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 147,
+          "rating": 5.75
+        },
+        "2024_25": {
+          "goals": 5,
+          "assists": 3,
+          "minutes": 2128,
+          "rating": 6.07
+        }
+      },
+      "notes": {
+        "comm": "Nikola Vlasic è sempre in cerca della definitiva consacrazione al fantacalcio. Troppi alti e bassi (e anche infortuni), raramente riesce ad avere continuità per tutta la stagione. Alla fine la sua migliore annata resta la prima, con 5 gol e 6 assist. L’anno scorso ha comunque migliorato lo score del 2023-24, ma può fare ancora di più. Ci proverà con Baroni, che almeno sulla carta fa il modulo ideale per lui, ovvero il 4-2-3-1."
+      }
+    },
+    {
+      "nome": "TRAMONI M.",
+      "team": "PIS",
+      "prezzi": {
+        "min": 12,
+        "max": 27,
+        "avg": 20.8
+      },
+      "stats": {
+        "t": 5,
+        "a": 4,
+        "i": 3,
+        "f": 5.75
+      },
+      "allPrices": {
+        "fantaboom_2025": 27,
+        "fantaclassic_2025": 19,
+        "profeta_2025": 25,
+        "sos_fanta_2025": 12,
+        "fantaboom_2024": 27,
+        "fantaclassic_2024": 19,
+        "profeta_2024": 25,
+        "sos_fanta_2024": 12
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 125,
+          "rating": 5.75
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 1923,
+          "rating": 6.0
+        }
+      },
+      "notes": {
+        "comm": "Matteo Tramoni è il giocatore più interessante del Pisa. Ancora di più visto che è stato listato come centrocampista. Classe 2000 di Ajaccio, in Corsica, era stato portato in Italia dal Cagliari nel 2020. Dopo un’esperienza al Brescia è esploso in Serie B col Pisa segnando 13 gol e facendo 3 assist. Il punto debole sono gli infortuni: due anni fa la rottura del crociato, l’anno scorso solo 25 partite giocate. Di piede destro, nasce come ala sinistra e ora gioca nei due trequartisti alle spalle della punta. Specialista sui calci piazzati, è anche uno dei rigoristi, anche se non l’unico."
+      }
+    },
+    {
+      "nome": "THURAM K.",
+      "team": "JUV",
+      "prezzi": {
+        "min": 24,
+        "max": 28,
+        "avg": 25.5
+      },
+      "stats": {
+        "t": 5,
+        "a": 4,
+        "i": 3,
+        "f": 6.25
+      },
+      "allPrices": {
+        "fantaboom_2025": 24,
+        "fantaclassic_2025": 25,
+        "profeta_2025": 25,
+        "sos_fanta_2025": 28,
+        "fantaboom_2024": 24,
+        "fantaclassic_2024": 25,
+        "profeta_2024": 25,
+        "sos_fanta_2024": 28
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 180,
+          "rating": 6.25
+        },
+        "2024_25": {
+          "goals": 4,
+          "assists": 5,
+          "minutes": 2337,
+          "rating": 6.3
+        }
+      },
+      "notes": {
+        "comm": "Khephren Thuram è stato uno dei migliori nella sua prima stagione alla Juventus. Un acquisto azzeccato che ha dato parecchie soddisfazioni anche al fantacalcio. La missione per il secondo anno è semplice, ovvero migliorarsi ancora. Questo vorrebbe dire superare quota 10 bonus, facendo più di 5 gol e 5 assist. L’obiettivo è alla portata, se ci riuscirà sarà un centrocampista di alto livello al fantacalcio."
+      }
+    },
+    {
+      "nome": "KONÈ M.",
+      "team": "ROM",
+      "prezzi": {
+        "min": 15,
+        "max": 22,
+        "avg": 18.8
+      },
+      "stats": {
+        "t": 4,
+        "a": 4,
+        "i": 3,
+        "f": 6.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 22,
+        "fantaclassic_2025": 19,
+        "profeta_2025": 15,
+        "sos_fanta_2025": 19,
+        "fantaboom_2024": 22,
+        "fantaclassic_2024": 19,
+        "profeta_2024": 15,
+        "sos_fanta_2024": 19
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 180,
+          "rating": 6.5
+        },
+        "2024_25": {
+          "goals": 2,
+          "assists": 1,
+          "minutes": 2582,
+          "rating": 6.26
+        }
+      },
+      "notes": {
+        "comm": "Manu Koné è rimasto alla Roma, nonostante l'offerta dell'Inter. La società ha deciso di tenerlo e questo gli dà nuovo hype in vista dell'asta, c'è grande entusiasmo intorno al suo nome. Qualche bonus lo porta ma rimane un centrocampista più da rendimento e continuità, uno da ottimi voti. E con Gasperini lo sarà ancora di più. Poi, certo, anche alcuni gol e assist potranno arrivare, come per Ederson all'Atalanta...\n"
+      }
+    },
+    {
+      "nome": "EDERSON D.S.",
+      "team": "ATA",
+      "prezzi": {
+        "min": 10,
+        "max": 21,
+        "avg": 15.2
+      },
+      "stats": {
+        "t": 4,
+        "a": 5,
+        "i": 3,
+        "f": 5.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 21,
+        "fantaclassic_2025": 15,
+        "profeta_2025": 15,
+        "sos_fanta_2025": 10,
+        "fantaboom_2024": 21,
+        "fantaclassic_2024": 15,
+        "profeta_2024": 15,
+        "sos_fanta_2024": 10
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 19,
+          "rating": 5.5
+        },
+        "2024_25": {
+          "goals": 4,
+          "assists": 2,
+          "minutes": 2888,
+          "rating": 6.17
+        }
+      },
+      "notes": {
+        "comm": "Ederson è un centrocampista totale. Al fantacalcio sa fare tutto: porta buoni voti, segna e fa pure qualche assist. È più di un semplice mediano. Si tratta di un titolare fisso delle vostre squadre al fanta. Anche con Juric resta un intoccabile, il problema è l'infortunio che gli fa perdere almeno tutto settembre. E di conseguenza non sarà facile replicare il numero di bonus (4 gol e 2 assist) della scorsa stagione. E cala anche il prezzo, visto che inizierà a essere a disposizione da ottobre di fatto. "
+      }
+    },
+    {
+      "nome": "MODRIC",
+      "team": "MIL",
+      "prezzi": {
+        "min": 20,
+        "max": 23,
+        "avg": 21.5
+      },
+      "stats": {
+        "t": 4,
+        "a": 5,
+        "i": 3,
+        "f": 7.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 20,
+        "fantaclassic_2025": 23,
+        "profeta_2025": 20,
+        "sos_fanta_2025": 23,
+        "fantaboom_2024": 20,
+        "fantaclassic_2024": 23,
+        "profeta_2024": 20,
+        "sos_fanta_2024": 23
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 1,
+          "minutes": 164,
+          "rating": 6.5
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 1830,
+          "rating": 6.5
+        }
+      },
+      "notes": {
+        "comm": "Luka Modric arricchisce l’asta del fantacalcio con la sua classe e qualità. A settembre farà 40 anni ma vuole essere ancora protagonista e titolare, sfruttando il fatto di giocare una partita a settimana. L’anno scorso al Real Madrid 17 partite su 35 le ha giocate dall’inizio. Nel Milan Allegri lo vede sia in cabina di regia che da mezzala, sta ancora cercando l'assetto ideale per i rossoneri. Arriva in Italia integro fisicamente nonostante l’età, è ancora da bonus visto che l’anno scorso ha segnato 4 gol e fatto 9 assist tra tutte le competizioni. Modric è un nome di prestigio che probabilmente all’asta costerà più del rendimento in termini di bonus che potrà offrire. Difficile pagarlo molto meno dei top dei reparto, può essere all’incirca un secondo slot per i prezzi a cui andrà. Alla seconda a Lecce, subito un assist per lui direttamente da punizione."
+      }
+    },
+    {
+      "nome": "ZAMBO ANGUISSA",
+      "team": "NAP",
+      "prezzi": {
+        "min": 17,
+        "max": 20,
+        "avg": 18.5
+      },
+      "stats": {
+        "t": 4,
+        "a": 5,
+        "i": 3,
+        "f": 8.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 19,
+        "fantaclassic_2025": 17,
+        "profeta_2025": 18,
+        "sos_fanta_2025": 20,
+        "fantaboom_2024": 19,
+        "fantaclassic_2024": 17,
+        "profeta_2024": 18,
+        "sos_fanta_2024": 20
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 1,
+          "assists": 0,
+          "minutes": 180,
+          "rating": 7.0
+        },
+        "2024_25": {
+          "goals": 6,
+          "assists": 4,
+          "minutes": 2857,
+          "rating": 6.41
+        }
+      },
+      "notes": {
+        "comm": "Zambo Anguissa ha avuto un grande exploit nella passata stagione: 6 gol e 4 assist in 35 partite a voto. Quest’anno aumenta la concorrenza nel Napoli e ci saranno più rotazioni con la Champions: non più posto garantito per 38 su 38 in campionato, ma comunque avrà spazio e a voto andrà quasi sempre se starà bene. Resta un elemento molto importante per Conte, avrà solo il limite della Coppa d’Africa. All’asta ovviamente andrà a meno rispetto ai compagni McTominay e De Bruyne, ma per rapporto qualità-prezzo può comunque fare bene. E lo ha confermato subito: suo il gol da tre punti in extremis contro il Cagliari alla seconda di campionato. "
+      }
+    },
+    {
+      "nome": "CARBONI V.",
+      "team": "GEN",
+      "prezzi": {
+        "min": 14,
+        "max": 20,
+        "avg": 16.8
+      },
+      "stats": {
+        "t": 4,
+        "a": 4,
+        "i": 2,
+        "f": 5.75
+      },
+      "allPrices": {
+        "fantaboom_2025": 17,
+        "fantaclassic_2025": 14,
+        "profeta_2025": 20,
+        "sos_fanta_2025": 16,
+        "fantaboom_2024": 17,
+        "fantaclassic_2024": 14,
+        "profeta_2024": 20,
+        "sos_fanta_2024": 16
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 138,
+          "rating": 5.75
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 100,
+          "rating": 6.0
+        }
+      },
+      "notes": {
+        "comm": "Valentin Carboni proverà a esplodere nel Genoa. Il talento dell’Inter è andato in prestito per cercare più spazio e più avrà spazio più i nerazzurri pagheranno come bonus. In linea di massima sarà titolare, comunque giocherà tanto. Anche perché è molto duttile e sulla trequarti (nel 4-2-3-1 ma non solo) può giocare praticamente ovunque. Dipenderà anche dalle sue condizioni fisiche, che sono il punto interrogativo maggiore. Arriva infatti dalla rottura del crociato (ha perso tutta l’ultima stagione), ma ha pienamente recuperato ed è sembrato in buona forma al Mondiale per Club con l’Inter. Sul lungo periodo le sue condizioni andranno comunque monitorate. Anche per questo è una scommessa, definizione che incarna alla perfezione anche per talento, potenziale ed età. E non solo da ultimi slot, anzi."
+      }
+    },
+    {
+      "nome": "VAZQUEZ",
+      "team": "CRE",
+      "prezzi": {
+        "min": 12,
+        "max": 20,
+        "avg": 17.0
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 4,
+        "f": 10.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 16,
+        "fantaclassic_2025": 12,
+        "profeta_2025": 20,
+        "sos_fanta_2025": 20,
+        "fantaboom_2024": 16,
+        "fantaclassic_2024": 12,
+        "profeta_2024": 20,
+        "sos_fanta_2024": 20
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 1,
+          "assists": 0,
+          "minutes": 74,
+          "rating": 7.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 1867,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Franco Vazquez listato centrocampista è una tentazione. Ha trascinato in Serie A la Cremonese e torna nel massimo campionato, l’argentino è un giocatore di classe sopraffina. Col suo mancino disegna calcio, più da assist che da gol per caratteristiche, ma alla seconda ha subito segnato al Sassuolo. Poteva essere considerata una tentazione low cost, ora non più visto che ha subito lasciato il segno (alla prima non aveva giocato per squalifica col Milan). Gioca avanzato, spesso quasi da seconda punta, quindi è vicino alla porta e ha grandi chance di arrivare al tiro o di rifinire. Intrigante per l’asta, classico colpo da una neopromossa. Occhio anche ai rigori, può essere uno dei candidati (9 su 11 in carriera). L’unica incognita è la tenuta fisica: non è detto che le giochi tutte e che sia sempre a disposizione. Ma può andare a bonus anche in pochi minuti e dalla panchina. Non è più giovane, andrà gestito."
+      }
+    },
+    {
+      "nome": "SAELEMAEKERS",
+      "team": "MIL",
+      "prezzi": {
+        "min": 15,
+        "max": 20,
+        "avg": 18.0
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 2,
+        "f": 6.25
+      },
+      "allPrices": {
+        "fantaboom_2025": 15,
+        "fantaclassic_2025": 17,
+        "profeta_2025": 20,
+        "sos_fanta_2025": 20,
+        "fantaboom_2024": 15,
+        "fantaclassic_2024": 17,
+        "profeta_2024": 20,
+        "sos_fanta_2024": 20
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 167,
+          "rating": 6.25
+        },
+        "2024_25": {
+          "goals": 7,
+          "assists": 3,
+          "minutes": 1494,
+          "rating": 6.39
+        }
+      },
+      "notes": {
+        "comm": "Alexis Saelemaekers ci riprova. Bene al Bologna e soprattutto l’anno scorso alla Roma, ora vuole affermarsi nel suo Milan. Con Allegri è molto interessante, perché il nuovo allenatore può sfruttare la sua duttilità sulla fascia: a destra può fare il terzino, l’esterno e l’ala. All’occorrenza può giocare anche in altri ruoli, a Lecce per esempio ha fatto la seconda punta pura. Non sarà troppo sottovalutato perché arriva da una stagione con 7 gol, ma si può prendere a condizioni interessanti."
+      }
+    },
+    {
+      "nome": "MALDINI",
+      "team": "ATA",
+      "prezzi": {
+        "min": 7,
+        "max": 14,
+        "avg": 10.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 3,
+        "f": 5.25
+      },
+      "allPrices": {
+        "fantaboom_2025": 14,
+        "fantaclassic_2025": 10,
+        "profeta_2025": 10,
+        "sos_fanta_2025": 7,
+        "fantaboom_2024": 14,
+        "fantaclassic_2024": 10,
+        "profeta_2024": 10,
+        "sos_fanta_2024": 7
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 135,
+          "rating": 5.5
+        },
+        "2024_25": {
+          "goals": 6,
+          "assists": 0,
+          "minutes": 1571,
+          "rating": 6.02
+        }
+      },
+      "notes": {
+        "comm": "Daniel Maldini ha chiuso la scorsa stagione con 27 partite a voto e 6 gol tra Monza e Atalanta. È un jolly per Juric, in partenza si gioca il posto con altri giocatori, ma può trovare spazio nelle rotazioni (a maggior ragione dopo il caso Lookman). È listato a centrocampo e questo in chiave asta è positivo: è un jolly, si può prendere in un reparto con tanti titolari. Va preso alle giuste condizioni, non con troppe scommesse o non titolari. Titolare alle prime due, ma non ha lasciato il segno: occhio alla grande concorrenza."
+      }
+    },
+    {
+      "nome": "ORISTANIO",
+      "team": "PAR",
+      "prezzi": {
+        "min": 9,
+        "max": 15,
+        "avg": 12.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 3,
+        "f": 6.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 14,
+        "fantaclassic_2025": 11,
+        "profeta_2025": 15,
+        "sos_fanta_2025": 9,
+        "fantaboom_2024": 14,
+        "fantaclassic_2024": 11,
+        "profeta_2024": 15,
+        "sos_fanta_2024": 9
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 34,
+          "rating": 6.5
+        },
+        "2024_25": {
+          "goals": 3,
+          "assists": 3,
+          "minutes": 2333,
+          "rating": 6.05
+        }
+      },
+      "notes": {
+        "comm": "Gaetano Oristanio riparte dal Parma. Al fantacalcio arriva da una buona stagione con 3 gol e 3 assist, ha avuto una buona continuità perché è andato a voto 37 volte su 38. È un giocatore che può essere utile anche da subentrante, ma al Parma nella situazione attuale può puntare a fare il titolare affianco a Pellegrino nel 3-5-2. È anche un’opzione per i piazzati, ha un buon mancino anche se c’è pure Bernabé. Non è un rigorista, solo due a livello giovanile. All’asta è un centrocampista potenzialmente da bonus (può anche farne più dei 6 dello scorso anno), ma comunque a prezzi non eccessivi."
+      }
+    },
+    {
+      "nome": "LOFTUS-CHEEK",
+      "team": "MIL",
+      "prezzi": {
+        "min": 13,
+        "max": 22,
+        "avg": 17.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 2,
+        "f": 7.75
+      },
+      "allPrices": {
+        "fantaboom_2025": 13,
+        "fantaclassic_2025": 18,
+        "profeta_2025": 22,
+        "sos_fanta_2025": 16,
+        "fantaboom_2024": 13,
+        "fantaclassic_2024": 18,
+        "profeta_2024": 22,
+        "sos_fanta_2024": 16
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 1,
+          "assists": 0,
+          "minutes": 166,
+          "rating": 6.25
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 1031,
+          "rating": 5.86
+        }
+      },
+      "notes": {
+        "comm": "Ruben Loftus-Cheek prova a rifarsi sotto la guida di Massimiliano Allegri, che cercherà di farlo rendere 'alla Rabiot'. La funzione che avrà nel suo Milan sarà simile, il problema però è - quasi - solo uno: gli infortuni. L’inglese, ora 29enne, è stato falcidiato dai problemi fisici nell’ultima stagione, giocando poco. Al suo primo anno in rossonero invece aveva fatto bene con 6 gol in campionato. Questo bottino di reti è tranquillamente alla portata se riuscirà a giocare almeno 25-30 partite, dipenderà dalle sue condizioni. Se starà bene potrà avere continuità, poi si capirà se sarà sempre titolare o meno. Per ora, per Allegri è una prima scelta e l'inglese ha ripagato la fiducia con un gol di testa a Lecce. Con la giusta continuità, potrà restare un titolare anche dopo l'arrivo di Rabiot."
+      }
+    },
+    {
+      "nome": "STANCIU",
+      "team": "GEN",
+      "prezzi": {
+        "min": 8,
+        "max": 15,
+        "avg": 12.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 4,
+        "f": 6.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 13,
+        "fantaclassic_2025": 13,
+        "profeta_2025": 15,
+        "sos_fanta_2025": 8,
+        "fantaboom_2024": 13,
+        "fantaclassic_2024": 13,
+        "profeta_2024": 15,
+        "sos_fanta_2024": 8
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 152,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 152,
+          "rating": 6.0
+        }
+      },
+      "notes": {
+        "comm": "Nicolae Stanciu è un acquisto di esperienza per il Genoa. Classe ’93, è arrivato a parametro zero dal Damac FC. Si tratta di un trequartista centrale o all'occorrenza centrocampista, può giocare anche a destra. È un pilastro della nazionale rumena, dove ha giocato 81 partite con 15 gol. In Saudi Pro League arriva da 29 presenze con 5 gol e 7 assist realizzati. Va segnalato che è un ottimo tiratore di calci piazzati, a differenza di Malinovskyi è di piede destro. È un rigorista anche se non con grandi numeri: 16 segnati e 10 sbagliati. Può mettersi comunque in lista, poi deciderà Vieira la gerarchia. È partito molto bene e non è più un low cost da ultimi slot, c'è hype intorno al suo nome. Ha un'ottima balistica e i bonus potranno arrivare.\n"
+      }
+    },
+    {
+      "nome": "BERNABÈ",
+      "team": "PAR",
+      "prezzi": {
+        "min": 7,
+        "max": 12,
+        "avg": 10.2
+      },
+      "stats": {
+        "t": 5,
+        "a": 4,
+        "i": 2,
+        "f": 6.25
+      },
+      "allPrices": {
+        "fantaboom_2025": 12,
+        "fantaclassic_2025": 12,
+        "profeta_2025": 10,
+        "sos_fanta_2025": 7,
+        "fantaboom_2024": 12,
+        "fantaclassic_2024": 12,
+        "profeta_2024": 10,
+        "sos_fanta_2024": 7
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 179,
+          "rating": 6.25
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 1,
+          "minutes": 1461,
+          "rating": 6.29
+        }
+      },
+      "notes": {
+        "comm": "Adrian Bernabé ha fatto un primo anno deludente al fantacalcio, perché le aspettative erano alte e ha avuto troppi infortuni. Alla fine soltanto 19 partite a voto, di fatto metà campionato. Il problema restano gli infortuni, è fragile fisicamente. Ma se riuscirà ad avere continuità può fare molto meglio dell’anno scorso, anche perché se sta bene è titolare fisso e tira i piazzati. E in più è perfetto per il gioco di Cuesta."
+      }
+    },
+    {
+      "nome": "ROWE",
+      "team": "BOL",
+      "prezzi": {
+        "min": 10,
+        "max": 15,
+        "avg": 11.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 4,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 12,
+        "fantaclassic_2025": 10,
+        "profeta_2025": 15,
+        "sos_fanta_2025": 10,
+        "fantaboom_2024": 12,
+        "fantaclassic_2024": 10,
+        "profeta_2024": 15,
+        "sos_fanta_2024": 10
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 63,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 817,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Jonathan Rowe, classe 2003, è il sostituto di Ndoye per il Bologna. Si tratta di un’ala sinistra di piede destro, è inglese di origini giamaicane ed è alto 173 cm. Arriva dal Marsiglia dove ha fatto 3 gol e 3 assist in 28 presenze in Ligue 1, ma solo 6 da titolare (giocando anche da attaccante). Recentemente è venuto alle cronache per il pesante litigio con Rabiot, che ha costretto il Marsiglia a metterlo sul mercato. E questo ha aiutato il Bologna a prenderlo, per un’operazione complessiva da quasi 20 milioni, segnale di fiducia da parte del club. Ora toccherà a Italiano gestirlo, sotto tutti i punti di vista. Prima di andare al Marsiglia era esploso in seconda divisione inglese facendo 12 gol con il Norwich. Non avrà rigori e piazzati, mentre in carriera ha avuto un solo infortunio ma da circa due mesi nel 2023-24. Ha velocità e dribbling, è bravo nell’uno contro uno. Difficile considerare un giocatore del Bologna titolare fisso, specialmente sull’esterno: Italiano farà molte rotazioni. Ma a voto ci andrà quasi sempre. La concorrenza è con Cambiaghi e Dominguez da quella parte. Il ruolo di centrocampista lo rende intrigante al fanta, anche perché ha caratteristiche che in Italia possono fare la differenza. Se diventa meno “giocoliere” e più incisivo."
+      }
+    },
+    {
+      "nome": "VANDEPUTTE",
+      "team": "CRE",
+      "prezzi": {
+        "min": 9,
+        "max": 20,
+        "avg": 13.2
+      },
+      "stats": {
+        "t": 4,
+        "a": 4,
+        "i": 4,
+        "f": 7.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 12,
+        "fantaclassic_2025": 12,
+        "profeta_2025": 20,
+        "sos_fanta_2025": 9,
+        "fantaboom_2024": 12,
+        "fantaclassic_2024": 12,
+        "profeta_2024": 20,
+        "sos_fanta_2024": 9
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 1,
+          "minutes": 130,
+          "rating": 6.5
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 2020,
+          "rating": 6.0
+        }
+      },
+      "notes": {
+        "comm": "Jari Vandeputte è uno dei giocatori più interessanti della Cremonese. Mezzala o esterno, quest’anno dovrebbe fare principalmente il primo ruolo. In Serie B ha fatto 5 gol e addirittura 15 assist. Classe ’96, è belga di nazionalità ed è alto 177 cm. È esploso tardi ma si parla di lui già da diversi anni, ora è atteso al grande salto in Serie A e ci sono aspettative alte. Al Catanzaro aveva fatto 9 gol e 14 assist in B e 11 gol e 20 assist in C, ha sempre portato bonus ed è anche un’opzione per piazzati e punizioni. 6 all'esordio a San Siro col Milan, 7 +1 (assist) contro il Sassuolo alla seconda. "
+      }
+    },
+    {
+      "nome": "FOLORUNSHO",
+      "team": "CAG",
+      "prezzi": {
+        "min": 5,
+        "max": 12,
+        "avg": 8.5
+      },
+      "stats": {
+        "t": 5,
+        "a": 3,
+        "i": 3,
+        "f": 6.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 10,
+        "fantaclassic_2025": 5,
+        "profeta_2025": 12,
+        "sos_fanta_2025": 7,
+        "fantaboom_2024": 10,
+        "fantaclassic_2024": 5,
+        "profeta_2024": 12,
+        "sos_fanta_2024": 7
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 173,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 685,
+          "rating": 5.96
+        }
+      },
+      "notes": {
+        "comm": "Michael Folorunsho arriva dal Napoli per dare dinamismo e fisicità alla squadra di Fabio Pisacane. Il classe '98 è alla ricerca di riscatto dopo le parentesi non positive con Napoli e Fiorentina. O mezzala o trequartista a seconda delle scelte dell'allenatore, sulla carta sarà titolare e ha giocato dal 1' nelle prime due: inserimenti e tiri dalla distanza sono armi che può sfruttare per andare a bonus. Negativa la scorsa stagione, ma nel suo anno a Verona aveva raccolto 5 reti, un ottimo bottino per un centrocampista di una squadra che lotta per la salvezza: chissà che a Cagliari, con la continuità che gli è mancata, non possa ripetersi. A livello di cartellini nella scorsa stagione ha ricevuto 5 gialli su 26 presenze e fisicamente è integro e non ha molti infortuni superiori al mese di stop, si era solo fermato al termine della stagione. Per l'asta Folorunsho è qualcosa in più di un low cost da ultimi slot, siamo in una fascia più alta, a cavallo tra il 4 e 5°."
+      }
+    },
+    {
+      "nome": "PIEROTTI",
+      "team": "LEC",
+      "prezzi": {
+        "min": 4,
+        "max": 10,
+        "avg": 6.5
+      },
+      "stats": {
+        "t": 4,
+        "a": 3,
+        "i": 4,
+        "f": 6.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 10,
+        "fantaclassic_2025": 4,
+        "profeta_2025": 5,
+        "sos_fanta_2025": 7,
+        "fantaboom_2024": 10,
+        "fantaclassic_2024": 4,
+        "profeta_2024": 5,
+        "sos_fanta_2024": 7
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 63,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 4,
+          "assists": 1,
+          "minutes": 1947,
+          "rating": 5.81
+        }
+      },
+      "notes": {
+        "comm": "Santiago Pierotti è listato a centrocampo, una notizia importante per il fantacalcio. 4 gol e 1 assist in 35 partite a voto nella scorsa stagione, ora dovrà convincere anche Di Francesco ad affidargli una maglia da titolare. Ha tutto per restare una delle prime scelte sulle fasce, ma deciderà il nuovo allenatore. Un dato da migliorare: i 4 gialli e un rosso della passata stagione. Colpo low cost in provincia, dei centrocampisti del Lecce è probabilmente il più interessante per il fanta."
+      }
+    },
+    {
+      "nome": "ATTA",
+      "team": "UDI",
+      "prezzi": {
+        "min": 8,
+        "max": 25,
+        "avg": 17.0
+      },
+      "stats": {
+        "t": 4,
+        "a": 4,
+        "i": 5,
+        "f": 8.25
+      },
+      "allPrices": {
+        "fantaboom_2025": 8,
+        "fantaclassic_2025": 18,
+        "profeta_2025": 25,
+        "sos_fanta_2025": 17,
+        "fantaboom_2024": 8,
+        "fantaclassic_2024": 18,
+        "profeta_2024": 25,
+        "sos_fanta_2024": 17
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 1,
+          "assists": 0,
+          "minutes": 180,
+          "rating": 6.75
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 1246,
+          "rating": 6.0
+        }
+      },
+      "notes": {
+        "comm": "Arthur Atta è in rampa di lancio in casa Udinese dopo una prima stagione di ambientamento. È un centrocampista molto duttile che può fare la mezzala e non solo, ha dalla sua un buon fisico (è alto 189 cm) e anche agilità. Classe 2003, è giovane e può crescere molto in questa stagione. Il talento si è visto, si è sbloccato anche al fantacalcio con il gol realizzato a San Siro contro l'Inter. Quest’anno può essere diverso dallo scorso, si è già visto dalla Coppa Italia e dall'inizio di campionato. Intriga."
+      }
+    },
+    {
+      "nome": "EL AYNAOUI",
+      "team": "ROM",
+      "prezzi": {
+        "min": 8,
+        "max": 10,
+        "avg": 8.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 3,
+        "f": 6.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 8,
+        "fantaclassic_2025": 8,
+        "profeta_2025": 10,
+        "sos_fanta_2025": 9,
+        "fantaboom_2024": 8,
+        "fantaclassic_2024": 8,
+        "profeta_2024": 10,
+        "sos_fanta_2024": 9
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 31,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 1605,
+          "rating": 6.0
+        }
+      },
+      "notes": {
+        "comm": "Neil El Aynaoui è il rinforzo della Roma per il centrocampo. Gasperini potrà contare su un giocatore giovane (24 anni) e proverà a farlo crescere come ha fatto con Ederson all’Atalanta. Il marocchino, nato in Francia, è un centrocampista centrale, di piede destro e alto 185 cm. Al fantacalcio non va sottovalutato perché può portare bonus e al Lens era anche rigorista. Ha iniziato a calciarli a febbraio, tre su tre nel finale di stagione. Alla Roma troverà grande concorrenza a partire da Dybala, non sarà quindi lui il rigorista. Però all’occorrenza si farebbe trovare pronto. Chiaramente all’asta non andrà pagato (tanto) come se fosse rigorista. Ma non c’è neanche troppo hype su di lui. Qualche bonus, in ogni caso, potrà arrivare anche su azione. Con Gasperini segnano pure i mediani, anche se qualche cartellino andrà messo in conto. Il suo problema sono gli infortuni, perché ha giocato solo 24 partite di campionato un anno fa e 25 due anni fa. Nella scorsa stagione ha avuto tre infortuni, uno al ginocchio e due muscolari. Occhio alla Coppa d'Africa: ha scelto il Marocco e salvo sorprese parteciperà.\n\n"
+      }
+    },
+    {
+      "nome": "LOCATELLI",
+      "team": "JUV",
+      "prezzi": {
+        "min": 5,
+        "max": 8,
+        "avg": 6.5
+      },
+      "stats": {
+        "t": 4,
+        "a": 4,
+        "i": 4,
+        "f": 6.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 8,
+        "fantaclassic_2025": 5,
+        "profeta_2025": 5,
+        "sos_fanta_2025": 8,
+        "fantaboom_2024": 8,
+        "fantaclassic_2024": 5,
+        "profeta_2024": 5,
+        "sos_fanta_2024": 8
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 119,
+          "rating": 6.5
+        },
+        "2024_25": {
+          "goals": 2,
+          "assists": 1,
+          "minutes": 2840,
+          "rating": 6.19
+        }
+      },
+      "notes": {
+        "comm": "Manuel Locatelli è stato bravo a prendersi il posto da titolare fisso nella scorsa stagione. Di fatto ha giocato sempre e questo potrebbe succedere anche nella nuova stagione. Tudor lo considera importante e addirittura gli aveva fatto tirare il rigore decisivo per l’accesso in Champions all’ultima giornata. Rigori che l'allenatore gli ha confermato per la nuova stagione, un fattore che fa salire molto il suo prezzo all'asta."
+      }
+    },
+    {
+      "nome": "MKHITARYAN",
+      "team": "INT",
+      "prezzi": {
+        "min": 2,
+        "max": 8,
+        "avg": 4.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 3,
+        "f": 6.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 8,
+        "fantaclassic_2025": 5,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 4,
+        "fantaboom_2024": 8,
+        "fantaclassic_2024": 5,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 4
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 107,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 5,
+          "minutes": 2410,
+          "rating": 6.06
+        }
+      },
+      "notes": {
+        "comm": "Henrikh Mkhitaryan inizia a perdere colpi al fantacalcio, ormai l’età avanza. Non è più un punto fermo al fantacalcio, inizierà a diventare maggiormente un jolly. In una rosa al fanta ci può stare, ma solo a prezzo basso. Da quando ha cambiato ruolo non è mai stato uno da molti gol, anzi. Però nell’ultima stagione ha portato almeno 5 assist."
+      }
+    },
+    {
+      "nome": "STENGS",
+      "team": "PIS",
+      "prezzi": {
+        "min": 4,
+        "max": 10,
+        "avg": 6.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 2,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 8,
+        "fantaclassic_2025": 4,
+        "profeta_2025": 10,
+        "sos_fanta_2025": 5,
+        "fantaboom_2024": 8,
+        "fantaclassic_2024": 4,
+        "profeta_2024": 10,
+        "sos_fanta_2024": 5
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 13,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 3,
+          "minutes": 626,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Calvin Stengs è un nuovo giocatore del Pisa. Classe 1998, arriva dal Feyenoord ed è di piede mancino, in carriera ha giocato sia come trequartista che come ala destra. È alto 187 cm, è quindi un fantasista alto e non dal passo veloce, ma comunque con dribbling e imbucate. È cresciuto nel settore giovanile dell’AZ Alkmaar, poi le esperienze con Nizza e Anversa prima del ritorno in Olanda, ora il passaggio al Pisa. 1 gol e 3 assist in 12 gare di Eredivisie nella scorsa stagione, nella precedente era arrivato a 6 gol e 13 assist, la migliore della sua carriera. Complessivamente, 45 gol e 62 assist in 286 partite, con 28 gialli e 2 rossi. Ha giocato anche in nazionale, 8 presenze e 3 gol, l’ultima risale al 2023. Non è un rigorista, solo uno sbagliato in carriera. Le poche presenze della scorsa stagione hanno una motivazione chiara: si è fermato per un’operazione al ginocchio 85 giorni, poi per un infortunio alla coscia 27 giorni e alla caviglia 81 giorni. Una stagione da dimenticare, in precedenza l’unico infortunio grave risaliva al 2017/18 (rottura del legamento crociato). Ora cerca riscatto, è un nome appena più che low cost come scommessa, reso intrigante dal ruolo di centrocampista nel listone ma senza esagerare per via degli infortuni della passata stagione. Se sta bene andrà quasi sempre a voto, possibile titolare nei due trequartisti dietro alla punta.\n\n"
+      }
+    },
+    {
+      "nome": "THORSTVEDT",
+      "team": "SAS",
+      "prezzi": {
+        "min": 5,
+        "max": 8,
+        "avg": 6.5
+      },
+      "stats": {
+        "t": 4,
+        "a": 4,
+        "i": 2,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 8,
+        "fantaclassic_2025": 6,
+        "profeta_2025": 5,
+        "sos_fanta_2025": 7,
+        "fantaboom_2024": 8,
+        "fantaclassic_2024": 6,
+        "profeta_2024": 5,
+        "sos_fanta_2024": 7
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 1925,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "KristianThorstvedt è un centrocampista che è stato già apprezzato al fantacalcio, segnò 6 gol in Serie A due anni fa. L’anno scorso in B ha fatto la differenza con 7 gol in 24 partite, poi l’infortunio. Mezzala con fisicità e inserimenti in zona bonus, nel Sassuolo è un big e al fanta può fare ancora bene. Si può risparmiare qualche credito visto che ha iniziato la stagione ai box (in ripresa dall'infortunio della passata stagione appunto, ma dopo la sosta può tornare a disposizione).\n\n"
+      }
+    },
+    {
+      "nome": "ZALEWSKI",
+      "team": "ATA",
+      "prezzi": {
+        "min": 5,
+        "max": 8,
+        "avg": 6.0
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 4,
+        "f": 6.25
+      },
+      "allPrices": {
+        "fantaboom_2025": 8,
+        "fantaclassic_2025": 5,
+        "profeta_2025": 5,
+        "sos_fanta_2025": 6,
+        "fantaboom_2024": 8,
+        "fantaclassic_2024": 5,
+        "profeta_2024": 5,
+        "sos_fanta_2024": 6
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 155,
+          "rating": 6.25
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 2,
+          "minutes": 982,
+          "rating": 6.03
+        }
+      },
+      "notes": {
+        "comm": "Nicola Zalewski è un nuovo giocatore dell'Atalanta e questo cambia radicalmente il suo scenario al fantacalcio. Se all’Inter era chiuso da Dimarco e Carlos Augusto, alla Dea hanno deciso di puntare su di lui: si gioca il posto con Zappacosta, o parte titolare uno o l'altro. Ahanor è visto più come braccetto, quindi l'ex Inter potrà avere spazio e andare quasi sempre a voto. Per lui una nuova occasione da protagonista in Serie A, con un minutaggio destinato a crescere e un appeal al fantacalcio che aumenta. L'hype è ancora basso perché è listato centrocampista, quindi rimane da slot secondari però può tornare utile a un prezzo contenuto, può fare più assist che gol. Titolare lui e non Zappacosta nelle prime due di campionato. "
+      }
+    },
+    {
+      "nome": "CASADEI",
+      "team": "TOR",
+      "prezzi": {
+        "min": 6,
+        "max": 12,
+        "avg": 8.0
+      },
+      "stats": {
+        "t": 4,
+        "a": 3,
+        "i": 5,
+        "f": 6.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 7,
+        "fantaclassic_2025": 7,
+        "profeta_2025": 12,
+        "sos_fanta_2025": 6,
+        "fantaboom_2024": 7,
+        "fantaclassic_2024": 7,
+        "profeta_2024": 12,
+        "sos_fanta_2024": 6
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 180,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 1,
+          "minutes": 1023,
+          "rating": 6.03
+        }
+      },
+      "notes": {
+        "comm": "Cesare Casadei è arrivato lo scorso gennaio al Torino, 1 gol e 1 assist in 15 partite a voto. Ricci è partito, lui ha tutto per diventare titolare inamovibile nel centrocampo di Baroni. È giovane e ha ampi margini di miglioramento, può crescere anche in zona bonus dove comunque è bravo con gli inserimenti. Si colloca come centrocampista low cost, ha potenzialità dal punto di vista dei bonus perché vede la porta, non sempre porta a casa la grande prestazione."
+      }
+    },
+    {
+      "nome": "GUENDOUZI",
+      "team": "LAZ",
+      "prezzi": {
+        "min": 6,
+        "max": 10,
+        "avg": 7.5
+      },
+      "stats": {
+        "t": 5,
+        "a": 4,
+        "i": 4,
+        "f": 7.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 7,
+        "fantaclassic_2025": 6,
+        "profeta_2025": 10,
+        "sos_fanta_2025": 7,
+        "fantaboom_2024": 7,
+        "fantaclassic_2024": 6,
+        "profeta_2024": 10,
+        "sos_fanta_2024": 7
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 1,
+          "assists": 0,
+          "minutes": 180,
+          "rating": 6.25
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 2,
+          "minutes": 3274,
+          "rating": 6.04
+        }
+      },
+      "notes": {
+        "comm": "Mattéo Guendouzi è un titolare fisso nella Lazio. Un centrocampista non propriamente da fantacalcio come caratteristiche, perché non ha mai segnato più di 2 gol da quando è in Italia. Però - al giusto prezzo - è sempre utile averlo in rosa, perché gioca sempre. E avrà solo il campionato con Sarri che lo conosce bene. Alla seconda contro il Verona ha subito lasciato il segno con un gol.\n\n"
+      }
+    },
+    {
+      "nome": "SOHM",
+      "team": "FIO",
+      "prezzi": {
+        "min": 4,
+        "max": 10,
+        "avg": 7.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 3,
+        "f": 5.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 7,
+        "fantaclassic_2025": 4,
+        "profeta_2025": 10,
+        "sos_fanta_2025": 8,
+        "fantaboom_2024": 7,
+        "fantaclassic_2024": 4,
+        "profeta_2024": 10,
+        "sos_fanta_2024": 8
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 135,
+          "rating": 5.75
+        },
+        "2024_25": {
+          "goals": 4,
+          "assists": 0,
+          "minutes": 2999,
+          "rating": 6.03
+        }
+      },
+      "notes": {
+        "comm": "Simon Sohm è un centrocampista molto utile per il fantacalcio e lo sarà anche alla Fiorentina, perché è affidabile e vede anche la porta. È un giocatore di grande fisicità e ha fiuto del gol, l’anno scorso ha portato a casa un bottino di 4 reti. Al Parma era titolare fisso (37 su 38 l’anno scorso), alla Fiorentina avrà probabilmente più ballottaggi e concorrenza ma rimane comunque importante e da bonus. Con voti anche leggermente più alti."
+      }
+    },
+    {
+      "nome": "ASLLANI",
+      "team": "TOR",
+      "prezzi": {
+        "min": 1,
+        "max": 5,
+        "avg": 3.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 5,
+        "f": 5.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 5,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 5,
+        "sos_fanta_2025": 2,
+        "fantaboom_2024": 5,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 5,
+        "sos_fanta_2024": 2
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 81,
+          "rating": 5.5
+        },
+        "2024_25": {
+          "goals": 2,
+          "assists": 2,
+          "minutes": 1007,
+          "rating": 6.16
+        }
+      },
+      "notes": {
+        "comm": "Kristian Asllani sarà titolare nel centrocampo del Torino, che cercava un regista per il 4-3-3. Al fantacalcio vuol dire un voto praticamente fisso, probabilmente qualche cartellino giallo di troppo ma anche qualche bonus, che potrebbe arrivare da calcio piazzato (più assist che gol). Alla fine una scelta low cost da ultimi slot che può avere un senso."
+      }
+    },
+    {
+      "nome": "COLLOCOLO",
+      "team": "CRE",
+      "prezzi": {
+        "min": 3,
+        "max": 10,
+        "avg": 5.8
+      },
+      "stats": {
+        "t": 4,
+        "a": 3,
+        "i": 4,
+        "f": 6.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 5,
+        "fantaclassic_2025": 5,
+        "profeta_2025": 10,
+        "sos_fanta_2025": 3,
+        "fantaboom_2024": 5,
+        "fantaclassic_2024": 5,
+        "profeta_2024": 10,
+        "sos_fanta_2024": 3
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 180,
+          "rating": 6.5
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 2292,
+          "rating": 6.5
+        }
+      },
+      "notes": {
+        "comm": "Michele Collocolo è un profilo da non sottovalutare nella Cremonese, un buon giocatore low cost. Nella scorsa stagione in Serie B ha fatto 8 gol e 2 assist, tutti con il destro tranne uno di testa. Centrocampista classe ’99, ha fatto proprio l’anno scorso il suo record di gol ma di solito segnava comunque sui 4/5 gol. Un titolare a basso prezzo che può farvi comodo in provincia."
+      }
+    },
+    {
+      "nome": "DA CUNHA",
+      "team": "COM",
+      "prezzi": {
+        "min": 5,
+        "max": 10,
+        "avg": 8.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 5,
+        "f": 6.25
+      },
+      "allPrices": {
+        "fantaboom_2025": 5,
+        "fantaclassic_2025": 8,
+        "profeta_2025": 10,
+        "sos_fanta_2025": 10,
+        "fantaboom_2024": 5,
+        "fantaclassic_2024": 8,
+        "profeta_2024": 10,
+        "sos_fanta_2024": 10
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 171,
+          "rating": 6.25
+        },
+        "2024_25": {
+          "goals": 3,
+          "assists": 2,
+          "minutes": 2625,
+          "rating": 6.1
+        }
+      },
+      "notes": {
+        "comm": "Lucas Da Cunha è un giocatore molto apprezzato da Fabregas, che è stato bravo a cambiargli il ruolo nel corso della scorsa stagione. Da centrocampista centrale non è più uscito dal campo e nella seconda metà di stagione ha anche portato bonus. Quest’anno avrà più concorrenza, il posto non sarà più assicurato ma sarà comunque utile a Fabregas e nelle prime due ha giocato da titolare. "
+      }
+    },
+    {
+      "nome": "FERGUSON",
+      "team": "BOL",
+      "prezzi": {
+        "min": 2,
+        "max": 7,
+        "avg": 4.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 2,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 5,
+        "fantaclassic_2025": 5,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 7,
+        "fantaboom_2024": 5,
+        "fantaclassic_2024": 5,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 7
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 1,
+          "minutes": 985,
+          "rating": 6.11
+        }
+      },
+      "notes": {
+        "comm": "Lewis Ferguson è atteso al riscatto dopo una stagione condizionata dal recupero post rottura del crociato. Il vero Ferguson, quello in grado di fare la differenza al fantacalcio, di fatto non è mai tornato. Numeri bassi per uno come lui, che può fare più gol che assist se sta bene. Il problema sono ancora gli infortuni, ne ha avuto uno a inizio stagione ma ha già recuperato.\n\n\n"
+      }
+    },
+    {
+      "nome": "TOURÈ I.",
+      "team": "PIS",
+      "prezzi": {
+        "min": 5,
+        "max": 12,
+        "avg": 6.8
+      },
+      "stats": {
+        "t": 4,
+        "a": 4,
+        "i": 4,
+        "f": 6.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 5,
+        "fantaclassic_2025": 5,
+        "profeta_2025": 12,
+        "sos_fanta_2025": 5,
+        "fantaboom_2024": 5,
+        "fantaclassic_2024": 5,
+        "profeta_2024": 12,
+        "sos_fanta_2024": 5
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 180,
+          "rating": 6.5
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 2420,
+          "rating": 7.0
+        }
+      },
+      "notes": {
+        "comm": "Idrissa Touré è un esterno del Pisa, aveva fatto molto bene in Serie B l'anno scorso. In 33 partite aveva fatto 6 gol e 5 assist, da titolare. Quest'anno può avere la concorrenza di Cuadrado, che però potrebbe giocare anche più avanzato. Rimane un low cost interessante, uno di quei giocatori a poco da prendere dalle neopromosse."
+      }
+    },
+    {
+      "nome": "ZERBIN",
+      "team": "CRE",
+      "prezzi": {
+        "min": 3,
+        "max": 10,
+        "avg": 5.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 5,
+        "f": 7.25
+      },
+      "allPrices": {
+        "fantaboom_2025": 5,
+        "fantaclassic_2025": 5,
+        "profeta_2025": 10,
+        "sos_fanta_2025": 3,
+        "fantaboom_2024": 5,
+        "fantaclassic_2024": 5,
+        "profeta_2024": 10,
+        "sos_fanta_2024": 3
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 1,
+          "minutes": 172,
+          "rating": 6.75
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 1,
+          "minutes": 1522,
+          "rating": 6.0
+        }
+      },
+      "notes": {
+        "comm": "Alessio Zerbin arriva alla Cremonese per giocare ed essere titolare. Un gol e un assist in 18 partite a voto nella passata stagione, a gennaio il Napoli lo aveva prestato al Venezia. Davide Nicola è pronto a schierare i suoi con la difesa a 3 e Zerbin - listato centrocampista - giocherà a tutta fascia a destra, visto che a sinistra è arrivato Pezzella. Proverà a raggiungere quota 5 tra gol e assist, sulla carta è il titolare di quella fascia ma c'è anche la concorrenza di Floriani Mussolini. Per il fantacalcio è il classico innesto low cost da una neopromossa, per gli ultimi slot e ancora di più da lega numerosa: a voto dovrebbe andare quasi sempre."
+      }
+    },
+    {
+      "nome": "ANJORIN",
+      "team": "TOR",
+      "prezzi": {
+        "min": 3,
+        "max": 5,
+        "avg": 3.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 2,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 4,
+        "fantaclassic_2025": 3,
+        "profeta_2025": 5,
+        "sos_fanta_2025": 3,
+        "fantaboom_2024": 4,
+        "fantaclassic_2024": 3,
+        "profeta_2024": 5,
+        "sos_fanta_2024": 3
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 11,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 2,
+          "assists": 3,
+          "minutes": 1117,
+          "rating": 6.3
+        }
+      },
+      "notes": {
+        "comm": "Tino Anjorin è di fatto il sostituto - a livello numerico - di Ricci al Torino, anche se hanno caratteristiche diverse. Nell’ultima stagione l’inglese è stato una sorpresa da 2 gol e 3 assist, anche se ha avuto il problema degli infortuni (solo 22 partite a voto). Se starà bene, con Baroni non andrà sottovalutato: già dai tempi del Verona con Folorunsho un centrocampista con queste caratteristiche può fare bene con l’allenatore ex Lazio. Resta dunque una scommessa che si può fare anche in questa stagione, in linea di massima sarà titolare e ha bonus nelle gambe, specialmente un gran tiro."
+      }
+    },
+    {
+      "nome": "DE ROON",
+      "team": "ATA",
+      "prezzi": {
+        "min": 3,
+        "max": 6,
+        "avg": 4.5
+      },
+      "stats": {
+        "t": 5,
+        "a": 4,
+        "i": 4,
+        "f": 5.75
+      },
+      "allPrices": {
+        "fantaboom_2025": 4,
+        "fantaclassic_2025": 3,
+        "profeta_2025": 5,
+        "sos_fanta_2025": 6,
+        "fantaboom_2024": 4,
+        "fantaclassic_2024": 3,
+        "profeta_2024": 5,
+        "sos_fanta_2024": 6
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 180,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 4,
+          "assists": 4,
+          "minutes": 3058,
+          "rating": 6.15
+        }
+      },
+      "notes": {
+        "comm": "Marten De Roon è il capitano e leader dell’Atalanta. Al fantacalcio torna a essere un mediano da rendimento e che qualche bonus lo può regalare, ma difficilmente potrà replicare i 4 gol e 4 assist dell’ultima stagione (la sua migliore di sempre). Da Gasperini e Juric i bonus possono diminuire, resta comunque un’ottima riserva e un centrocampista dal voto sicuro. Insomma, le caratteristiche che lo hanno sempre contraddistinto al fantacalcio."
+      }
+    },
+    {
+      "nome": "FRENDRUP",
+      "team": "GEN",
+      "prezzi": {
+        "min": 2,
+        "max": 4,
+        "avg": 3.5
+      },
+      "stats": {
+        "t": 5,
+        "a": 4,
+        "i": 4,
+        "f": 6.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 4,
+        "fantaclassic_2025": 4,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 4,
+        "fantaboom_2024": 4,
+        "fantaclassic_2024": 4,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 4
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 165,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 2,
+          "assists": 0,
+          "minutes": 3107,
+          "rating": 6.0
+        }
+      },
+      "notes": {
+        "comm": "Morten Frendrup è una garanzia di titolarità e buoni voti, è il perno del centrocampo del Genoa. Praticamente intoccabile se sta bene, Vieira non rinuncia mai alle sue geometrie e alla sua capacità di recuperare palloni in ogni zona del campo. 2 gol in 35 partite a voto nella passata stagione, può fare ancora meglio e aggiungere qualche assist. Qualcosa in più di un semplice centrocampista low cost di provincia per il vostro fanta, siamo sul 4-5° slot."
+      }
+    },
+    {
+      "nome": "FREULER",
+      "team": "BOL",
+      "prezzi": {
+        "min": 2,
+        "max": 4,
+        "avg": 2.5
+      },
+      "stats": {
+        "t": 5,
+        "a": 5,
+        "i": 4,
+        "f": 6.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 4,
+        "fantaclassic_2025": 2,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 2,
+        "fantaboom_2024": 4,
+        "fantaclassic_2024": 2,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 2
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 170,
+          "rating": 6.25
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 1,
+          "minutes": 3214,
+          "rating": 6.19
+        }
+      },
+      "notes": {
+        "comm": "Remo Freuler è uno dei titolarissimi low cost a centrocampo per eccellenza. Rispetto all’Atalanta ha perso un po’ di gol e assist, ma un paio di bonus può comunque portarli. Al fantacalcio quello che gli si chiede è il voto fisso, spesso sufficienze o addirittura un 6,5. Per questo è un’ottima riserva da tenere in panchina a coprire."
+      }
+    },
+    {
+      "nome": "LOBOTKA",
+      "team": "NAP",
+      "prezzi": {
+        "min": 2,
+        "max": 4,
+        "avg": 3.0
+      },
+      "stats": {
+        "t": 4,
+        "a": 4,
+        "i": 3,
+        "f": 6.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 4,
+        "fantaclassic_2025": 3,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 3,
+        "fantaboom_2024": 4,
+        "fantaclassic_2024": 3,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 3
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 172,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 1,
+          "minutes": 2647,
+          "rating": 6.05
+        }
+      },
+      "notes": {
+        "comm": "Stanislav Lobotka è il perno del centrocampo del Napoli e con Conte sarà ancora un titolare fisso. Non porta bonus ma garantisce sempre buoni voti grazie al lavoro di regia e interdizione in mezzo al campo. Fa un lavoro anche oscuro, non premiato dal punto di vista fantacalcistico vista la scarsa produzione di gol e assist, ma fondamentale per l'equilibrio della squadra. Al fantacalcio è ottimo da tenere in rosa come riserva, non tradisce."
+      }
+    },
+    {
+      "nome": "EKKELENKAMP",
+      "team": "UDI",
+      "prezzi": {
+        "min": 1,
+        "max": 8,
+        "avg": 4.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 4,
+        "f": 6.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 3,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 5,
+        "sos_fanta_2025": 8,
+        "fantaboom_2024": 3,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 5,
+        "sos_fanta_2024": 8
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 3,
+          "assists": 2,
+          "minutes": 1902,
+          "rating": 5.97
+        }
+      },
+      "notes": {
+        "comm": "Jurgen Ekkelenkamp era una scommessa all’asta dell’anno scorso, ora sta diventando una certezza. Al suo primo anno di Serie A 5 bonus sono un buon bottino, in più è andato praticamente sempre a voto. Fisicità e tecnica, con i suoi 188 cm di altezza può rendersi pericoloso in fase offensiva. Il bottino di bonus può aumentare nella nuova stagione, specialmente se Runjaic lo schiererà più avanzato dopo l'addio di Thauvin. Può fare sia la seconda punta/trequartista che la mezzala.\n\n"
+      }
+    },
+    {
+      "nome": "FAGIOLI",
+      "team": "FIO",
+      "prezzi": {
+        "min": 2,
+        "max": 4,
+        "avg": 2.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 4,
+        "f": 5.75
+      },
+      "allPrices": {
+        "fantaboom_2025": 3,
+        "fantaclassic_2025": 4,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 2,
+        "fantaboom_2024": 3,
+        "fantaclassic_2024": 4,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 2
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 135,
+          "rating": 5.75
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 2,
+          "minutes": 1541,
+          "rating": 5.92
+        }
+      },
+      "notes": {
+        "comm": "Nicolò Fagioli proverà a imporsi definitivamente alla Fiorentina. Non ci è riuscito del tutto nei primi sei mesi, il bilancio al fantacalcio è stato di due assist e un gol arrivato all’ultima giornata. Con Pioli è un possibile titolare a centrocampo, dove c’è comunque un po’ di concorrenza. Centrocampista di qualità con visione di gioco e più assist che gol, resta una scelta low cost per l’asta."
+      }
+    },
+    {
+      "nome": "FOFANA Y.",
+      "team": "MIL",
+      "prezzi": {
+        "min": 1,
+        "max": 3,
+        "avg": 2.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 5,
+        "f": 5.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 3,
+        "fantaclassic_2025": 3,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 3,
+        "fantaclassic_2024": 3,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 180,
+          "rating": 5.5
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 6,
+          "minutes": 2509,
+          "rating": 6.03
+        }
+      },
+      "notes": {
+        "comm": "Youssouf Fofana ha fatto una buona prima stagione in Italia, specialmente considerando le difficoltà del Milan. Più alto del previsto il numero di assist, ben 6. Solo un gol ma era da mettere in preventivo, non è un goleador. Può essere utile anche ad Allegri, resta ancora da capire la composizione esatta del suo centrocampo. Il francese può essere ancora utile al fantacalcio, ma comunque per gli ultimi slot."
+      }
+    },
+    {
+      "nome": "LOVRIC",
+      "team": "UDI",
+      "prezzi": {
+        "min": 2,
+        "max": 5,
+        "avg": 3.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 4,
+        "f": 7.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 3,
+        "fantaclassic_2025": 3,
+        "profeta_2025": 5,
+        "sos_fanta_2025": 2,
+        "fantaboom_2024": 3,
+        "fantaclassic_2024": 3,
+        "profeta_2024": 5,
+        "sos_fanta_2024": 2
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 1,
+          "minutes": 61,
+          "rating": 6.5
+        },
+        "2024_25": {
+          "goals": 2,
+          "assists": 2,
+          "minutes": 2326,
+          "rating": 5.96
+        }
+      },
+      "notes": {
+        "comm": "Sandi Lovric è calato e non si è confermato dopo l’exploit del primo anno con 5 gol. Due anni fa ne ha fatto solo uno, l’anno scorso due. Lo sloveno si inserisce meno ed è diventato più un centrocampista che deve dare equilibrio alla squadra. Resta un giocatore importante per Runjaic e per l’Udinese, arriva da un'annata da titolare (35 partite a voto l’anno scorso), ma avrà più concorrenza e rischia di non avere più il posto garantito.\n\n"
+      }
+    },
+    {
+      "nome": "NICOLUSSI CAVIGLIA",
+      "team": "FIO",
+      "prezzi": {
+        "min": 1,
+        "max": 10,
+        "avg": 4.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 4,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 3,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 10,
+        "sos_fanta_2025": 3,
+        "fantaboom_2024": 3,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 10,
+        "sos_fanta_2024": 3
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 4,
+          "assists": 3,
+          "minutes": 2870,
+          "rating": 6.2
+        }
+      },
+      "notes": {
+        "comm": "Hans Nicolussi Caviglia è il nuovo regista della Fiorentina. Un gradito ritorno al fantacalcio, dopo che ha fatto 4 gol e 3 assist con il Venezia. Tra le sue specialità ci sono il tiro da fuori area e i calci piazzati. Potrà calciarne anche alla Fiorentina, nonostante la concorrenza. Anche in campo avrà più concorrenza rispetto al Venezia, dove era titolare fisso, ma giocherà spesso. È una scelta a basso costo interessante, qualche bonus potrà portarlo."
+      }
+    },
+    {
+      "nome": "TETE MORENTE",
+      "team": "LEC",
+      "prezzi": {
+        "min": 1,
+        "max": 3,
+        "avg": 2.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 5,
+        "f": 5.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 3,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 3,
+        "fantaboom_2024": 3,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 3
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 171,
+          "rating": 5.75
+        },
+        "2024_25": {
+          "goals": 3,
+          "assists": 2,
+          "minutes": 2029,
+          "rating": 5.87
+        }
+      },
+      "notes": {
+        "comm": "Tete Morente è ancora listato a centrocampo e questa è una notizia importante per il fantacalcio. 3 gol e 2 assist in 30 partite nella passata stagione, ora è arrivato Di Francesco e le gerarchie si azzerano sulle fasce. Non più posto fisso, dovrà guadagnarselo sul campo, ma comunque resta appetibile da centrocampista. Lo sarebbe stato meno da attaccante. Può essere un jolly low cost di provincia per il vostro reparto, siamo verso gli slot secondari."
+      }
+    },
+    {
+      "nome": "CAQUERET",
+      "team": "COM",
+      "prezzi": {
+        "min": 1,
+        "max": 3,
+        "avg": 2.0
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 3,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 2,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 3,
+        "fantaboom_2024": 2,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 3
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 12,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 2,
+          "assists": 4,
+          "minutes": 1097,
+          "rating": 6.34
+        }
+      },
+      "notes": {
+        "comm": "Maxence Caqueret è un centrocampista importante per il Como, lo ha fatto vedere nella passata stagione. Era arrivato a gennaio ed è riuscito a fare 2 gol e 3 partite in sole 16 partite a voto. Non è un mediano, ha qualità e doti di inserimento. Al Como è difficile essere considerati titolari fissi, perché c’è tanta concorrenza. Però il francese avrà sicuramente il suo spazio nelle rotazioni di Fabregas."
+      }
+    },
+    {
+      "nome": "CRISTANTE",
+      "team": "ROM",
+      "prezzi": {
+        "min": 1,
+        "max": 10,
+        "avg": 3.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 3,
+        "f": 6.25
+      },
+      "allPrices": {
+        "fantaboom_2025": 2,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 10,
+        "sos_fanta_2025": 2,
+        "fantaboom_2024": 2,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 10,
+        "sos_fanta_2024": 2
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 180,
+          "rating": 6.25
+        },
+        "2024_25": {
+          "goals": 4,
+          "assists": 3,
+          "minutes": 2047,
+          "rating": 6.2
+        }
+      },
+      "notes": {
+        "comm": "Bryan Cristante arriva da una buona stagione in termini numerici, perché ha portato a casa 4 gol e 3 assist. Nonostante questi bonus non è comunque molto considerato al fantacalcio, anche perché resta un mediano e non è sicuro di essere titolare fisso con Gasperini. Si giocherà il posto nei due centrocampisti centrali."
+      }
+    },
+    {
+      "nome": "ROVELLA",
+      "team": "LAZ",
+      "prezzi": {
+        "min": 1,
+        "max": 2,
+        "avg": 1.8
+      },
+      "stats": {
+        "t": 4,
+        "a": 4,
+        "i": 3,
+        "f": 6.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 2,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 2,
+        "fantaboom_2024": 2,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 2
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 1,
+          "minutes": 114,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 3,
+          "minutes": 2728,
+          "rating": 6.11
+        }
+      },
+      "notes": {
+        "comm": "Nicolò Rovella è il regista titolare della Lazio. Un giocatore con caratteristiche ben precise per il fantacalcio. Non è un goleador, questo è chiaro: nessuna rete alla Lazio in 74 partite. Può fare però qualche assist, 5 in due anni. E soprattutto gioca sempre. Utile come riserva a centrocampo, a un prezzo basso."
+      }
+    },
+    {
+      "nome": "AEBISCHER",
+      "team": "PIS",
+      "prezzi": {
+        "min": 1,
+        "max": 2,
+        "avg": 1.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 2,
+        "f": 5.75
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 180,
+          "rating": 5.75
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 728,
+          "rating": 5.77
+        }
+      },
+      "notes": {
+        "comm": "Michel Aebischer è un rinforzo di esperienza per il Pisa. Centrocampista centrale di ruolo naturale, è un jolly che può giocare dappertutto ed è molto duttile. Classe ’97, ha già esperienza in Serie A con il Bologna e troverà una maglia da titolare con Gilardino."
+      }
+    },
+    {
+      "nome": "BOLOCA",
+      "team": "SAS",
+      "prezzi": {
+        "min": 1,
+        "max": 5,
+        "avg": 2.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 3,
+        "f": 5.75
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 5,
+        "sos_fanta_2025": 2,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 5,
+        "sos_fanta_2024": 2
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 135,
+          "rating": 5.75
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 2696,
+          "rating": 6.0
+        }
+      },
+      "notes": {
+        "comm": "DanielBoloca era stato già apprezzato al fantacalcio come centrocampista di rendimento e affidabilità. Ora ha 26 anni ed è ancora più maturo, in Serie B ha portato anche diversi bonus (3 gol e 3 assist). Abbina qualità e quantità e va sempre a voto: è un buon low cost per il fanta."
+      }
+    },
+    {
+      "nome": "COULIBALY L.",
+      "team": "LEC",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.5
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 2,
+        "f": 6.25
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 173,
+          "rating": 6.25
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 0,
+          "minutes": 2678,
+          "rating": 5.96
+        }
+      },
+      "notes": {
+        "comm": "Lassana Coulibaly non è un giocatore da fantacalcio per caratteristiche perché è un mediano, ma può essere per portare un voto in una lega numerosa. Nella scorsa stagione è stato uno dei low cost con più voti, ben 37 su 38. Ha avuto anche la fanta-media del 6, con un gol."
+      }
+    },
+    {
+      "nome": "KARLSTROM",
+      "team": "UDI",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.8
+      },
+      "stats": {
+        "t": 5,
+        "a": 3,
+        "i": 4,
+        "f": 6.25
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 180,
+          "rating": 6.25
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 2,
+          "minutes": 3189,
+          "rating": 5.85
+        }
+      },
+      "notes": {
+        "comm": "Jesper Karlstrom è la classica riserva da ultimi slot al centrocampo. Non è un giocatore da fantacalcio, perché non porta bonus (solo 2 assist) e neanche voti alti (5,78). Però gioca sempre, 37 su 38 a voto l’anno scorso."
+      }
+    },
+    {
+      "nome": "KONÈ I.",
+      "team": "SAS",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 4,
+        "f": 3.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 79,
+          "rating": 4.5
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 829,
+          "rating": 4.5
+        }
+      },
+      "notes": {
+        "comm": "Ismael Koné è un nuovo rinforzo di casa Sassuolo. Centrocampista centrale classe 2002 di piede destro, si giocherà una maglia a centrocampo. Con una mediana a due avrebbe davanti giocatori come Thorstvedt e Boloca. Se invece Grosso opta per il 4-3-3 starebbe fuori Volpato e giocherebbe un centrocampista in più, che sarebbe Koné. Nell’ultima stagione ha giocato 8 gare col Marsiglia, prima di passare in prestito al Rennes (2 gol e 1 assist in 13 partite). Prima aveva giocato 42 gare in Championship con la maglia del Watford, con 4 gol e 3 assist. Giocatore più da rendimento che da bonus, positivo in chiave fanta il dato sui cartellini: solo un giallo nell’ultimo anno, solo 3 nella stagione col Watford. Si parlava molto bene di lui negli anni scorsi, non si è ancora confermato ma Sassuolo potrebbe essere la piazza giusta. Il giocatore c'è, deve solo venire fuori. Scommessa a prezzo molto basso, siamo sugli ultimi slot."
+      }
+    },
+    {
+      "nome": "MARIN M.",
+      "team": "PIS",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.5
+      },
+      "stats": {
+        "t": 4,
+        "a": 3,
+        "i": 5,
+        "f": 5.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 161,
+          "rating": 5.75
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 2556,
+          "rating": 6.0
+        }
+      },
+      "notes": {
+        "comm": "Opzioni per il centrocampo da voto e poco più, sono principalmente per leghe numerose dai 12 partecipanti in su."
+      }
+    },
+    {
+      "nome": "MASINI",
+      "team": "GEN",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 4,
+        "f": 6.25
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 180,
+          "rating": 6.25
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 0,
+          "minutes": 1544,
+          "rating": 6.06
+        }
+      },
+      "notes": {
+        "comm": "Patrizio Masini ha sorpreso tutti nella scorsa stagione. Vieira lo ha lanciato da titolare e non è più uscito dal campo. Alla fine ha chiuso con 18 partite a voto e un gol nella seconda parte di stagione. Ora vuole ricominciare come aveva finito, ovvero con una maglia da titolare al fantacalcio. Scelta molto low cost, poco da bonus."
+      }
+    },
+    {
+      "nome": "ORDONEZ C.",
+      "team": "PAR",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.5
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 3,
+        "f": 5.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 66,
+          "rating": 5.5
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 1129,
+          "rating": 5.5
+        }
+      },
+      "notes": {
+        "comm": "Christian Ordonez è un centrocampista centrale, arrivato al Parma in estate. È stato preso da Velez per una cifra importante, circa 8,5 milioni di euro. Soprannominato El Tractorcito, si tratta di un classe 2004 argentino alto 177 cm. Nel 2025 ha fatto 21 partite in totali, senza portare gol o assist. In carriera ha fatto solo un gol in 91 partite col Velez, dove è cresciuto. E 6 assist. Per il fanta non è quindi un centrocampista da bonus ma sarà un giovane talento che può essere una scommessa, soprattutto da leghe numerose o per chi ha le conferme."
+      }
+    },
+    {
+      "nome": "PERRONE",
+      "team": "COM",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 2,
+        "f": 5.75
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 123,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 3,
+          "minutes": 1859,
+          "rating": 5.94
+        }
+      },
+      "notes": {
+        "comm": "Maximo Perrone è diventato un giocatore del Como a titolo definitivo, la società ci punta. Fabregas lo vede come possibile regista titolare, ha caratteristiche uniche in rosa. Classico metronomo, di piede mancino, non è un giocatore da fantacalcio perché non ha gol nelle gambe, ha però portato tre assist l’anno scorso. "
+      }
+    },
+    {
+      "nome": "PIERRET",
+      "team": "LEC",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.5
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 2,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 8,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 1726,
+          "rating": 5.75
+        }
+      },
+      "notes": {
+        "comm": "Anche qui siamo in zona leghe numerose, ma non c’è il voto assicurato. Vedremo se dalla preseason arriverà qualche spunto o conferma ulteriore, per alcuni di loro occhio anche al mercato."
+      }
+    },
+    {
+      "nome": "PIOTROWSKI",
+      "team": "UDI",
+      "prezzi": {
+        "min": 1,
+        "max": 2,
+        "avg": 1.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 3,
+        "f": 5.75
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 86,
+          "rating": 5.75
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 1868,
+          "rating": 5.5
+        }
+      },
+      "notes": {
+        "comm": "Jakub Piotrowski è un nuovo acquisto dell’Udinese. Si tratta di un centrocampista centrale di 188 cm che abbina le sue fasi e ha spunti offensivi (può fare anche il trequartista), è arrivato dal Ludogorets per 3 milioni. Polacco classe ’97, vede la porta e ha buoni numeri. Tira anche qualche rigore ma non è uno specialista assoluto, in carriera 2 su 3 segnati. L’anno scorso ha segnato 6 gol in 20 partite di campionato, l’anno prima addirittura 11 in 27 partite più 4 in Conference. Molti gol arrivano di testa ma è bravo anche nel tiro da fuori. Non troppe ammonizioni, 3-4 a stagione. Solo un infortunio - di un mese - negli ultimi 2-3 anni. È anche nel giro della nazionale polacca con 2 gol in 12 partite. Runjaic lo aveva già allenato al Pogon Stettino nella stagione 2017/2018 (18 partite e 3 gol). Al fantacalcio è una scommessa interessante come low cost, può aspirare a una maglia da titolare come mezzala."
+      }
+    },
+    {
+      "nome": "PRATI",
+      "team": "CAG",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.5
+      },
+      "stats": {
+        "t": 4,
+        "a": 3,
+        "i": 3,
+        "f": 6.25
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 126,
+          "rating": 6.25
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 579,
+          "rating": 5.85
+        }
+      },
+      "notes": {
+        "comm": "Opzioni per il centrocampo da voto e poco più, sono principalmente per leghe numerose dai 12 partecipanti in su."
+      }
+    },
+    {
+      "nome": "SERDAR",
+      "team": "VER",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 3,
+        "f": 7.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 1,
+          "assists": 0,
+          "minutes": 172,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 2,
+          "assists": 1,
+          "minutes": 1377,
+          "rating": 5.79
+        }
+      },
+      "notes": {
+        "comm": "Opzioni per il centrocampo da voto e poco più, sono principalmente per leghe numerose dai 12 partecipanti in su."
+      }
+    },
+    {
+      "nome": "ZHEGROVA",
+      "team": "JUV",
+      "prezzi": {
+        "min": 17,
+        "max": 23,
+        "avg": 21.0
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 2,
+        "f": null
+      },
+      "allPrices": {
+        "fantaboom_2025": 22,
+        "fantaclassic_2025": 23,
+        "profeta_2025": 17,
+        "sos_fanta_2025": 22,
+        "fantaboom_2024": 22,
+        "fantaclassic_2024": 23,
+        "profeta_2024": 17,
+        "sos_fanta_2024": 22
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 4,
+          "assists": 1,
+          "minutes": 985,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Edon Zhegrova fa il suo ingresso nel listone al fantacalcio e prende subito appeal perché è centrocampista. Di fatto è l’alter ego di Conceicao, il suo “clone”: classe ’99, si tratta di un’ala destra. È mancino e tende ad accentrarsi, è molto, molto abile nel dribbling. È alto 180 cm ma ha il baricentro basso, tiene il pallone incollato al piede e cerca sempre l’uno contro uno. Non è un esterno da doppia cifra, in carriera il suo record di gol è stato 6 in Ligue 1 nel 2023-24 con 6 assist. L’anno scorso 12 partite di campionato con 4 gol. Attenzione agli infortuni, perché non gioca una partita dal 14 dicembre. Da lì in poi è iniziato il suo calvario, si è operato la pubalgia. Nelle scorse settimane è tornato in gruppo ma non è ancora al 100% e non hai mai giocato anche per ragioni di mercato. Servirà dunque un po’ di tempo per tornare in condizione, Conceicao parte sicuramente avanti e il kosovaro sarà inizialmente un jolly. Anche al fantacalcio si posiziona dunque tra i jolly delle big, un giocatore che avrà minutaggio sfruttando anche il turnover e sarà da mettere a prescindere. Poi alla lunga sfiderà Conceicao per una maglia da titolare, anche se in quel ruolo, da trequartista di destra nel 3-4-2-1, ci sarà continua alternanza viste le tante partite e l’alto dispendio di energia. Fare la coppia è da escludere, visto il costo di entrambi. Per quanto riguarda gli infortuni, anche prima della pubalgia, negli scorsi anni, aveva avuto qualche stop. Non molti i cartellini, un rosso diretto due anni e 2-3 ammonizioni a stagione. Non è un rigorista, solo uno segnato in carriera. Può essere però un’alternativa per i calci piazzati."
+      }
+    },
+    {
+      "nome": "SAMARDZIC",
+      "team": "ATA",
+      "prezzi": {
+        "min": 9,
+        "max": 17,
+        "avg": 12.0
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 5,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 17,
+        "fantaclassic_2025": 9,
+        "profeta_2025": 12,
+        "sos_fanta_2025": 10,
+        "fantaboom_2024": 17,
+        "fantaclassic_2024": 9,
+        "profeta_2024": 12,
+        "sos_fanta_2024": 10
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 11,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 2,
+          "assists": 0,
+          "minutes": 1149,
+          "rating": 6.09
+        }
+      },
+      "notes": {
+        "comm": "Lazar Samardzic l’anno scorso ha trovato meno spazio del previsto con Gasperini all’Atalanta. 2 gol in 28 partite a voto, 0 assist e 3 ammonizioni. Può cambiare la musica con Juric, la sensazione è che possa trovare maggior spazio, a volte da titolare e altre a gara in corso. Può incidere col suo mancino, anche coi calci piazzati. Vuole riscattarsi dopo il cambio in panchina, per il fanta si può prendere a condizioni più vantaggiose rispetto alla scorsa asta, dove era maggiormente in hype.\n\n"
+      }
+    },
+    {
+      "nome": "BAILEY",
+      "team": "ROM",
+      "prezzi": {
+        "min": 9,
+        "max": 14,
+        "avg": 12.0
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 1,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 12,
+        "fantaclassic_2025": 14,
+        "profeta_2025": 13,
+        "sos_fanta_2025": 9,
+        "fantaboom_2024": 12,
+        "fantaclassic_2024": 14,
+        "profeta_2024": 13,
+        "sos_fanta_2024": 9
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 1151,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Leon Bailey è un nuovo giocatore della Roma di Gasperini. Classe 1997, è mancino di piede ma a differenza di Dybala e Soulé, può giocare anche a sinistra ed è stato preso proprio per agire sul centro-sinistra alle spalle della punta, nel 3-4-2-1 ormai noto del nuovo allenatore giallorosso. Arriva dall’Aston Villa, è un nazionale giamaicano che ha collezionato 7 gol in 39 partite. Calcisticamente è esploso nel Genk, prima di passare al Bayer Leverkusen nel 2017 e poi nel 2021 all’Aston Villa. Grande velocità, tecnica e dribbling, sono queste le principali caratteristiche di Bailey, che arriva per dare ulteriore imprevedibilità alla Roma in attacco. 377 partite in carriera, 76 gol e 68 assist, vanta 13 presenze in Champions, 27 in Europa League e 11 in Conference, è un giocatore di livello internazionale. 1 gol e 2 assist in 24 partite di Premier League nell’ultima stagione, non ai suoi livelli. La migliore è quella 23/24: 10 gol e 9 assist in 35 gare di Premier. 44 gialli in carriera (non pochi per un esterno offensivo), 3 rossi (ma l’ultimo nel lontano 2019/20). 4 rigori segnati e 2 sbagliati, la Roma ha grandi specialisti (Dybala su tutti, ma non è il solo) e quindi è molto difficile che si candidi. Ha segnato 3 gol su punizione in carriera, ma anche qui c’è Paulo e dunque se in campo va la Joya, anche per i corner col mancino naturalmente. Dal punto di vista degli infortuni parte subito male perché ha avuto uno stop al primo allenamento. Nell’ultima stagione aveva saltato 12 gare. In generale, qualche problema fisico lo ha sempre avuto, il più grave nel 2021/22: due problemi alla coscia e un infortunio ai legamenti lo hanno tenuto ai box per 31 gare. Occhio dunque agli infortuni. È una cosa che condiziona molto e che ha fatto rimanere molto basso il suo prezzo. Non starà fuori troppo a lungo, ma tornerà solo a fine settembre. Per questo parte come jolly, aspettando di essere al 100% e poi di conquistarsi spazio anche da titolare. E anche perché il suo prezzo nelle aste non sale, quindi si può prendere da occasione.\n"
+      }
+    },
+    {
+      "nome": "FRATTESI",
+      "team": "INT",
+      "prezzi": {
+        "min": 8,
+        "max": 12,
+        "avg": 10.0
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 4,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 12,
+        "fantaclassic_2025": 8,
+        "profeta_2025": 10,
+        "sos_fanta_2025": 10,
+        "fantaboom_2024": 12,
+        "fantaclassic_2024": 8,
+        "profeta_2024": 10,
+        "sos_fanta_2024": 10
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 5,
+          "assists": 1,
+          "minutes": 1222,
+          "rating": 6.02
+        }
+      },
+      "notes": {
+        "comm": "DavideFrattesi, da quando è all’Inter, è un grande punto interrogativo al fantacalcio. Un jolly che in linea di massima va messo a prescindere ma che non è non facile da utilizzare. Il rapporto tra minuti giocati e bonus resta ottimo, anche se tra alti e bassi non è mai riuscito a imporsi da titolare fisso. Quando gioca, però, spesso lascia il segno. Con Chivu può cambiare qualcosa nelle gerarchie e spera di trovare più continuità. Se avrà il giusto spazio potrà diventare uno dei centrocampisti più prolifici del campionato, si inserisce come pochi. Ai blocchi di partenza comunque parte ancora da jolly, con lo stesso status degli anni scorsi."
+      }
+    },
+    {
+      "nome": "ELMAS",
+      "team": "NAP",
+      "prezzi": {
+        "min": 3,
+        "max": 15,
+        "avg": 8.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 2,
+        "f": null
+      },
+      "allPrices": {
+        "fantaboom_2025": 10,
+        "fantaclassic_2025": 3,
+        "profeta_2025": 15,
+        "sos_fanta_2025": 7,
+        "fantaboom_2024": 10,
+        "fantaclassic_2024": 3,
+        "profeta_2024": 15,
+        "sos_fanta_2024": 7
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 4,
+          "assists": 0,
+          "minutes": 1025,
+          "rating": 6.12
+        }
+      },
+      "notes": {
+        "comm": "Eljif Elmas torna al Napoli dopo i sei mesi positivi al Torino, dove ha messo a segno 4 gol in 13 presenze. In Germania non ha inciso (un solo assist in un anno), ma in Serie A ha già dimostrato di essere un jolly prezioso: nella stagione 2022/23 con il Napoli aveva raccolto 36 presenze con 6 gol e 3 assist. Con Conte sarà di nuovo un’arma duttile: può giocare da trequartista alle spalle della punta, da ala sinistra oppure da mezzala offensiva. Non parte come titolare fisso, ma sarà inserito stabilmente nelle rotazioni e avrà minutaggio anche a gara in corso. In chiave fantacalcio resta un profilo appetibile, soprattutto se preso al prezzo giusto: non garantisce continuità da titolare, ma i suoi numeri dicono che può portare bonus anche senza giocare sempre dall’inizio. Il classico jolly da bonus."
+      }
+    },
+    {
+      "nome": "FAZZINI",
+      "team": "FIO",
+      "prezzi": {
+        "min": 2,
+        "max": 15,
+        "avg": 7.0
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 2,
+        "f": 6.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 9,
+        "fantaclassic_2025": 2,
+        "profeta_2025": 15,
+        "sos_fanta_2025": 2,
+        "fantaboom_2024": 9,
+        "fantaclassic_2024": 2,
+        "profeta_2024": 15,
+        "sos_fanta_2024": 2
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 30,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 4,
+          "assists": 1,
+          "minutes": 1393,
+          "rating": 6.42
+        }
+      },
+      "notes": {
+        "comm": "Jacopo Fazzini vuole consacrarsi alla Fiorentina. C’erano grandi aspettative a inizio stagione, ma le ha rispettate solo in parte, nel finale di stagione. Annata molto deludente fino alla 32a giornata, tra infortuni, assenze e un’espulsione alla 30a. Qualche buon voto e due 7 in pagella ma fin lì era a 0 bonus. Poi la svolta improvvisa alla 33a giornata, ha chiuso il campionato con 4 gol e 1 assist in 6 partite. E un po’ di questo hype finale rimarrà. Anche se alla Fiorentina ha l’incognita della titolarità e in più ci sarà anche la Conference, questo vuol dire più ballottaggi e sempre il rischio infortuni (solo 20 partite a voto l’anno scorso). Però a Pioli piace e può essere da bonus dopo essersi sbloccato a fine stagione."
+      }
+    },
+    {
+      "nome": "PASALIC",
+      "team": "ATA",
+      "prezzi": {
+        "min": 8,
+        "max": 15,
+        "avg": 12.0
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 3,
+        "f": 8.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 8,
+        "fantaclassic_2025": 10,
+        "profeta_2025": 15,
+        "sos_fanta_2025": 15,
+        "fantaboom_2024": 8,
+        "fantaclassic_2024": 10,
+        "profeta_2024": 15,
+        "sos_fanta_2024": 15
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 1,
+          "assists": 1,
+          "minutes": 161,
+          "rating": 6.5
+        },
+        "2024_25": {
+          "goals": 3,
+          "assists": 2,
+          "minutes": 1969,
+          "rating": 5.91
+        }
+      },
+      "notes": {
+        "comm": "Mario Pasalic non ha mantenuto le aspettative nell’ultima stagione, con pochi bonus (3 gol e 2 assist) e un rendimento lontano da quello che l’aveva reso un jolly prezioso al fantacalcio. Quest’anno, con l’Atalanta in piena rivoluzione e l’arrivo di Juric, può ritagliarsi un ruolo importante grazie alla sua duttilità: trequartista, falso 9 o centrale di centrocampo. L’hype era calato, ma il gol a Parma alla seconda ha riacceso i riflettori sul croato e soprattutto l'infortunio di Ederson che starà fuori per tutto settembre. Può essere interessante, ma dipende sempre dalle condizioni visto che non ha il posto fisso garantito."
+      }
+    },
+    {
+      "nome": "SUCIC P.",
+      "team": "INT",
+      "prezzi": {
+        "min": 8,
+        "max": 19,
+        "avg": 14.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 4,
+        "f": 6.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 8,
+        "fantaclassic_2025": 19,
+        "profeta_2025": 15,
+        "sos_fanta_2025": 15,
+        "fantaboom_2024": 8,
+        "fantaclassic_2024": 19,
+        "profeta_2024": 15,
+        "sos_fanta_2024": 15
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 1,
+          "minutes": 152,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 1,
+          "minutes": 1880,
+          "rating": 7.0
+        }
+      },
+      "notes": {
+        "comm": "Petar Sucic rinforza la mediana dell’Inter ed è una delle sorprese di inizio campionato. Si tratta di un centrocampista centrale croato, è un classe 2003 e può fare sia la mezzala che il regista. Arriva dalla Dinamo Zagabria, club con cui ha già accumulato esperienza anche a livello europeo. Nella scorsa stagione ha collezionato 33 presenze con 7 gol e 4 assist, dimostrando buona qualità sia in fase di costruzione che in zona offensiva. È un centrocampista duttile e di rendimento, ha un'ottima predisposizione agli assist. Il suo valore si impenna dopo l'avvio di campionato, ora andrà pagato molto di più ma comunque valere la spesa perché ha ancora margini."
+      }
+    },
+    {
+      "nome": "MANDRAGORA",
+      "team": "FIO",
+      "prezzi": {
+        "min": 4,
+        "max": 10,
+        "avg": 6.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 3,
+        "f": 8.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 7,
+        "fantaclassic_2025": 4,
+        "profeta_2025": 10,
+        "sos_fanta_2025": 6,
+        "fantaboom_2024": 7,
+        "fantaclassic_2024": 4,
+        "profeta_2024": 10,
+        "sos_fanta_2024": 6
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 1,
+          "assists": 0,
+          "minutes": 111,
+          "rating": 6.5
+        },
+        "2024_25": {
+          "goals": 4,
+          "assists": 4,
+          "minutes": 1941,
+          "rating": 6.19
+        }
+      },
+      "notes": {
+        "comm": "Rolando Mandragora è reduce dalla sua miglior stagione, sia per continuità che per numeri in zona bonus. Nel centrocampo della Fiorentina è un punto fermo e il suo mancino è spesso decisivo: calcia punizioni, angoli e può andare anche dal dischetto. Se riuscirà a evitare gli infortuni (il suo punto debole) ha tutto per confermarsi anche sotto la guida di Stefano Pioli. Occhio comunque alle rotazioni visto che la Fiorentina è impegnata in Conference.\n\n"
+      }
+    },
+    {
+      "nome": "EL SHAARAWY",
+      "team": "ROM",
+      "prezzi": {
+        "min": 6,
+        "max": 10,
+        "avg": 7.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 2,
+        "f": 6.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 6,
+        "fantaclassic_2025": 7,
+        "profeta_2025": 10,
+        "sos_fanta_2025": 8,
+        "fantaboom_2024": 6,
+        "fantaclassic_2024": 7,
+        "profeta_2024": 10,
+        "sos_fanta_2024": 8
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 105,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 3,
+          "assists": 3,
+          "minutes": 1110,
+          "rating": 6.19
+        }
+      },
+      "notes": {
+        "comm": "Stephan El Shaarawy era e rimarrà un jolly nella Roma e al fantacalcio. 3 gol e 3 assist in 21 partite a voto, può ricoprire davvero tanti ruoli: esterno a tutta fascia sia a destra che a sinistra o alle spalle della punta. Titolare nelle prime due, la sensazione è che avrà spazio, a volte dall'inizio e altre a gara in corso. Va sfruttato nel modo giusto e può essere interessante anche al fanta, da jolly appunto. Questi giocatori spesso lasciano il segno nelle squadre di Gasperini, entrando dalla panchina."
+      }
+    },
+    {
+      "nome": "JASHARI",
+      "team": "MIL",
+      "prezzi": {
+        "min": 2,
+        "max": 7,
+        "avg": 4.0
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 2,
+        "f": 5.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 5,
+        "fantaclassic_2025": 7,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 2,
+        "fantaboom_2024": 5,
+        "fantaclassic_2024": 7,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 2
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 16,
+          "rating": 5.5
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 2766,
+          "rating": 5.5
+        }
+      },
+      "notes": {
+        "comm": "Ardon Jashari è partito male nella sua esperienza al Milan. Lo svizzero era stato il grande acquisto del centrocampo rossonero per 39 milioni bonus inclusi, ma un infortunio ora cambia tutto. Il centrocampista ha rimediato la frattura composta del perone, i tempi di recupero sono circa 2 mesi a partire dal 28 agosto. A questo punto diventa un rischio prenderlo al fantacalcio, può avere senso solo da ultimo slot in un reparto completo, diventa quindi un jolly che dovete potervi permettere di aspettare.\n"
+      }
+    },
+    {
+      "nome": "PELLEGRINI LO.",
+      "team": "ROM",
+      "prezzi": {
+        "min": 1,
+        "max": 5,
+        "avg": 2.5
+      },
+      "stats": {
+        "t": 1,
+        "a": 3,
+        "i": 3,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 5,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 2,
+        "fantaboom_2024": 5,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 2
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 2,
+          "assists": 1,
+          "minutes": 1632,
+          "rating": 5.68
+        }
+      },
+      "notes": {
+        "comm": "Lorenzo Pellegrini è in una fase calante al fantacalcio. Due anni fa aveva avuto un exploit con De Rossi, ma l’anno scorso ha fortemente deluso con soli 2 gol segnati. Il problema sono anche i voti, troppo bassi: la sua media coi bonus è stata del 5,88. Dopo questo flop l’hype è totalmente azzerato, anche perché inizia la stagione da infortunato. E così dopo anni da big finisce un po’ ai margini anche al fantacalcio, diventando un jolly. Vedremo se Gasperini riuscirà a rivitalizzarlo."
+      }
+    },
+    {
+      "nome": "SUSLOV",
+      "team": "VER",
+      "prezzi": {
+        "min": 0,
+        "max": 5,
+        "avg": 1.2
+      },
+      "stats": {
+        "t": 1,
+        "a": 3,
+        "i": 1,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 5,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 0,
+        "fantaboom_2024": 5,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 0
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 1,
+          "minutes": 2097,
+          "rating": 5.84
+        }
+      },
+      "notes": {
+        "comm": "Tomas Suslov si è infortunato gravemente a inizio stagione, rottura del crociato per lui. Tornerà solo da marzo 2026 in avanti, quindi non è il caso di puntarci al fantacalcio."
+      }
+    },
+    {
+      "nome": "FABBIAN",
+      "team": "BOL",
+      "prezzi": {
+        "min": 1,
+        "max": 5,
+        "avg": 3.0
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 4,
+        "f": 6.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 4,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 5,
+        "sos_fanta_2025": 2,
+        "fantaboom_2024": 4,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 5,
+        "sos_fanta_2024": 2
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 83,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 3,
+          "assists": 0,
+          "minutes": 1023,
+          "rating": 6.09
+        }
+      },
+      "notes": {
+        "comm": "Giovanni Fabbian resta un jolly nel Bologna. Italiano lo ha alternato con Odgaard sulla trequarti, raramente lo ha schierato anche in posizione più arretrata. Non un titolare fisso, tutt'altro. Ha infatti chiuso la scorsa stagione con 3 gol in 22 partite a voto (0 assist). La sensazione è che la gestione sarà simile: non un titolare ma un giocatore da rotazioni, da prendere come jolly a centrocampo all’asta. Dovete potervelo permettere in rosa, altrimenti meglio guardare altrove.\n"
+      }
+    },
+    {
+      "nome": "MALINOVSKYI",
+      "team": "GEN",
+      "prezzi": {
+        "min": 3,
+        "max": 5,
+        "avg": 3.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 2,
+        "f": 6.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 4,
+        "fantaclassic_2025": 3,
+        "profeta_2025": 5,
+        "sos_fanta_2025": 3,
+        "fantaboom_2024": 4,
+        "fantaclassic_2024": 3,
+        "profeta_2024": 5,
+        "sos_fanta_2024": 3
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 25,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 2,
+          "minutes": 383,
+          "rating": 6.33
+        }
+      },
+      "notes": {
+        "comm": "Ruslan Malinovskyi, causa lungo infortunio, si è visto solo in 9 partite a voto nella passata stagione, con 2 assist a referto. Se sta bene, è un giocatore in grado di fare la differenza nel Genoa. Si augura di averlo al top della condizione Vieira, che è pronto a schierarlo da titolare alle spalle della punta o da mezzala, a seconda dell’assetto scelto. Tutti i piazzati sono suoi col mancino, potrebbe diventare anche il primo rigorista della squadra dopo l’addio di Pinamonti. Se ritrova la continuità avuta all’Atalanta - la condizione fisica è il vero nodo -, per l’asta può essere una vera e propria rivelazione e si può prendere a prezzi ancora contenuti visti i numeri della passata stagione."
+      }
+    },
+    {
+      "nome": "RICCI S.",
+      "team": "MIL",
+      "prezzi": {
+        "min": 1,
+        "max": 4,
+        "avg": 2.0
+      },
+      "stats": {
+        "t": 2,
+        "a": 4,
+        "i": 3,
+        "f": 6.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 4,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 4,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 14,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 1,
+          "minutes": 2836,
+          "rating": 6.06
+        }
+      },
+      "notes": {
+        "comm": "Samuele Ricci sarà importante nel centrocampo del Milan. In una linea a tre può giocare bene da mediano davanti alla difesa, altrimenti da mezzala. Il classe 2001 prende appeal rispetto a quando era al Torino, è stato fortemente voluto dalla società rossonera e dal nuovo allenatore Allegri. Dovrà migliorare in zona bonus: 1 gol e 1 assist in 34 partite l’anno scorso. 1 gol e 0 assist l’anno prima, ha ampi margini di crescita da questo punto di vista anche se non è certo la sua specialità. Troppi cartellini nelle ultime due stagioni: 8 gialli e 1 rosso nel 2024/25, l’anno prima 6 gialli e 1 rosso. Dovrà migliorare anche sotto questo punto di vista. Ma il salto in una big può valorizzarlo. Punta a fare decisamente meglio in rossonero specialmente come voti: a oggi è sul quarto o quinto slot, il classico giocatore da 6/6,5 fisso che proverà ad arrivare almeno a 5 tra gol e assist."
+      }
+    },
+    {
+      "nome": "BALDANZI",
+      "team": "ROM",
+      "prezzi": {
+        "min": 1,
+        "max": 3,
+        "avg": 1.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 3,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 3,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 3,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 1,
+          "minutes": 848,
+          "rating": 6.0
+        }
+      },
+      "notes": {
+        "comm": "Tommaso Baldanzi resta un jolly in casa Roma. Lo status non cambia con Gasperini, che potrà schierarlo nei due trequartisti alle spalle della punta. Non parte come titolare, però sappiamo già dall’Atalanta che Gasp fa molte sostituzioni nei giocatori offensivi. L’anno scorso solo 21 partite a voto con un gol e un assist, può fare meglio."
+      }
+    },
+    {
+      "nome": "MESSIAS",
+      "team": "GEN",
+      "prezzi": {
+        "min": 1,
+        "max": 3,
+        "avg": 1.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 1,
+        "f": 5.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 3,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 3,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 30,
+          "rating": 5.5
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 1,
+          "minutes": 851,
+          "rating": 6.0
+        }
+      },
+      "notes": {
+        "comm": "Junior Messias ci riprova. Il brasiliano è rimasto al Genoa e cerca riscatto dopo una stagione molto travagliata per via degli infortuni. Al fantacalcio serve prudenza perché gli infortuni della passata stagione sono stati troppi. Se sta bene, può giocare in tutti e tre i ruoli della trequarti."
+      }
+    },
+    {
+      "nome": "ZIELINSKI",
+      "team": "INT",
+      "prezzi": {
+        "min": 1,
+        "max": 3,
+        "avg": 1.8
+      },
+      "stats": {
+        "t": 2,
+        "a": 3,
+        "i": 4,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 3,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 3,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 24,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 2,
+          "assists": 1,
+          "minutes": 984,
+          "rating": 5.98
+        }
+      },
+      "notes": {
+        "comm": "Piotr Zielinski ha deluso al suo primo anno all’Inter. Solo due gol in campionato, segnati entrambi nella stessa partita contro la Juventus. Poi tante panchine e infortuni. La situazione non dovrebbe cambiare troppo con l’arrivo di Chivu, sempre se resterà in nerazzurro."
+      }
+    },
+    {
+      "nome": "BRESCIANINI",
+      "team": "ATA",
+      "prezzi": {
+        "min": 1,
+        "max": 2,
+        "avg": 1.5
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 3,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 2,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 2,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 2,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 4,
+          "assists": 2,
+          "minutes": 1010,
+          "rating": 6.13
+        }
+      },
+      "notes": {
+        "comm": "Marco Brescianini è ancora un jolly in casa Atalanta. Non c’è un upgrade al fantacalcio, la situazione rimane la stessa da Gasperini a Juric. L’anno scorso 23 partite a voto con 4 gol e 2 assist. Continuerà a essere un centrocampista duttile che può far comodo nelle rotazioni, dall’inizio o a gara in corso. Sa portare bonus, ma il problema è lo spazio: è solo da ultimi slot."
+      }
+    },
+    {
+      "nome": "MCKENNIE",
+      "team": "JUV",
+      "prezzi": {
+        "min": 0,
+        "max": 2,
+        "avg": 1.5
+      },
+      "stats": {
+        "t": 2,
+        "a": 3,
+        "i": 3,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 2,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 2,
+        "fantaboom_2024": 2,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 2
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 2,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 2,
+          "assists": 3,
+          "minutes": 2320,
+          "rating": 5.94
+        }
+      },
+      "notes": {
+        "comm": "Weston McKennie è un jolly totale per la Juventus, capace di adattarsi a più ruoli, dal centrocampo alle fasce. Al fantacalcio è imprevedibile: può portare bonus quando meno te lo aspetti, ma non offre garanzie né sul minutaggio né sulla continuità. Non parte come titolare fisso per Tudor, ma sarà spesso coinvolto grazie alla sua duttilità. Va valutato con attenzione all’asta, può essere utile come jolly ma a un prezzo contenuto."
+      }
+    },
+    {
+      "nome": "POBEGA",
+      "team": "BOL",
+      "prezzi": {
+        "min": 0,
+        "max": 2,
+        "avg": 1.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 2,
+        "f": 5.25
+      },
+      "allPrices": {
+        "fantaboom_2025": 2,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 2,
+        "fantaboom_2024": 2,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 2
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 115,
+          "rating": 5.5
+        },
+        "2024_25": {
+          "goals": 2,
+          "assists": 2,
+          "minutes": 1178,
+          "rating": 6.05
+        }
+      },
+      "notes": {
+        "comm": "Tommaso Pobega è tornato al Bologna, questa volta per restarci. La sua stagione ha avuto alti e bassi, perché sono stati 2 i gol e 2 gli assist, ma altrettante le espulsioni. Come partite a voto non ha superato quota 20, poco più della metà. Nel Bologna c’è ancora tanta concorrenza e Italiano continuerà con le sue rotazioni, quindi ci si può aspettare una stagione simile, con magari qualche partita a voto in più e qualche cartellino in meno."
+      }
+    },
+    {
+      "nome": "ELLERTSSON",
+      "team": "GEN",
+      "prezzi": {
+        "min": 0,
+        "max": 15,
+        "avg": 4.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 5,
+        "f": 6.25
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 15,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 15,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 94,
+          "rating": 6.25
+        },
+        "2024_25": {
+          "goals": 2,
+          "assists": 2,
+          "minutes": 2480,
+          "rating": 6.01
+        }
+      },
+      "notes": {
+        "comm": "Mikael Ellertsson è arrivato al Genoa in estate, anche se era stato acquistato dal Venezia a gennaio. L’islandese è molto duttile, può fare il centrocampista centrale oppure giocare sulla fascia sinistra. La sua duttilità lo potrà far andare spesso a voto, non parte comunque come intoccabile al fanta e nel Genoa, è un nome da leghe numerose. Già ripetere i 2 gol e 2 assist dell’ultima stagione, con ben 35 partite a voto, sarebbe un buon risultato."
+      }
+    },
+    {
+      "nome": "ILIC",
+      "team": "TOR",
+      "prezzi": {
+        "min": 1,
+        "max": 2,
+        "avg": 1.2
+      },
+      "stats": {
+        "t": 2,
+        "a": 4,
+        "i": 2,
+        "f": 6.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 76,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 0,
+          "minutes": 921,
+          "rating": 5.91
+        }
+      },
+      "notes": {
+        "comm": "Ivan Ilic sembrava sul punto di partire a gennaio poi è rimasto al Torino. Chissà che non possa andare così anche in questo mercato estivo. Al momento è un punto interrogativo per l’asta, dovrà inquadrarlo Baroni che lo potrebbe schierare nei due di centrocampo."
+      }
+    },
+    {
+      "nome": "LUIS HENRIQUE",
+      "team": "INT",
+      "prezzi": {
+        "min": 1,
+        "max": 5,
+        "avg": 2.0
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 4,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 5,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 5,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 4,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 2620,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Luis Henrique è una novità per l’Inter, un jolly per le fasce. Classe 2001, è un esterno che arriva dal Marsiglia. In carriera nasce come ala destra, ma è molto duttile perché può giocare anche a sinistra e soprattutto può fare il quinto di centrocampo, ruolo che ha ricoperto con De Zerbi. Resta comunque molto più bravo in fase offensiva che in fase difensiva. Giocando anche da ala, questo va specificato, nell’ultima stagione ha fatto 7 gol e 8 assist in campionato. All’Inter in linea di massima fa il vice Dumfries a destra in un 3-5-2 o 3-4-2-1. Il problema al fantacalcio è che ha un ruolo nel listone diverso dall’olandese, quindi non si può fare la coppia. È dunque solo un jolly a centrocampo da ultimo slot, perde appeal per il fanta-ruolo."
+      }
+    },
+    {
+      "nome": "VECINO",
+      "team": "LAZ",
+      "prezzi": {
+        "min": 0,
+        "max": 2,
+        "avg": 1.0
+      },
+      "stats": {
+        "t": 2,
+        "a": 4,
+        "i": 2,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 2,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 2
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 2,
+          "assists": 3,
+          "minutes": 875,
+          "rating": 6.14
+        }
+      },
+      "notes": {
+        "comm": "Matias Vecino è un centrocampista da bonus, lo dicono i numeri. Nella scorsa stagione 2 gol e 3 assist in sole 18 partite a voto. Alla Lazio ha fatto anche il regista, ma si trova meglio da mezzala. Sarri lo conosce bene, lo potrà alternare nel ruolo di mezzala e potrà avere spazio. Occhio agli infortuni, negli anni qualche acciacco lo ha sempre avuto. "
+      }
+    },
+    {
+      "nome": "KOOPMEINERS",
+      "team": "JUV",
+      "prezzi": {
+        "min": 10,
+        "max": 24,
+        "avg": 16.0
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 3,
+        "f": 5.75
+      },
+      "allPrices": {
+        "fantaboom_2025": 24,
+        "fantaclassic_2025": 15,
+        "profeta_2025": 15,
+        "sos_fanta_2025": 10,
+        "fantaboom_2024": 24,
+        "fantaclassic_2024": 15,
+        "profeta_2024": 15,
+        "sos_fanta_2024": 10
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 61,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 3,
+          "assists": 4,
+          "minutes": 1997,
+          "rating": 5.98
+        }
+      },
+      "notes": {
+        "comm": "Teun Koopmeiners è in cerca di riscatto dopo una stagione a dir poco deludente. 3 gol e 4 assist in 28 partite a voto, questi i numeri, ma non dicono tutto: il Koopmeiners dell’Atalanta non si è mai visto alla Juve, neanche a livello di prestazioni. Proverà a riscattarsi, ma al momento non si può dire che sia un titolare, né in mediana né sulla trequarti. Nelle rotazioni di Tudor con le coppe troverà spazio, ma bisogna capire se tornerà il vero Koopmeiners oppure no. Sono cambiate completamente le condizioni per l’asta rispetto a un anno fa: non più un top, si prenderà a molto meno visto che non ha neanche il posto fisso garantito."
+      }
+    },
+    {
+      "nome": "GRONBAEK",
+      "team": "GEN",
+      "prezzi": {
+        "min": 7,
+        "max": 15,
+        "avg": 11.0
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 3,
+        "f": 5.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 15,
+        "fantaclassic_2025": 10,
+        "profeta_2025": 12,
+        "sos_fanta_2025": 7,
+        "fantaboom_2024": 15,
+        "fantaclassic_2024": 10,
+        "profeta_2024": 12,
+        "sos_fanta_2024": 7
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 60,
+          "rating": 5.5
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 813,
+          "rating": 5.5
+        }
+      },
+      "notes": {
+        "comm": "Albert Gronbaek è uno dei tanti fantasisti a disposizione di Patrick Vieira. Si tratta di un trequartista centrale, danese classe 2001, alto 181 cm. È nel giro della nazionale, dove ha fatto 6 partite e un gol. Di piede destro, può giocare anche sulla sinistra. Elemento utile per il 4-2-3-1 dell’allenatore, può ricoprire un doppio ruolo. Non parte come titolare fisso e c’è concorrenza, ma proverà a prendersi una maglia e si giocherà il posto. Nell’ultima stagione non bene al Southampton da gennaio in poi, solo 143 minuti in Premier. Aveva fatto un po’ meglio al Rennes con 2 gol in 16 partite. Però non si è ancora confermato nei top campionati dopo aver fatto molto bene al Bodo-Glimt per due stagioni (8 e 9 gol in campionato). Da centrocampista è una scommessa low cost.\n\n"
+      }
+    },
+    {
+      "nome": "ZANIOLO",
+      "team": "UDI",
+      "prezzi": {
+        "min": 7,
+        "max": 14,
+        "avg": 10.0
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 1,
+        "f": null
+      },
+      "allPrices": {
+        "fantaboom_2025": 14,
+        "fantaclassic_2025": 7,
+        "profeta_2025": 10,
+        "sos_fanta_2025": 9,
+        "fantaboom_2024": 14,
+        "fantaclassic_2024": 7,
+        "profeta_2024": 10,
+        "sos_fanta_2024": 9
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 2,
+          "assists": 1,
+          "minutes": 700,
+          "rating": 6.03
+        }
+      },
+      "notes": {
+        "comm": "Nicolò Zaniolo torna in Serie A e riparte dall’Udinese, dove potrà finalmente avere continuità di minutaggio. Lo scorso anno, dopo una prima parte a sprazzi all’Atalanta (14 presenze con 2 gol e 2 assist), ha avuto un’esperienza deludente alla Fiorentina (0 bonus in 9 presenze di campionato). Ora trova un contesto in cui, se sta bene, può essere titolare e centrale nel progetto di Runjaic. La duttilità è uno dei suoi punti di forza: può giocare seconda punta, ala destra o trequartista alle spalle delle punte, adattandosi a diversi moduli. Nel 3-5-2 attuale agisce da seconda punta. Resta l’incognita degli infortuni, storicamente il vero limite del suo percorso. Al fantacalcio il suo appeal cresce perché listato centrocampista e con la prospettiva di un ruolo offensivo. Come al solito non va strapagato all’asta, ma ormai anche i fantallenatori stanno avendo sempre meno fiducia in lui dopo le ultime delusioni. A un prezzo contenuto si può anche provare. "
+      }
+    },
+    {
+      "nome": "BATURINA",
+      "team": "COM",
+      "prezzi": {
+        "min": 7,
+        "max": 15,
+        "avg": 11.5
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 4,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 13,
+        "fantaclassic_2025": 11,
+        "profeta_2025": 15,
+        "sos_fanta_2025": 7,
+        "fantaboom_2024": 13,
+        "fantaclassic_2024": 11,
+        "profeta_2024": 15,
+        "sos_fanta_2024": 7
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 9,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 2376,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Martin Baturina è uno degli acquisti estivi del Como, tra i colpi migliori. La società lo ha pagato tanto, 17 milioni più 5 di bonus. E si aspetta tanto. Può fare sia la mezzala che il trequartista (sarebbe il suo ruolo naturale): la coesistenza con Nico Paz non è un problema, anche se nelle prime due non è andato a voto. È alto 172 cm, vede la porta e ha segnato 6 gol con 12 assist nell’ultima stagione alla Dinamo Zagabria. Solo 15 cartellini gialli in 180 partite in carriera (senza espulsioni) e soltanto 11 giorni saltati per infortunio l’anno scorso. Per i calci piazzati è un’opzione soprattutto per le punizioni, mentre all’asta siamo sul terzo slot. La sensazione è che già dopo la sosta il suo minutaggio potrà aumentare in modo graduale. "
+      }
+    },
+    {
+      "nome": "DELE-BASHIRU",
+      "team": "LAZ",
+      "prezzi": {
+        "min": 3,
+        "max": 10,
+        "avg": 8.0
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 4,
+        "f": 5.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 10,
+        "fantaclassic_2025": 9,
+        "profeta_2025": 10,
+        "sos_fanta_2025": 3,
+        "fantaboom_2024": 10,
+        "fantaclassic_2024": 9,
+        "profeta_2024": 10,
+        "sos_fanta_2024": 3
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 153,
+          "rating": 5.5
+        },
+        "2024_25": {
+          "goals": 3,
+          "assists": 1,
+          "minutes": 953,
+          "rating": 6.06
+        }
+      },
+      "notes": {
+        "comm": "Fisayo Dele-Bashiru ha fatto vedere nella scorsa stagione di avere potenzialità, ma non si è ancora adattato al 100% alla Serie A e ora riparte da zero con Sarri. Si giocherà un posto da mezzala a centrocampo, non è “sarriano” come caratteristiche ma ha fisicità e strappi. È un centrocampista potente e di grande corsa, in più vede la porta perché l’anno scorso ha segnato 3 gol in 17 presenze."
+      }
+    },
+    {
+      "nome": "BERNARDESCHI",
+      "team": "BOL",
+      "prezzi": {
+        "min": 2,
+        "max": 7,
+        "avg": 4.5
+      },
+      "stats": {
+        "t": 3,
+        "a": 2,
+        "i": 4,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 7,
+        "fantaclassic_2025": 2,
+        "profeta_2025": 5,
+        "sos_fanta_2025": 4,
+        "fantaboom_2024": 7,
+        "fantaclassic_2024": 2,
+        "profeta_2024": 5,
+        "sos_fanta_2024": 4
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 10,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 1301,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Federico Bernardeschi torna in Italia e a 31 anni cerca il rilancio nel Bologna. Dopo l’addio alla Juve, ha fatto tre anni e mezzo ai Toronto FC. Primo anno da 8 gol e 2 assist in 13 partite, era partito molto bene in metà stagione. Nel 2023 5 gol e 2 assist in 31 partite, nel 2024 8 gol e 6 assist in 29 presenze. L’ultimo anno - a metà - 4 gol e 3 assist in 15 partite. I bonus non sono mai mancati, ma il campionato è meno competitivo rispetto a quello italiano. C’è un dato un po’ particolare che emerge dai suoi anni in MLS: troppi cartellini e troppe giornate saltate per squalifica. Quattro cartellini rossi e 22 cartellini gialli in totale. In compenso però non ha mai avuto infortuni, se non proprio alla fine della sua avventura (fine maggio e giugno). Un infortunio lo ha avuto in preseason, ma è già tornato. Il rientro in Italia è sempre un rebus, c’è anche chi ha fatto molto bene dopo una parentesi estera di questo tipo (ad esempio Toni e Ibrahimovic). Occhio quindi a darlo per finito, può avere ancora qualcosa da dare e in più motivazioni aggiuntive dalla Nazionale. Con Italiano può giocare a destra, al centro o a sinistra nel 4-2-3-1. Non ha però il posto assicurato ed è un elemento jolly, sia al Bologna che al fantacalcio. Uno da tenere in slot secondari e schierare eventualmente a prescindere, non si paga nemmeno troppo e quindi può essere una scommessa."
+      }
+    },
+    {
+      "nome": "GAETANO",
+      "team": "CAG",
+      "prezzi": {
+        "min": 3,
+        "max": 10,
+        "avg": 5.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 1,
+        "f": 6.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 5,
+        "fantaclassic_2025": 3,
+        "profeta_2025": 10,
+        "sos_fanta_2025": 3,
+        "fantaboom_2024": 5,
+        "fantaclassic_2024": 3,
+        "profeta_2024": 10,
+        "sos_fanta_2024": 3
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 1,
+          "minutes": 41,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 2,
+          "assists": 4,
+          "minutes": 1003,
+          "rating": 6.04
+        }
+      },
+      "notes": {
+        "comm": "Gianluca Gaetano è una scommessa intrigante per il fantacalcio, anche se gli serve più continuità. Con Pisacane potrebbe avere più spazio rispetto alla scorsa stagione, anche subentrando dalla panchina. È un centrocampista con qualità offensive e bonus nelle gambe, come ha dimostrato anche in poche presenze. Prezzo basso, poco hype, ma potenziale interessante: può essere una mossa low cost da ultimi slot per chi cerca giocate decisive anche a gara in corso."
+      }
+    },
+    {
+      "nome": "SOTTIL",
+      "team": "LEC",
+      "prezzi": {
+        "min": 2,
+        "max": 5,
+        "avg": 3.0
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 2,
+        "f": 5.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 5,
+        "fantaclassic_2025": 3,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 2,
+        "fantaboom_2024": 5,
+        "fantaclassic_2024": 3,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 2
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 58,
+          "rating": 5.5
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 1,
+          "minutes": 952,
+          "rating": 5.95
+        }
+      },
+      "notes": {
+        "comm": "Riccardo Sottil ha un’altra occasione. L’esterno d’attacco ha lasciato la Fiorentina in prestito per cercare più spazio al Lecce. Anche qua però avrà concorrenza, perché ci sono molti esterni e l’idea di Di Francesco è di alternarli molto, anche a gara in corso. Sottil non sarà quindi titolare fisso ma andrà quasi sempre a voto. Listato centrocampista diventa un po’ più interessante, ma rimane comunque una scelta da ultimi slot e molto low cost. Al Milan aveva fatto poco o nulla, giocando pochissimo. Alla Fiorentina il suo record di gol era stato tre nel 2020-21. Ora, a 26 anni, deve dare un segnale."
+      }
+    },
+    {
+      "nome": "FADERA",
+      "team": "SAS",
+      "prezzi": {
+        "min": 2,
+        "max": 5,
+        "avg": 3.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 3,
+        "f": 5.75
+      },
+      "allPrices": {
+        "fantaboom_2025": 3,
+        "fantaclassic_2025": 5,
+        "profeta_2025": 5,
+        "sos_fanta_2025": 2,
+        "fantaboom_2024": 3,
+        "fantaclassic_2024": 5,
+        "profeta_2024": 5,
+        "sos_fanta_2024": 2
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 38,
+          "rating": 5.75
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 3,
+          "minutes": 1667,
+          "rating": 6.0
+        }
+      },
+      "notes": {
+        "comm": "Alieu Fadera è passato dal Como al Sassuolo per trovare maggior spazio. Il club neroverde ha scelto lui per sostituire Laurienté, che però al momento non è ancora partito (probabilmente lo farà presto). 1 gol e 3 assist in 24 partite a voto nella scorsa stagione, prima che arrivasse Diao. Fadera è in cerca di riscatto e ha scelto Sassuolo, sulla carta sarà titolare se andrà via Laurienté. Listato a centrocampo, giocherà come esterno offensivo: può essere interessante al fanta per questo motivo, come bug di listone low cost. Classe 2001, ha ancora margini di crescita importanti e può scalare posizioni."
+      }
+    },
+    {
+      "nome": "HELGASON",
+      "team": "LEC",
+      "prezzi": {
+        "min": 1,
+        "max": 3,
+        "avg": 1.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 4,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 3,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 3,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 9,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 4,
+          "minutes": 1157,
+          "rating": 6.03
+        }
+      },
+      "notes": {
+        "comm": "Thorir Helgason si è preso la scena con Giampaolo, ha chiuso la stagione con 4 assist in 17 partite. È stato importante nel finale di campionato, quando il Lecce ha conquistato la salvezza. Bisognerà capire quanto spazio avrà con Di Francesco, che inizialmente gli ha preferito altri giocatori. Per il fantacalcio rimane un jolly low cost a centrocampo, non ha il posto fisso e non è sempre facile lasciare il segno dalla panchina. Da ultimi slot, in un reparto già ben definito e come scommessina."
+      }
+    },
+    {
+      "nome": "ADOPO",
+      "team": "CAG",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.8
+      },
+      "stats": {
+        "t": 4,
+        "a": 3,
+        "i": 5,
+        "f": 6.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 180,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 1,
+          "minutes": 2417,
+          "rating": 5.87
+        }
+      },
+      "notes": {
+        "comm": "Si arriva ad altri low cost ma che possono essere utili più da leghe abbastanza numerose in su. Opzioni - molte in provincia - per chi cerca un voto sicuro o quasi ma senza troppe pretese in termini di bonus."
+      }
+    },
+    {
+      "nome": "BERISHA M.",
+      "team": "LEC",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 2,
+        "f": 5.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 86,
+          "rating": 5.5
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 1,
+          "minutes": 722,
+          "rating": 6.07
+        }
+      },
+      "notes": {
+        "comm": "Anche qui siamo in zona leghe numerose, ma non c’è il voto assicurato. Vedremo se dalla preseason arriverà qualche spunto o conferma ulteriore, per alcuni di loro occhio anche al mercato."
+      }
+    },
+    {
+      "nome": "FELICI",
+      "team": "CAG",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.5
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 4,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 3,
+          "minutes": 923,
+          "rating": 5.83
+        }
+      },
+      "notes": {
+        "comm": "Mattia Felici ha deluso le aspettative dei fantallenatori, illusi solo per poche partite in un momento positivo della stagione. Complessivamente però ha trovato poco spazio e pochi bonus nonostante quel buon periodo a metà campionato. Quest’anno potrebbe partire da titolare ma ci sarà sempre concorrenza. Rimane un profilo solo da ultimi slot."
+      }
+    },
+    {
+      "nome": "HARROUI",
+      "team": "VER",
+      "prezzi": {
+        "min": 0,
+        "max": 2,
+        "avg": 1.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 1,
+        "f": 5.75
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 2,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 2
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 69,
+          "rating": 5.75
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 2,
+          "minutes": 462,
+          "rating": 5.95
+        }
+      },
+      "notes": {
+        "comm": "Abdou Harroui arriva da una stagione condizionata dalla rottura del crociato. Soltanto 10 partite a voto, condite da un gol e 2 assist. Ora è tornato ed è a disposizione, però qualche dubbio sugli infortuni rimane data la sua fragilità vista in questi ultimi anni. Jolly dal centrocampo in su per Zanetti."
+      }
+    },
+    {
+      "nome": "ONDREJKA",
+      "team": "PAR",
+      "prezzi": {
+        "min": 1,
+        "max": 5,
+        "avg": 2.0
+      },
+      "stats": {
+        "t": 1,
+        "a": 4,
+        "i": 1,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 5,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 5,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 5,
+          "assists": 0,
+          "minutes": 428,
+          "rating": 6.35
+        }
+      },
+      "notes": {
+        "comm": "Jakob Ondrejka è stato protagonista nella scorsa stagione con 5 gol da gennaio in poi, ha avuto un grande impatto in Serie ed è stato decisivo nella salvezza del Parma. Inizia la stagione con un grave infortunio, si è infatti rotto il perone. Dovrebbe tornare a novembre, si può prendere da ultimo slot aspettando il suo ritorno in campo con pazienza."
+      }
+    },
+    {
+      "nome": "PAYERO",
+      "team": "CRE",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.5
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 3,
+        "f": 5.75
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 50,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 1,
+          "minutes": 1383,
+          "rating": 5.9
+        }
+      },
+      "notes": {
+        "comm": "Martin Payero è un rinforzo della Cremonese a centrocampo. Non è un profilo da fantacalcio, ma può essere utile per il voto in leghe numerose. Così come lo era all’Udinese, nulla di più."
+      }
+    },
+    {
+      "nome": "PICCININI G.",
+      "team": "PIS",
+      "prezzi": {
+        "min": 0,
+        "max": 2,
+        "avg": 1.0
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 5,
+        "f": 6.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 12,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 2333,
+          "rating": 6.0
+        }
+      },
+      "notes": {
+        "comm": "Gabriele Piccinini è un centrocampista centrale low cost dalle neopromosse. Ha fatto molto bene al Pisa nella scorsa stagione, con 4 gol e 6 assist. Classe 2001, è da tenere d’occhio per i suoi inserimenti: soluzione interessante specialmente per le leghe abbastanza numerose."
+      }
+    },
+    {
+      "nome": "PISILLI",
+      "team": "ROM",
+      "prezzi": {
+        "min": 0,
+        "max": 2,
+        "avg": 1.0
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 4,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 2,
+          "assists": 1,
+          "minutes": 1225,
+          "rating": 5.98
+        }
+      },
+      "notes": {
+        "comm": "Niccolò Pisilli è ancora molto giovane ed è pronto per esplodere. La Roma punta tantissimo su di lui e Gasperini, che lavora molto bene coi giovani, lo sta studiando. Nel suo 3-4-2-1 può giocare sia da mediano che nei due trequartisti alle spalle della punta. L’anno scorso 2 gol e 1 assist in 24 partite a voto, quest’anno può provare a raddoppiare il numero di bonus."
+      }
+    },
+    {
+      "nome": "SULEMANA I.",
+      "team": "BOL",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.5
+      },
+      "stats": {
+        "t": 2,
+        "a": 3,
+        "i": 4,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 2,
+          "assists": 0,
+          "minutes": 282,
+          "rating": 6.17
+        }
+      },
+      "notes": {
+        "comm": "Ibrahim Sulemena passa al Bologna. Il centrocampo aveva poco spazio all’Atalanta, nella scorsa stagione non aveva mai giocato se non per l’exploit finale (anche in zona gol). È un centrocampista centrale, perfetto per giocare nei due mediani del 4-2-3-1, può fare il vice Freuler o giocare al suo fianco. Sarà utile nelle rotazioni, non molto da fantacalcio."
+      }
+    },
+    {
+      "nome": "VENTURINO",
+      "team": "GEN",
+      "prezzi": {
+        "min": 0,
+        "max": 2,
+        "avg": 1.0
+      },
+      "stats": {
+        "t": 2,
+        "a": 4,
+        "i": 5,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 2,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 2
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 2,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 6.83
+        }
+      },
+      "notes": {
+        "comm": "Lorenzo Venturino si è preso la scena nel finale della scorsa stagione al Genoa. 2 gol in 3 partite a voto per il classe 2006, baby gioiello della squadra allenata da Vieira. Ha tutto per esplodere, è rimasto listato a centrocampo è questa è una notizia molto interessante per il fantacalcio. Intrigante scommessa, potete puntarci per gli ultimissimi slot. Non è un titolare fisso, ma Vieira l’ha lanciato già l’anno scorso e gli darà spazio anche in questa stagione. A volte dall’inizio, altre a gara in corso. Se poi giocate con le conferme, è un’occasione da non perdere."
+      }
+    },
+    {
+      "nome": "VOLPATO",
+      "team": "SAS",
+      "prezzi": {
+        "min": 0,
+        "max": 2,
+        "avg": 1.0
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 3,
+        "f": 7.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 2,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 2
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 1,
+          "minutes": 45,
+          "rating": 6.5
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 728,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Cristian Volpato è una variabile impazzita nel Sassuolo. Di ruolo è trequartista, può giocare da titolare in caso di 4-2-3-1 oppure essere un jolly per le fasce nel 4-3-3. In Serie B ha fatto 4 gol e 6 assist, è del 2003 e ha ancora margini di crescita. Deve migliorare sotto diversi punti di vista, ad esempio sono troppi per un giocatore col suo ruolo 4 cartellini gialli e uno rosso. Non è titolare fisso, l’anno scorso solo 9 dall’inizio."
+      }
+    },
+    {
+      "nome": "CORNET",
+      "team": "GEN",
+      "prezzi": {
+        "min": 0,
+        "max": 15,
+        "avg": 4.5
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 3,
+        "f": null
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 15,
+        "sos_fanta_2025": 2,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 15,
+        "sos_fanta_2024": 2
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 2,
+          "assists": 1,
+          "minutes": 242,
+          "rating": 6.08
+        }
+      },
+      "notes": {
+        "comm": "Maxwel Cornet è tornato al Genoa. Nei sei mesi dello scorso campionato aveva fatto bene dal punto di vista dei bonus, ovvero 2 gol e 1 assist in 6 partite, ma era stato preoccupante dal punto di vista degli infortuni. Dalla 29a giornata in avanti non ha più preso voto, subentrando dall’82’ dell’ultima giornata. Si porta dunque dietro questa fragilità, sperando che quest’anno riesca ad avere una maggiore continuità. Se sta bene, può avere spazio e anche portare dei bonus."
+      }
+    },
+    {
+      "nome": "LORRAN",
+      "team": "PIS",
+      "prezzi": {
+        "min": 0,
+        "max": 8,
+        "avg": 2.5
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 5,
+        "f": null
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 8,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 8,
+        "sos_fanta_2024": 1
       },
       "performance": {
         "2025_26": {
@@ -9292,11 +15999,6397 @@
           "goals": 0,
           "assists": 0,
           "minutes": 0,
-          "rating": 0
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Lorran è il nuovo jolly del Pisa, arrivato dal Flamengo in prestito con obbligo di riscatto a 4 milioni: un investimento importante per un classe 2006. Trequartista mancino, può giocare anche da esterno destro rientrando sul piede forte e nello scacchiere di Gilardino sarà impiegato nei due trequartisti dietro la punta. Ha già collezionato 36 presenze col Flamengo (2 gol e 3 assist), numeri interessanti per la sua età. Al fantacalcio è una scommessa solo da ultimo slot, più per chi ha le conferme: listato centrocampista, può sorprendere in futuro se si adatterà bene alla Serie A, ma serve pazienza e fiducia in un talento ancora tutto da scoprire e con margini di crescita."
+      }
+    },
+    {
+      "nome": "ADZIC",
+      "team": "JUV",
+      "prezzi": {
+        "min": 0,
+        "max": 0,
+        "avg": 0.0
+      },
+      "stats": {
+        "t": 0,
+        "a": 0,
+        "i": 0,
+        "f": 0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 0,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 0
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 50,
+          "rating": 6.0
         }
       },
       "notes": {
         "comm": ""
+      }
+    },
+    {
+      "nome": "AKINSANMIRO",
+      "team": "PIS",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 4,
+        "f": 6.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 28,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 1519,
+          "rating": 6.0
+        }
+      },
+      "notes": {
+        "comm": "Ebenezer Akinsamiro è una soluzione per il centrocampo del Pisa, si è mosso bene in preseason e prova a prendersi una maglia da titolare. Classe 2004, nigeriano, è alto 184 cm ed è cresciuto nell’Inter. Centrocampista centrale bravo nelle due fasi, l’anno scorso un gol e un assist alla Sampdoria in Serie B."
+      }
+    },
+    {
+      "nome": "AL-MUSRATI",
+      "team": "VER",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.5
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 3,
+        "f": 5.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 5.5
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 0,
+          "minutes": 1177,
+          "rating": 5.5
+        }
+      },
+      "notes": {
+        "comm": "Moatasem Al-Musrati è un nuovo centrocampista del Verona. Si tratta di un mediano di 29 anni, è alto 189 cm e ha grande fisicità. È un punto fermo della nazionale della Libia. Le sue ultime esperienze sono state in Monaco e Besiktas, dove non era titolare. Era venuto fuori al Braga, dove aveva segnato anche 3 gol a stagione. Non sarà titolare fisso all’Hellas, ma si giocherà una maglia a centrocampo cercando il riscatto. Opzione solo da leghe molto numerose."
+      }
+    },
+    {
+      "nome": "BASIC",
+      "team": "LAZ",
+      "prezzi": {
+        "min": 0,
+        "max": 0,
+        "avg": 0.0
+      },
+      "stats": {
+        "t": 0,
+        "a": 0,
+        "i": 0,
+        "f": 0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 0,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 0
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Sono opzioni da escludere, meglio evitare questi centrocampisti al fantacalcio."
+      }
+    },
+    {
+      "nome": "BELAHYANE",
+      "team": "LAZ",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.2
+      },
+      "stats": {
+        "t": 2,
+        "a": 4,
+        "i": 5,
+        "f": 7.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 1,
+          "minutes": 12,
+          "rating": 6.5
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 2,
+          "minutes": 1848,
+          "rating": 5.77
+        }
+      },
+      "notes": {
+        "comm": "Anche qui siamo in zona leghe numerose, ma non c’è il voto assicurato. Vedremo se dalla preseason arriverà qualche spunto o conferma ulteriore, per alcuni di loro occhio anche al mercato."
+      }
+    },
+    {
+      "nome": "BERNEDE",
+      "team": "VER",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 3,
+        "f": 5.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 160,
+          "rating": 5.5
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 0,
+          "minutes": 598,
+          "rating": 5.79
+        }
+      },
+      "notes": {
+        "comm": "Anche qui siamo in zona leghe numerose, ma non c’è il voto assicurato. Vedremo se dalla preseason arriverà qualche spunto o conferma ulteriore, per alcuni di loro occhio anche al mercato."
+      }
+    },
+    {
+      "nome": "BONDO",
+      "team": "CRE",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 3,
+        "f": 5.75
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 101,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 1785,
+          "rating": 5.91
+        }
+      },
+      "notes": {
+        "comm": "Warren Bondo si è trasferito alla Cremonese. Al fantacalcio è un mediano, uno da pochi bonus. Zero nella scorsa stagione, al Monza e poi al Milan dove non ha quasi mai giocato. Più malus che bonus: 4 gialli e un rosso. Alla Cremonese almeno giocherà, andrà quasi sempre a voto e dovrebbe avere una maglia in mediana, Nicola apprezza i giocatori quantità in mezzo al campo. Soluzione estremamente low cost per l’asta."
+      }
+    },
+    {
+      "nome": "CATALDI",
+      "team": "LAZ",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 2,
+        "f": 5.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 66,
+          "rating": 5.0
+        },
+        "2024_25": {
+          "goals": 3,
+          "assists": 0,
+          "minutes": 1724,
+          "rating": 6.04
+        }
+      },
+      "notes": {
+        "comm": "Anche qui siamo in zona leghe numerose, ma non c’è il voto assicurato. Vedremo se dalla preseason arriverà qualche spunto o conferma ulteriore, per alcuni di loro occhio anche al mercato."
+      }
+    },
+    {
+      "nome": "CREMASCHI",
+      "team": "PAR",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.2
+      },
+      "stats": {
+        "t": 1,
+        "a": 3,
+        "i": 4,
+        "f": null
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 2,
+          "minutes": 1388,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Benja Cremaschi è il nuovo acquisto a centrocampo del Parma. Classe 2005, arriva in prestito dall’Inter Miami dove, nonostante la giovane età, ha già collezionato 107 presenze con 8 gol e 9 assist, condividendo lo spogliatoio con campioni come Messi e Suarez. È un centrocampista centrale tecnico e duttile, capace di giocare anche sulla trequarti o da esterno. Al Parma entrerà nelle rotazioni in mezzo al campo, ma dovrà conquistarsi minutaggio in un contesto più competitivo come la Serie A. In ottica fantacalcio resta una scommessa: giovane, interessante e con potenziale, ma da prendere solo come ultimi slot.\n\n"
+      }
+    },
+    {
+      "nome": "DEIOLA",
+      "team": "CAG",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 2,
+        "i": 5,
+        "f": 6.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 164,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 2,
+          "assists": 1,
+          "minutes": 1446,
+          "rating": 5.98
+        }
+      },
+      "notes": {
+        "comm": "Opzioni per il centrocampo da voto e poco più, sono principalmente per leghe numerose dai 12 partecipanti in su."
+      }
+    },
+    {
+      "nome": "DIOUF",
+      "team": "INT",
+      "prezzi": {
+        "min": 0,
+        "max": 3,
+        "avg": 1.5
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 5,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 3,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 3
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 11,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 2240,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Andy Diouf è il centrocampista che cercava l’Inter, che necessitava di caratteristiche diverse per il reparto. Il francese, classe 2003, è un giocatore che ha conduzione di palla e dribbling, non è un incontrista. Non porta però molti bonus, solo due gol e due assist negli ultimi due campionati con il Lens. Non è quindi molto da fantacalcio come profilo, perché non ha neanche il posto fisso giocando in una big. Però può essere un buon jolly, qualcosa di diverso nell’Inter."
+      }
+    },
+    {
+      "nome": "ESTEVEZ",
+      "team": "PAR",
+      "prezzi": {
+        "min": 0,
+        "max": 0,
+        "avg": 0.0
+      },
+      "stats": {
+        "t": 0,
+        "a": 0,
+        "i": 0,
+        "f": 0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 0,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 0
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 3,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 664,
+          "rating": 5.79
+        }
+      },
+      "notes": {
+        "comm": "Non sono scelte di prima classe per il fantacalcio, ma rischiose: potete fare altre scelte."
+      }
+    },
+    {
+      "nome": "GILMOUR",
+      "team": "NAP",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.2
+      },
+      "stats": {
+        "t": 2,
+        "a": 4,
+        "i": 4,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 8,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 1,
+          "minutes": 1178,
+          "rating": 6.0
+        }
+      },
+      "notes": {
+        "comm": "Billy Gilmour è un’alternativa nel centrocampo del Napoli. Non è un titolare e quest’anno avrà ancora meno spazio dopo le 17 partite a voto della scorsa stagione. Di base è il sostituto di Lobotka, ma non è assolutamente una coppia da fare al fantacalcio perché nessuno dei due porta bonus."
+      }
+    },
+    {
+      "nome": "GINEITIS",
+      "team": "TOR",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 5,
+        "f": 4.75
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 104,
+          "rating": 4.75
+        },
+        "2024_25": {
+          "goals": 3,
+          "assists": 1,
+          "minutes": 1423,
+          "rating": 5.95
+        }
+      },
+      "notes": {
+        "comm": "Gvidas Gineitis è in rampa di lancio nel Torino. Centrocampista classe 2004 di piede mancino e lituano di nazionalità, si è messo in mostra già nella scorsa stagione. Un buon numero di bonus: 3 gol e un assist. Può crescere ancora, per Baroni sarà un jolly perché è molto duttile."
+      }
+    },
+    {
+      "nome": "GRASSI",
+      "team": "CRE",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 3,
+        "f": 5.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 79,
+          "rating": 5.25
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 0,
+          "minutes": 2228,
+          "rating": 5.91
+        }
+      },
+      "notes": {
+        "comm": "Alberto Grassi è un rinforzo di esperienza per il centrocampo della Cremonese. 28 partite a voto con 1 gol nell'ultima stagione a Empoli, è un giocatore che conosce la categoria ed è stato voluto dal nuovo allenatore Davide Nicola. Centrocampista centrale, è decisamente più da rendimento che da bonus. Al fantacalcio è un possibile acquisto low cost tappabuchi per il vostro centrocampo, da leghe numerose."
+      }
+    },
+    {
+      "nome": "HERNANI",
+      "team": "PAR",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 2,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 3,
+          "assists": 3,
+          "minutes": 1329,
+          "rating": 6.08
+        }
+      },
+      "notes": {
+        "comm": "Hernani è un centrocampista da bonus al fantacalcio, il problema è che gli manca continuità ed è troppo soggetto a infortuni. L’anno scorso è riuscito a fare solo 25 partite a voto, quest’anno avrà un anno in più. È però da bonus perché è uno dei rigoristi principali del Parma, 3 su 3 nella scorsa stagione. Anche 3 assist a referto. È quindi potenzialmente interessante ma solo se da low cost e se riuscirà ad avere continuità."
+      }
+    },
+    {
+      "nome": "HOJHOLT",
+      "team": "PIS",
+      "prezzi": {
+        "min": 0,
+        "max": 0,
+        "avg": 0.0
+      },
+      "stats": {
+        "t": 0,
+        "a": 0,
+        "i": 0,
+        "f": 0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 0,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 0
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 1179,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Non sono scelte di prima classe per il fantacalcio, ma rischiose: potete fare altre scelte."
+      }
+    },
+    {
+      "nome": "IANNONI",
+      "team": "SAS",
+      "prezzi": {
+        "min": 0,
+        "max": 0,
+        "avg": 0.0
+      },
+      "stats": {
+        "t": 0,
+        "a": 0,
+        "i": 0,
+        "f": 0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 0,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 0
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 8,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 989,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Sono opzioni da escludere, meglio evitare questi centrocampisti al fantacalcio."
+      }
+    },
+    {
+      "nome": "ILKHAN",
+      "team": "TOR",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 2,
+        "i": 3,
+        "f": 5.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 58,
+          "rating": 5.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 58,
+          "rating": 5.0
+        }
+      },
+      "notes": {
+        "comm": ""
+      }
+    },
+    {
+      "nome": "KABA",
+      "team": "LEC",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.2
+      },
+      "stats": {
+        "t": 2,
+        "a": 3,
+        "i": 3,
+        "f": 6.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 94,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 452,
+          "rating": 5.88
+        }
+      },
+      "notes": {
+        "comm": "Non sono scelte di prima classe per il fantacalcio, ma rischiose: potete fare altre scelte."
+      }
+    },
+    {
+      "nome": "KASTANOS",
+      "team": "VER",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.2
+      },
+      "stats": {
+        "t": 2,
+        "a": 3,
+        "i": 3,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 0,
+          "minutes": 866,
+          "rating": 5.89
+        }
+      },
+      "notes": {
+        "comm": "Anche qui siamo in zona leghe numerose, ma non c’è il voto assicurato. Vedremo se dalla preseason arriverà qualche spunto o conferma ulteriore, per alcuni di loro occhio anche al mercato."
+      }
+    },
+    {
+      "nome": "KEITA M.",
+      "team": "PAR",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 2,
+        "f": 5.25
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 169,
+          "rating": 5.25
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 1,
+          "minutes": 1827,
+          "rating": 5.73
+        }
+      },
+      "notes": {
+        "comm": "Mandela Keita ha avuto una stagione d’esordio negativa in Serie A. Per il prezzo speso dal Parma, 15 milioni, ci si aspettava di più. In termini di fantacalcio offre poco, perché ha fatto solo un assist con 4 ammonizioni e un’espulsione. Fanta-media bassa del 5,66 in 28 partite a voto, quest’anno potrà migliorare come voti diventando un low cost tappabuchi da ultimo slot."
+      }
+    },
+    {
+      "nome": "KOSTIC",
+      "team": "JUV",
+      "prezzi": {
+        "min": 0,
+        "max": 0,
+        "avg": 0.0
+      },
+      "stats": {
+        "t": 0,
+        "a": 0,
+        "i": 0,
+        "f": 0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 0,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 0
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 1,
+          "minutes": 28,
+          "rating": 6.5
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 1,
+          "minutes": 28,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Tante voci di mercato su di loro, c’è la possibilità che possano partire e quindi occhio per il fantacalcio."
+      }
+    },
+    {
+      "nome": "LERIS",
+      "team": "PIS",
+      "prezzi": {
+        "min": 0,
+        "max": 0,
+        "avg": 0.0
+      },
+      "stats": {
+        "t": 0,
+        "a": 0,
+        "i": 0,
+        "f": 0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 0,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 0
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 8,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 169,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Non sono scelte di prima classe per il fantacalcio, ma rischiose: potete fare altre scelte."
+      }
+    },
+    {
+      "nome": "LIPANI",
+      "team": "SAS",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 4,
+        "f": 5.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 94,
+          "rating": 5.5
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 728,
+          "rating": 5.5
+        }
+      },
+      "notes": {
+        "comm": "Anche qui siamo in zona leghe numerose, ma non c’è il voto assicurato. Vedremo se dalla preseason arriverà qualche spunto o conferma ulteriore, per alcuni di loro occhio anche al mercato."
+      }
+    },
+    {
+      "nome": "LITETA",
+      "team": "CAG",
+      "prezzi": {
+        "min": 0,
+        "max": 0,
+        "avg": 0.0
+      },
+      "stats": {
+        "t": 0,
+        "a": 0,
+        "i": 0,
+        "f": 0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 0,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 0
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Sono opzioni da escludere, meglio evitare questi centrocampisti al fantacalcio."
+      }
+    },
+    {
+      "nome": "MALEH",
+      "team": "LEC",
+      "prezzi": {
+        "min": 0,
+        "max": 0,
+        "avg": 0.0
+      },
+      "stats": {
+        "t": 0,
+        "a": 0,
+        "i": 0,
+        "f": 0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 0,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 0
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 1,
+          "minutes": 1514,
+          "rating": 5.82
+        }
+      },
+      "notes": {
+        "comm": "Tante voci di mercato su di loro, c’è la possibilità che possano partire e quindi occhio per il fantacalcio."
+      }
+    },
+    {
+      "nome": "MARCHWINSKI",
+      "team": "LEC",
+      "prezzi": {
+        "min": 0,
+        "max": 0,
+        "avg": 0.0
+      },
+      "stats": {
+        "t": 0,
+        "a": 0,
+        "i": 0,
+        "f": 0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 0,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 0
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 14,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Non sono scelte di prima classe per il fantacalcio, ma rischiose: potete fare altre scelte."
+      }
+    },
+    {
+      "nome": "MATIC",
+      "team": "SAS",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.5
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 3,
+        "f": 5.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 82,
+          "rating": 5.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 82,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Nemanja Matic torna in Italia. E lo fa a 37 anni. Il serbo rinforza la mediana del Sassuolo, dovrebbe essere titolare davanti alla difesa anche se Grosso ha una buona scelta in mezzo al campo. Matic è integro fisicamente, solo qualche acciacco nella scorsa stagione e 25 partite da titolare in Ligue 1. Dopo la Roma ha giocato al Rennes e poi al Lione, dove è stato titolare per un anno e mezzo. Grande esperienza internazionale, non solo in nazionale ma anche al Chelsea e al Manchester United, darà leadership al centrocampo del Sassuolo e sarà una chioccia per i più giovane. Alla Roma aveva fatto 2 gol e 3 assist in una stagione, ma difficilmente potrà ripetere questi bonus: è un profilo più da voto e solamente low cost da ultimi slot."
+      }
+    },
+    {
+      "nome": "MAZZITELLI",
+      "team": "CAG",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.2
+      },
+      "stats": {
+        "t": 2,
+        "a": 4,
+        "i": 3,
+        "f": 5.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 29,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 1,
+          "minutes": 358,
+          "rating": 6.0
+        }
+      },
+      "notes": {
+        "comm": "Si arriva ad altri low cost ma che possono essere utili più da leghe abbastanza numerose in su. Opzioni - molte in provincia - per chi cerca un voto sicuro o quasi ma senza troppe pretese in termini di bonus."
+      }
+    },
+    {
+      "nome": "MILLER L.",
+      "team": "UDI",
+      "prezzi": {
+        "min": 0,
+        "max": 3,
+        "avg": 1.0
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 3,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 3,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 3
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 2803,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Lennon Miller è l’ultima giovane scommessa di casa Udinese. Si tratta di una società che in passato ha spesso portato talenti interessanti in Serie A. Stavolta ci prova con questo centrocampista centrale di 18 anni, è soltanto un 2006 ma è molto promettente. È scozzese ed è alto 182 cm, l’Udinese lo ha pescato dal Motherwell FC - per 5,5 milioni - dove l’anno scorso ha fatto 32 partite con 2 gol e 8 assist in campionato. Nella Premiership scozzese ha giocato due stagioni, per la sua età 76 presenze in prima squadra non sono poche. In Scozia è considerato un predestinato e ha già 2 presenze in nazionale maggiore dopo aver fatto 5 gol e 2 assist con l’Under 21. È un centrocampista centrale completo (ha fatto sia il mediano che il trequartista), bravo nei passaggi e nel dribbling ma anche a contrasto. In un 3-5-2 può fare la mezzala, idem in un 4-3-3. Ha personalità ed è anche un rigorista, 3 su 3 nella scorsa stagione. Difficilmente sarà la primissima scelta dell’Udinese, ma comunque si candida. Bisogna anche capire quanto spazio avrà, se potrà essere titolare da subito nonostante la giovanissima età o se avrà bisogno di ambientarsi in Italia. La baby scommessa (da ultimo slot) è servita, specialmente per chi ha il fantacalcio con conferme o può fare plusvalenze."
+      }
+    },
+    {
+      "nome": "MIRETTI",
+      "team": "JUV",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.2
+      },
+      "stats": {
+        "t": 2,
+        "a": 3,
+        "i": 3,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 3,
+          "assists": 3,
+          "minutes": 1694,
+          "rating": 5.98
+        }
+      },
+      "notes": {
+        "comm": "Tante voci di mercato su di loro, c’è la possibilità che possano partire e quindi occhio per il fantacalcio."
+      }
+    },
+    {
+      "nome": "MORO N.",
+      "team": "BOL",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.2
+      },
+      "stats": {
+        "t": 2,
+        "a": 3,
+        "i": 5,
+        "f": 5.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 65,
+          "rating": 5.5
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 1,
+          "minutes": 1229,
+          "rating": 6.0
+        }
+      },
+      "notes": {
+        "comm": "Anche qui siamo in zona leghe numerose, ma non c’è il voto assicurato. Vedremo se dalla preseason arriverà qualche spunto o conferma ulteriore, per alcuni di loro occhio anche al mercato."
+      }
+    },
+    {
+      "nome": "MUSAH",
+      "team": "ATA",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.2
+      },
+      "stats": {
+        "t": 2,
+        "a": 3,
+        "i": 4,
+        "f": 6.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 90,
+          "rating": 6.5
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 2,
+          "minutes": 1581,
+          "rating": 5.69
+        }
+      },
+      "notes": {
+        "comm": "Yunus Musah è un nuovo rinforzo per l’Atalanta di Juric, dopo due stagioni al Milan in cui ha avuto alti e bassi. È un giocatore duttile, capace di ricoprire più ruoli: può essere un’alternativa nei due centrali di centrocampo ma anche un vice Bellanova sulla destra. In chiave fantacalcio però resta un profilo secondario: nelle ultime due stagioni in Serie A non ha segnato e ha portato appena 2 assist per campionato, con anche diversi cartellini (5 in entrambe le annate). Non cambia quindi la sua appetibilità, migliora solo lievemente così come il suo probabile minutaggio: utile solo in leghe numerose come riempitivo da ultimi slot, senza garanzie di bonus."
+      }
+    },
+    {
+      "nome": "NDOUR",
+      "team": "FIO",
+      "prezzi": {
+        "min": 0,
+        "max": 3,
+        "avg": 0.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 4,
+        "f": 5.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 3,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 3
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 69,
+          "rating": 5.5
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 407,
+          "rating": 5.71
+        }
+      },
+      "notes": {
+        "comm": "Cher Ndour ha avuto modo di ambientarsi per sei mesi a Firenze, non ha però giocato molto. Solo 7 partite a voto da gennaio in avanti, non un titolare fisso. È invece partito con un'altra marcia con Pioli, che gli ha dato più spazio. È ancora giovane (2004) e ha margini di miglioramento, può crescere durante la stagione."
+      }
+    },
+    {
+      "nome": "NIASSE",
+      "team": "VER",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 3,
+        "f": 5.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 66,
+          "rating": 5.5
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 757,
+          "rating": 5.5
+        }
+      },
+      "notes": {
+        "comm": "Anche qui siamo in zona leghe numerose, ma non c’è il voto assicurato. Vedremo se dalla preseason arriverà qualche spunto o conferma ulteriore, per alcuni di loro occhio anche al mercato."
+      }
+    },
+    {
+      "nome": "ONANA J.",
+      "team": "GEN",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 3,
+        "f": null
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 298,
+          "rating": 5.86
+        }
+      },
+      "notes": {
+        "comm": "Jean Onana è tornato al Genoa, dove l’anno scorso aveva giocato solo 9 partite. È un mediano di 25 anni, non è un’opzione intrigante per il fantacalcio."
+      }
+    },
+    {
+      "nome": "RAFIA",
+      "team": "LEC",
+      "prezzi": {
+        "min": 0,
+        "max": 0,
+        "avg": 0.0
+      },
+      "stats": {
+        "t": 0,
+        "a": 0,
+        "i": 0,
+        "f": 0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 0,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 0
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 1064,
+          "rating": 5.78
+        }
+      },
+      "notes": {
+        "comm": "Non sono scelte di prima classe per il fantacalcio, ma rischiose: potete fare altre scelte."
+      }
+    },
+    {
+      "nome": "RAMADANI",
+      "team": "LEC",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.2
+      },
+      "stats": {
+        "t": 4,
+        "a": 3,
+        "i": 4,
+        "f": 6.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 171,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 1,
+          "minutes": 1819,
+          "rating": 5.85
+        }
+      },
+      "notes": {
+        "comm": "Ylber Ramadani ha chiuso con 1 gol e 1 assist in 27 partite a voto. Con l’arrivo di Di Francesco le gerarchie in casa Lecce si azzerano, lui è il classico mediano davanti alla difesa con anche compiti di regia. Non ha caratteristiche propriamente da fantacalcio, è al massimo un acquisto low cost da ultimissimi slot per completare il vostro reparto in leghe numerose. Al netto del buon tiro da fuori non porta molti bonus."
+      }
+    },
+    {
+      "nome": "RICHARDSON",
+      "team": "FIO",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.2
+      },
+      "stats": {
+        "t": 2,
+        "a": 3,
+        "i": 5,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 1,
+          "minutes": 1106,
+          "rating": 5.78
+        }
+      },
+      "notes": {
+        "comm": "Amir Richardson ha avuto una prima stagione di ambientamento in Serie A, anche se non ha lasciato il segno nella Fiorentina. Per lui 1 gol e 1 assist in 25 presenze, solo 5,84 di fanta-media. I voti non sono stati alti, è incappato in diverse bocciature. È un centrocampista che ha qualità ma ancora non le ha mostrate in Italia e quest’anno non parte come titolare."
+      }
+    },
+    {
+      "nome": "ROG",
+      "team": "CAG",
+      "prezzi": {
+        "min": 0,
+        "max": 0,
+        "avg": 0.0
+      },
+      "stats": {
+        "t": 0,
+        "a": 0,
+        "i": 0,
+        "f": 0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 0,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 0
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 639,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Sono opzioni da escludere, meglio evitare questi centrocampisti al fantacalcio."
+      }
+    },
+    {
+      "nome": "SABIRI",
+      "team": "FIO",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.2
+      },
+      "stats": {
+        "t": 2,
+        "a": 3,
+        "i": 4,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Tante voci di mercato su di loro, c’è la possibilità che possano partire e quindi occhio per il fantacalcio."
+      }
+    },
+    {
+      "nome": "SALA A.",
+      "team": "LEC",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 4,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Alex Sala è un nuovo centrocampista del Lecce. Classe 2001, è spagnolo e nato a Barcellona ed è alto 185 cm. Arriva per un milione e mezzo dal Cordoba, squadra di metà classifica in Serie B spagnola, dove ha fatto 5 gol e 5 assist nell’ultima stagione giocando da titolare fisso (anche 11 ammonizioni). Un gol su rigore (unico in carriera) e gli altri con tiro da fuori, che è una sua specialità. È un centrocampista di qualità, che può fare la mezzala oppure il regista.\n\n"
+      }
+    },
+    {
+      "nome": "SANTIAGO",
+      "team": "VER",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.2
+      },
+      "stats": {
+        "t": 2,
+        "a": 3,
+        "i": 4,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 425,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Anche qui siamo in zona leghe numerose, ma non c’è il voto assicurato. Vedremo se dalla preseason arriverà qualche spunto o conferma ulteriore, per alcuni di loro occhio anche al mercato."
+      }
+    },
+    {
+      "nome": "SARMIENTO J.",
+      "team": "CRE",
+      "prezzi": {
+        "min": 0,
+        "max": 3,
+        "avg": 1.0
+      },
+      "stats": {
+        "t": 2,
+        "a": 3,
+        "i": 3,
+        "f": null
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 3,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 3
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 4,
+          "assists": 0,
+          "minutes": 1180,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Jeremy Sarmiento è un jolly che ha pescato la Cremonese, scommessa low cost al fantacalcio perché è listato centrocampista. L’anno scorso in B inglese al Burnley ha fatto 4 gol in 35 partite. Classe 2002, di ruolo è un’ala sinistra che nella Cremonese potrà fare la seconda punta o il trequartista. Qualche apparizione in Premier con il Brighton, da cui arriva in prestito. Giocatore di fantasia, può dare caratteristiche che mancano alla rosa di Nicola."
+      }
+    },
+    {
+      "nome": "SERGI ROBERTO",
+      "team": "COM",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.2
+      },
+      "stats": {
+        "t": 2,
+        "a": 3,
+        "i": 2,
+        "f": 6.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 56,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 1,
+          "minutes": 696,
+          "rating": 6.0
+        }
+      },
+      "notes": {
+        "comm": "Anche qui siamo in zona leghe numerose, ma non c’è il voto assicurato. Vedremo se dalla preseason arriverà qualche spunto o conferma ulteriore, per alcuni di loro occhio anche al mercato."
+      }
+    },
+    {
+      "nome": "SORENSEN O.",
+      "team": "PAR",
+      "prezzi": {
+        "min": 0,
+        "max": 5,
+        "avg": 2.5
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 3,
+        "f": 5.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 5,
+        "sos_fanta_2025": 4,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 5,
+        "sos_fanta_2024": 4
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 172,
+          "rating": 5.75
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 2385,
+          "rating": 6.0
+        }
+      },
+      "notes": {
+        "comm": "Oliver Sorensen è un nuovo centrocampista del Parma. Arriva dal Midtjylland, un’operazione importante per il club, da circa 10 milioni bonus compresi. Centrocampista di grande forza fisica, gioca con entrambi i piedi (destro e sinistro, ma è mancino naturale) ed è stato utilizzato sia in posizione centrale che sulle due fasce. Si contenderà una maglia da titolare nel nuovo Parma di Cuesta, è arrivato per sostituire Sohm (passato alla Fiorentina). Oltre 130 partite (e 16 gol) con il Midtjylland con cui ha giocato l’Europa League (13 presenze e un assist) e ha vinto una SuperLiga (2023/24). Nato a Nørre Aaby nel 2002, ha giocato con la maglia della nazionale danese dall’U16 fino all’U21, gli manca l’esordio in quella maggiore. Solo 14 gialli in carriera in 219 partite e nessun rosso, ma occhio a un dato molto importante: è un rigorista. 6 segnati e un solo errore nel lontano 2018; nelle ultime due stagioni ne ha segnati 5 su 5. Lui e l’altro nuovo arrivato Frigan (7 segnati e 2 errori) proveranno a insidiare Pellegrino, che a oggi dovrebbe essere la prima scelta dal dischetto. Nell’ultima stagione ha saltato 6 gare per un problema fisico, poi pienamente superato. Per l’asta, può essere una scommessa low cost interessante per il vostro centrocampo. Può essere un titolare tra centrocampo e trequarti nel Parma e portare qualche bonus, anche se non dovesse essere il rigorista."
+      }
+    },
+    {
+      "nome": "TAMEZE",
+      "team": "TOR",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.2
+      },
+      "stats": {
+        "t": 2,
+        "a": 3,
+        "i": 5,
+        "f": 5.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 41,
+          "rating": 5.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 659,
+          "rating": 5.9
+        }
+      },
+      "notes": {
+        "comm": "Tante voci di mercato su di loro, c’è la possibilità che possano partire e quindi occhio per il fantacalcio."
+      }
+    },
+    {
+      "nome": "THORSBY",
+      "team": "GEN",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.2
+      },
+      "stats": {
+        "t": 2,
+        "a": 3,
+        "i": 3,
+        "f": 6.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 33,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 1,
+          "minutes": 1902,
+          "rating": 5.78
+        }
+      },
+      "notes": {
+        "comm": "Morten Thorsby è un centrocampista che sarà utile nelle rotazioni del Genoa, per Vieira è un’arma tattica perché ha delle caratteristiche precise. Alto 189 cm, è bravo negli inserimenti anche nell’ultima stagione ha portato zero gol nonostante 27 presenze a voto. La bassa fanta-media del 5,65 non lo rende un nome troppo appetibile per quest’anno."
+      }
+    },
+    {
+      "nome": "VALOTI",
+      "team": "CRE",
+      "prezzi": {
+        "min": 0,
+        "max": 0,
+        "avg": 0.0
+      },
+      "stats": {
+        "t": 0,
+        "a": 0,
+        "i": 0,
+        "f": 0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 0,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 0
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 48,
+          "rating": 6.0
+        }
+      },
+      "notes": {
+        "comm": "Anche qui siamo in zona leghe numerose, ma non c’è il voto assicurato. Vedremo se dalla preseason arriverà qualche spunto o conferma ulteriore, per alcuni di loro occhio anche al mercato."
+      }
+    },
+    {
+      "nome": "VERGARA",
+      "team": "NAP",
+      "prezzi": {
+        "min": 0,
+        "max": 0,
+        "avg": 0.0
+      },
+      "stats": {
+        "t": 0,
+        "a": 0,
+        "i": 0,
+        "f": 0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 0,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 0
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 5,
+          "assists": 5,
+          "minutes": 2251,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Sono opzioni da escludere, meglio evitare questi centrocampisti al fantacalcio."
+      }
+    },
+    {
+      "nome": "VRANCKX",
+      "team": "SAS",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 2,
+        "f": 5.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 69,
+          "rating": 5.5
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 571,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Aster Vranckx è un nuovo centrocampista del Sassuolo. L’ex Milan si candida come possibile titolare, anche se c’è concorrenza. È ancora giovane perché ha 22 anni, cerca più spazio perché nella scorsa stagione al Wolfsburg ha fatto solo 14 presenze. Non è particolarmente da bonus, solo 2 in Bundesliga in 63 partite."
+      }
+    },
+    {
+      "nome": "VURAL",
+      "team": "PIS",
+      "prezzi": {
+        "min": 0,
+        "max": 0,
+        "avg": 0.0
+      },
+      "stats": {
+        "t": 0,
+        "a": 0,
+        "i": 0,
+        "f": 0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 0,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 0
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 1196,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Non sono scelte di prima classe per il fantacalcio, ma rischiose: potete fare altre scelte."
+      }
+    },
+    {
+      "nome": "ZARRAGA",
+      "team": "UDI",
+      "prezzi": {
+        "min": 0,
+        "max": 0,
+        "avg": 0.0
+      },
+      "stats": {
+        "t": 0,
+        "a": 0,
+        "i": 0,
+        "f": 0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 0,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 0
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 49,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 0,
+          "minutes": 896,
+          "rating": 5.78
+        }
+      },
+      "notes": {
+        "comm": "Anche qui siamo in zona leghe numerose, ma non c’è il voto assicurato. Vedremo se dalla preseason arriverà qualche spunto o conferma ulteriore, per alcuni di loro occhio anche al mercato."
+      }
+    }
+  ],
+  "A": [
+    {
+      "nome": "MARTINEZ L.",
+      "team": "INT",
+      "prezzi": {
+        "min": 120,
+        "max": 158,
+        "avg": 145.8
+      },
+      "stats": {
+        "t": 5,
+        "a": 5,
+        "i": 4,
+        "f": 8.25
+      },
+      "allPrices": {
+        "fantaboom_2025": 155,
+        "fantaclassic_2025": 158,
+        "profeta_2025": 120,
+        "sos_fanta_2025": 150,
+        "fantaboom_2024": 155,
+        "fantaclassic_2024": 158,
+        "profeta_2024": 120,
+        "sos_fanta_2024": 150
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 1,
+          "assists": 1,
+          "minutes": 169,
+          "rating": 6.5
+        },
+        "2024_25": {
+          "goals": 12,
+          "assists": 3,
+          "minutes": 2577,
+          "rating": 6.19
+        }
+      },
+      "notes": {
+        "comm": "Lautaro Martinez è stato uno dei top che hanno fallito nell’ultima stagione. Uno come lui non può fare solo 12 gol, specialmente dopo un anno da capocannoniere. L’argentino resta capitano e leader indiscusso dell’Inter, lo status non cambia con Chivu. Nonostante l’ultima stagione rimane sempre anche un top al fantacalcio. Obiettivo 20 gol per giustificare la spesa all'asta, l'inizio col nuovo allenatore è promettente."
+      }
+    },
+    {
+      "nome": "KEAN",
+      "team": "FIO",
+      "prezzi": {
+        "min": 105,
+        "max": 145,
+        "avg": 132.5
+      },
+      "stats": {
+        "t": 5,
+        "a": 4,
+        "i": 3,
+        "f": 5.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 145,
+        "fantaclassic_2025": 145,
+        "profeta_2025": 105,
+        "sos_fanta_2025": 135,
+        "fantaboom_2024": 145,
+        "fantaclassic_2024": 145,
+        "profeta_2024": 105,
+        "sos_fanta_2024": 135
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 180,
+          "rating": 5.0
+        },
+        "2024_25": {
+          "goals": 19,
+          "assists": 2,
+          "minutes": 2710,
+          "rating": 6.42
+        }
+      },
+      "notes": {
+        "comm": "Moise Kean è pronto a ripetersi. Ci sono state molte voci di mercato su di lui, specialmente sull’Arabia, ma l’attaccante ha deciso di rimanere alla Fiorentina. Ora sarà compito di Pioli provare a fargli superare quota 19 gol in Serie A, è stato vicecapocannoniere dopo Retegui. Solo un gol su rigore, uno lo aveva sbagliato. Se li giocherà principalmente con Gudmundsson, che l’anno scorso partiva leggermente avanti. Con o senza Dzeko in campo, con o senza Piccoli, a Kean poco importa: lui sarà titolare e punto fermo della Fiorentina. Nonché un top al fantacalcio, tra i più pagati.\n"
+      }
+    },
+    {
+      "nome": "DAVID",
+      "team": "JUV",
+      "prezzi": {
+        "min": 90,
+        "max": 140,
+        "avg": 115.0
+      },
+      "stats": {
+        "t": 5,
+        "a": 4,
+        "i": 4,
+        "f": 7.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 140,
+        "fantaclassic_2025": 120,
+        "profeta_2025": 90,
+        "sos_fanta_2025": 110,
+        "fantaboom_2024": 140,
+        "fantaclassic_2024": 120,
+        "profeta_2024": 90,
+        "sos_fanta_2024": 110
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 1,
+          "assists": 0,
+          "minutes": 142,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 0,
+          "minutes": 2558,
+          "rating": 7.0
+        }
+      },
+      "notes": {
+        "comm": "Jonathan David è un ingresso importante nel listone degli attaccanti, anche se bisognerà vedere come si presenterà il reparto offensivo della Juve a fine mercato e che concorrenza ci sarà. In ogni caso David sarà un pezzo pregiato della squadra di Tudor, andrà sempre a voto e vede bene la porta. C’è anche il fattore rigori,  è uno specialista da 31 segnati in carriera su 38: partirà appena dietro a Locatelli. L’anno scorso ha fatto 16 gol e 5 assist in Ligue 1, nella conferenza stampa di presentazione ha detto che proverà a segnare 25 gol in totale come nella scorsa stagione. Può fare anche la seconda punta, ma Tudor lo sta provando solo come prima punta per ora. Pochissimi infortuni in carriera, l’ultimo nel 2022-23."
+      }
+    },
+    {
+      "nome": "THURAM",
+      "team": "INT",
+      "prezzi": {
+        "min": 100,
+        "max": 138,
+        "avg": 125.8
+      },
+      "stats": {
+        "t": 4,
+        "a": 5,
+        "i": 3,
+        "f": 10.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 130,
+        "fantaclassic_2025": 135,
+        "profeta_2025": 100,
+        "sos_fanta_2025": 138,
+        "fantaboom_2024": 130,
+        "fantaclassic_2024": 135,
+        "profeta_2024": 100,
+        "sos_fanta_2024": 138
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 2,
+          "assists": 1,
+          "minutes": 157,
+          "rating": 7.0
+        },
+        "2024_25": {
+          "goals": 14,
+          "assists": 4,
+          "minutes": 2298,
+          "rating": 6.33
+        }
+      },
+      "notes": {
+        "comm": "Marcus Thuram era in calo dai primi mesi del 2025, ma è subito esploso con una doppietta alla prima, meritando lo status da top. La sua ultima stagione era iniziata con il botto, poi però il numero di gol ha subito una frenata. E quest'anno può fare una partenza come la scorsa, l'inizio va in questa direzione. Per un top d'attacco serviranno comunque più dei 14 gol della scorsa stagione. E il suo record di gol resta il 14 dello scorso campionato: è chiamato a superarlo."
+      }
+    },
+    {
+      "nome": "HOJLUND",
+      "team": "NAP",
+      "prezzi": {
+        "min": 75,
+        "max": 120,
+        "avg": 90.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 4,
+        "f": null
+      },
+      "allPrices": {
+        "fantaboom_2025": 120,
+        "fantaclassic_2025": 83,
+        "profeta_2025": 75,
+        "sos_fanta_2025": 85,
+        "fantaboom_2024": 120,
+        "fantaclassic_2024": 83,
+        "profeta_2024": 75,
+        "sos_fanta_2024": 85
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 4,
+          "assists": 0,
+          "minutes": 2022,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Rasmus Hojlund torna al fantacalcio. Il danese arriva al Napoli con il compito di sostituire Lukaku. I fantallenatori si ricordano la stagione all’Atalanta, quando segnò 9 gol giocando 20 partite da titolare e 12 da subentrato. Poi la cessione da record al Manchester United e gli alti e bassi: 10 gol in Premier al primo anno, solo 4 al secondo. Ora la missione rilancio al Napoli: è ancora giovane perché ha soli 22 anni ed è stato pagato molto perché complessivamente si arriva a 50 milioni. Non è facile esplodere allo United e ci sono tanti casi in questi ultimi anni, basta guardare anche la differenza di rendimento di McTominay. Ha avuto anche qualche infortunio, uno l’anno scorso alla coscia di 50 giorni e un paio l’anno prima. Hojlund ha già fatto bene in Serie A con le sue doti di velocità ed esplosività, ma ha anche un buon fisico perché è alto 191 cm. Al Napoli dovrà fare un gioco diverso rispetto a quello di Gasperini all’Atalanta, ma finché non torna Lukaku può essere in pole su Lucca. Il dualismo sarà tra loro due, una coppia che però non conviene fare al fantacalcio sia per una questione di costi sia perché a un certo punto della stagione tornerà Lukaku. Hojlund nei primi mesi può essere il centravanti del Napoli però non potrà andare al prezzo dei top, avrà un prezzo inferiore ma comunque più alto rispetto a Lucca. Diciamo che è un secondo slot per il momento, almeno nei primi mesi. Non è un rigorista, solo uno tirato in Austria."
+      }
+    },
+    {
+      "nome": "LEAO",
+      "team": "MIL",
+      "prezzi": {
+        "min": 80,
+        "max": 110,
+        "avg": 98.5
+      },
+      "stats": {
+        "t": 5,
+        "a": 5,
+        "i": 4,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 110,
+        "fantaclassic_2025": 98,
+        "profeta_2025": 80,
+        "sos_fanta_2025": 106,
+        "fantaboom_2024": 110,
+        "fantaclassic_2024": 98,
+        "profeta_2024": 80,
+        "sos_fanta_2024": 106
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 8,
+          "assists": 8,
+          "minutes": 2330,
+          "rating": 6.19
+        }
+      },
+      "notes": {
+        "comm": "Rafael Leao è un giocatore che fa discutere al fantacalcio. Ci si aspetta sempre di più rispetto a quanto poi porta in termini di bonus. Il prezzo all’asta di solito è più alto in proporzione al rendimento effettivo. Almeno la doppia cifra deve portarla, invece negli ultimi due anni si è fermato a 9 e 8 gol. Ci sono poi gli assist, che sono sempre tanti e circa 8-9. Il potenziale è da “doppia doppia”, ora toccherà ad Allegri farlo segnare di più. In preseason ha giocato più vicino alla porta, buon segno. E lo stop che ha avuto all'inizio non ha fatto alzare il suo prezzo."
+      }
+    },
+    {
+      "nome": "CASTELLANOS",
+      "team": "LAZ",
+      "prezzi": {
+        "min": 85,
+        "max": 104,
+        "avg": 93.0
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 3,
+        "f": 9.25
+      },
+      "allPrices": {
+        "fantaboom_2025": 90,
+        "fantaclassic_2025": 93,
+        "profeta_2025": 85,
+        "sos_fanta_2025": 104,
+        "fantaboom_2024": 90,
+        "fantaclassic_2024": 93,
+        "profeta_2024": 85,
+        "sos_fanta_2024": 104
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 1,
+          "assists": 2,
+          "minutes": 168,
+          "rating": 7.0
+        },
+        "2024_25": {
+          "goals": 10,
+          "assists": 3,
+          "minutes": 2395,
+          "rating": 6.29
+        }
+      },
+      "notes": {
+        "comm": "Valentin Castellanos ritrova Maurizio Sarri e il feeling sembra essere già scattato. Nella precedente esperienza c’era anche Immobile, che era titolare. Solo 2 gol in 34 presenze per l’argentino sotto la guida Sarri. Ora le cose sono cambiate, perché non c’è più la presenza ingombrante di Immobile mentre Castellanos arriva da 14 gol e 8 assist in 40 partite tra tutte le competizioni con Baroni. Lo status è diverso, è quello del titolare: 2 assist di cui uno da urlo in rabona e un gol alla seconda contro il Verona. Ha lanciato segnali importantissimi anche in chiave asta. Si giocherà anche i rigori con Zaccagni, che parte leggermente avanti.\n\n"
+      }
+    },
+    {
+      "nome": "FERGUSON E.",
+      "team": "ROM",
+      "prezzi": {
+        "min": 70,
+        "max": 88,
+        "avg": 82.5
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 2,
+        "f": 6.75
+      },
+      "allPrices": {
+        "fantaboom_2025": 87,
+        "fantaclassic_2025": 85,
+        "profeta_2025": 70,
+        "sos_fanta_2025": 88,
+        "fantaboom_2024": 87,
+        "fantaclassic_2024": 85,
+        "profeta_2024": 70,
+        "sos_fanta_2024": 88
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 1,
+          "minutes": 147,
+          "rating": 6.5
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 418,
+          "rating": 6.5
+        }
+      },
+      "notes": {
+        "comm": "Evan Ferguson si è calato molto bene nella Roma di Gasperini, il prezzo è in continua ascesa perché può essere il titolare davanti. L'anno scorso non è stato facile per l'attaccante, in ripresa dopo la rottura del crociato: non è riuscito a trovare continuità e gol (solo uno in Premier), ma ha dalla sua la giovane età visto che è un 2004. È un centravanti che ha fisico, potenza e anche tecnica, Gasp ha subito apprezzato le sue doti di pressing. Con Dovbyk ci sarà concorrenza, è una bella sfida con Ferguson che parte in pole e ha giocato da titolare le prime due (con un assist a referto contro il Pisa). L'ex Brighton essendo ancora giovane ha margini di crescita e uno storico minore, con soli 6 gol (per due anni di fila) nella sua miglior stagione in Premier. Ora l'incertezza principale è legata agli infortuni, ma ha dato buoni segnali. In più può essere un'opzione anche per i rigori: in carriera due calciati e due gol. Parte comunque dietro a Dybala e non solo, ci sono tanti specialisti."
+      }
+    },
+    {
+      "nome": "YILDIZ",
+      "team": "JUV",
+      "prezzi": {
+        "min": 75,
+        "max": 92,
+        "avg": 83.0
+      },
+      "stats": {
+        "t": 4,
+        "a": 5,
+        "i": 4,
+        "f": 7.75
+      },
+      "allPrices": {
+        "fantaboom_2025": 85,
+        "fantaclassic_2025": 80,
+        "profeta_2025": 75,
+        "sos_fanta_2025": 92,
+        "fantaboom_2024": 85,
+        "fantaclassic_2024": 80,
+        "profeta_2024": 75,
+        "sos_fanta_2024": 92
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 2,
+          "minutes": 178,
+          "rating": 6.75
+        },
+        "2024_25": {
+          "goals": 7,
+          "assists": 4,
+          "minutes": 2408,
+          "rating": 6.34
+        }
+      },
+      "notes": {
+        "comm": "Kenan Yildiz è atteso all’anno della consacrazione. La sua stagione al fantacalcio inizia con grandi aspettative, questo perché ha fatto un ottimo Mondiale per Club ed è partito molto bene anche in stagione. Il turco ha soltanto 20 anni e tutta la carriera davanti, ogni anno può migliorare e i bonus potranno aumentare già dal 2025-26. Tudor punta tanto su di lui e lo schirerà titolare nei due trequartisti alle spalle della punta, un ruolo perfetto per lui. L’unica controindicazione al fantacalcio può essere un prezzo eccessivo, considerando l’alta considerazione che può avere nelle aste, però può valere i soldi spesi."
+      }
+    },
+    {
+      "nome": "SCAMACCA",
+      "team": "ATA",
+      "prezzi": {
+        "min": 60,
+        "max": 80,
+        "avg": 70.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 1,
+        "f": 8.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 80,
+        "fantaclassic_2025": 70,
+        "profeta_2025": 60,
+        "sos_fanta_2025": 73,
+        "fantaboom_2024": 80,
+        "fantaclassic_2024": 70,
+        "profeta_2024": 60,
+        "sos_fanta_2024": 73
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 1,
+          "assists": 0,
+          "minutes": 136,
+          "rating": 6.5
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 13,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Gianluca Scamacca si è messo finalmente alle spalle gli infortuni, dopo una stagione con zero partite a voto. Retegui è partito e Scamacca si giocherà il posto con Krstovic. Sfida alla pari alla lunga, Gianluca parte avanti perché ha iniziato con un gol e alla seconda a Parma ha preso un palo. 12 gol e 6 assist nella stagione 2023/24, l’obiettivo può essere quello di avvicinarsi il più possibile a quei numeri. Ma la scorsa annata ai box non può essere dimenticata e incide anche sul prezzo all’asta di Scamacca. È giusto che sia così, perché delle perplessità lato fisico - alla lunga - ci sono anche se ora sta molto bene. Infine, occhio al fattore rigori: Retegui è partito e l’ex Sassuolo proverà a candidarsi, può tirare chi è in campo tra lui e Krstovic, altrimenti va De Ketelaere."
+      }
+    },
+    {
+      "nome": "BERARDI",
+      "team": "SAS",
+      "prezzi": {
+        "min": 70,
+        "max": 75,
+        "avg": 73.8
+      },
+      "stats": {
+        "t": 5,
+        "a": 3,
+        "i": 2,
+        "f": 7.75
+      },
+      "allPrices": {
+        "fantaboom_2025": 75,
+        "fantaclassic_2025": 70,
+        "profeta_2025": 75,
+        "sos_fanta_2025": 75,
+        "fantaboom_2024": 75,
+        "fantaclassic_2024": 70,
+        "profeta_2024": 75,
+        "sos_fanta_2024": 75
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 1,
+          "assists": 0,
+          "minutes": 179,
+          "rating": 6.5
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 2262,
+          "rating": 6.0
+        }
+      },
+      "notes": {
+        "comm": "Domenico Berardi è un giocatore storico al fantacalcio, il suo ritorno dopo l’infortunio e un anno di Serie B è molto importante. Le sue qualità rimangono le stesse, è prezioso perché le gioca tutte e tira i calci piazzati, dalle punizioni ai rigori. Al Sassuolo è capitano e bandiera, se sta bene è titolare inamovibile e nessuno lo toglie dalla sua mattonella (ala destra). 1 gol nelle prime 2 di campionato, ha subito lasciato il segno su rigore contro la Cremonese. "
+      }
+    },
+    {
+      "nome": "DYBALA",
+      "team": "ROM",
+      "prezzi": {
+        "min": 56,
+        "max": 72,
+        "avg": 64.5
+      },
+      "stats": {
+        "t": 3,
+        "a": 5,
+        "i": 2,
+        "f": 6.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 70,
+        "fantaclassic_2025": 56,
+        "profeta_2025": 60,
+        "sos_fanta_2025": 72,
+        "fantaboom_2024": 70,
+        "fantaclassic_2024": 56,
+        "profeta_2024": 60,
+        "sos_fanta_2024": 72
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 61,
+          "rating": 6.5
+        },
+        "2024_25": {
+          "goals": 6,
+          "assists": 3,
+          "minutes": 1420,
+          "rating": 6.48
+        }
+      },
+      "notes": {
+        "comm": "Paulo Dybala se sta bene non si discute. L’unica vera incognita è la sua condizione fisica, per il resto le sue qualità e i suoi numeri sono noti. 6 gol e 3 assist in 20 partite a voto (numero troppo basso) nella passata stagione e ricordiamo un fattore molto importante: è il rigorista della Roma, uno specialista assoluto dagli undici metri. Gasperini è pronto a dargli una maglia da titolare e spera che possa finalmente ritrovare continuità. Molto difficile pensare a un Dybala sempre titolare visto che la Roma giocherà anche in Europa League, sarà gestito dall’allenatore con l’obiettivo di averlo il più possibile a disposizione, dall’inizio o a gara in corso. Ormai il suo status è ben noto al fantacalcio, l’ideale è averlo da secondo slot in modo da non fare affidamento solo su di lui vista la fragilità fisica."
+      }
+    },
+    {
+      "nome": "SOULÈ",
+      "team": "ROM",
+      "prezzi": {
+        "min": 60,
+        "max": 69,
+        "avg": 66.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 4,
+        "f": 7.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 60,
+        "fantaclassic_2025": 69,
+        "profeta_2025": 67,
+        "sos_fanta_2025": 69,
+        "fantaboom_2024": 60,
+        "fantaclassic_2024": 69,
+        "profeta_2024": 67,
+        "sos_fanta_2024": 69
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 1,
+          "assists": 0,
+          "minutes": 163,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 5,
+          "assists": 5,
+          "minutes": 1799,
+          "rating": 6.24
+        }
+      },
+      "notes": {
+        "comm": "Matias Soulé è atteso alla consacrazione con la maglia della Roma. L’anno scorso era partito male, ma è esploso con il passare dei mesi e verso il finale di stagione. Ranieri è riuscito a valorizzarlo, ora toccherà a Gasperini e la sensazione è che sia sulla strada giusta: 1 gol nelle prime 2, è stato subito decisivo contro il Pisa. L’argentino è duttile perché può giocare sia da esterno a destra o a sinistra che sulla trequarti. Il voto lo prenderà quasi sempre e per i bonus si è sbloccato dalla metà dello scorso campionato in avanti."
+      }
+    },
+    {
+      "nome": "CASTRO S.",
+      "team": "BOL",
+      "prezzi": {
+        "min": 39,
+        "max": 55,
+        "avg": 46.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 5,
+        "f": 7.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 55,
+        "fantaclassic_2025": 39,
+        "profeta_2025": 45,
+        "sos_fanta_2025": 48,
+        "fantaboom_2024": 55,
+        "fantaclassic_2024": 39,
+        "profeta_2024": 45,
+        "sos_fanta_2024": 48
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 1,
+          "minutes": 133,
+          "rating": 6.5
+        },
+        "2024_25": {
+          "goals": 8,
+          "assists": 4,
+          "minutes": 2305,
+          "rating": 6.17
+        }
+      },
+      "notes": {
+        "comm": "Santiago Castro ora prende grande valore dopo l'infortunio di Immobile. L’anno scorso era diventato il titolare del Bologna, ha chiuso la stagione con 8 gol e 4 assist in 33 partite a voto. All’asta Castro si pagherà di più rispetto all’anno scorso e molto di più rispetto a inizio e metà agosto. Adesso cambia tutto, per un paio di mesi diventa lui il titolare con Dallinga riserva. Poi tornerà a giocarsi il posto con Immobile, ma intanto ha possibilità di mettersi in mostra e già contro il Como ha fornito un assist decisivo per Orsolini. Un aspetto da limare è quello dei gialli: 8 la scorsa stagione, troppi per un attaccante. Resta sconsigliata, infine, la coppia con Immobile, perché c'è anche Dallinga."
+      }
+    },
+    {
+      "nome": "DE KETELAERE",
+      "team": "ATA",
+      "prezzi": {
+        "min": 28,
+        "max": 50,
+        "avg": 35.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 4,
+        "f": 5.75
+      },
+      "allPrices": {
+        "fantaboom_2025": 50,
+        "fantaclassic_2025": 35,
+        "profeta_2025": 30,
+        "sos_fanta_2025": 28,
+        "fantaboom_2024": 50,
+        "fantaclassic_2024": 35,
+        "profeta_2024": 30,
+        "sos_fanta_2024": 28
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 174,
+          "rating": 5.75
+        },
+        "2024_25": {
+          "goals": 7,
+          "assists": 5,
+          "minutes": 2079,
+          "rating": 6.19
+        }
+      },
+      "notes": {
+        "comm": "Charles De Ketelaere ha chiuso la scorsa stagione a 7 gol e 5 assist in 34 partite a voto. Ci si attendeva qualcosa in più in termini di reti, ha un po’ deluso le aspettative. Resta listato attaccante al fantacalcio, con Juric le gerarchie si azzerano ma la sensazione è che CDK possa essere un titolare. Ci saranno comunque le coppe e le rotazioni sono da mettere in conto, ma il belga proverà a raggiungere quota 15 tra gol e assist, può essere questo l’obiettivo. Anche se rispetto a Gasperini la squadra molto probabilmente segnerà di meno e si è visto subito nelle prime due di campionato. Occhio ai rigori, Retegui è partito e l’ex Milan è uno dei candidati a calciare insieme a Scamacca e Krstovic. All’asta è scivolato verso il terzo slot dopo la passata stagione."
+      }
+    },
+    {
+      "nome": "ZAPATA D.",
+      "team": "TOR",
+      "prezzi": {
+        "min": 30,
+        "max": 47,
+        "avg": 36.5
+      },
+      "stats": {
+        "t": 4,
+        "a": 4,
+        "i": 1,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 47,
+        "fantaclassic_2025": 30,
+        "profeta_2025": 35,
+        "sos_fanta_2025": 34,
+        "fantaboom_2024": 47,
+        "fantaclassic_2024": 30,
+        "profeta_2024": 35,
+        "sos_fanta_2024": 34
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 3,
+          "assists": 0,
+          "minutes": 589,
+          "rating": 6.57
+        }
+      },
+      "notes": {
+        "comm": "Duvan Zapata cerca l’immediato riscatto dopo una stagione sfortunata. Il colombiano aveva giocato solo 7 partite prima di rompersi il crociato. In vista della nuova stagione è un punto interrogativo, perché dopo un infortunio così c'è sempre incertezza. È però rientrato e ora sta bene. Se in breve tempo torna in condizione è un semitop, perché è titolare fisso, capitano e rigorista del Torino. Ma qualche intoppo nella stagione si può mettere in conto, perché ha 34 anni e non è facile rientrare da un crociato. Quindi un po’ di prudenza servirà, non si pagherà al prezzo del miglior Duvan."
+      }
+    },
+    {
+      "nome": "MORATA",
+      "team": "COM",
+      "prezzi": {
+        "min": 22,
+        "max": 45,
+        "avg": 34.5
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 3,
+        "f": 5.75
+      },
+      "allPrices": {
+        "fantaboom_2025": 45,
+        "fantaclassic_2025": 31,
+        "profeta_2025": 40,
+        "sos_fanta_2025": 22,
+        "fantaboom_2024": 45,
+        "fantaclassic_2024": 31,
+        "profeta_2024": 40,
+        "sos_fanta_2024": 22
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 53,
+          "rating": 5.75
+        },
+        "2024_25": {
+          "goals": 5,
+          "assists": 0,
+          "minutes": 1105,
+          "rating": 6.09
+        }
+      },
+      "notes": {
+        "comm": "Alvaro Morata è un nuovo giocatore del Como. Si è esposto lui in prima persona per tornare in Italia ed essere allenato dal connazionale Cesc Fabregas, che lo ha fortemente voluto. 7 gol in 16 partite al Galatasaray nella seconda parte della scorsa stagione, al Milan ne aveva realizzati 6 in 23 gare. È reduce da una stagione al di sotto delle aspettative lo spagnolo, ma torna con grande voglia in Serie A. Dovrà meritarsi il posto da titolare sul campo, ma parte avanti a Douvikas per guidare l'attacco della squadra come centravanti. La carriera di Morata parla per lui: 37 gol in 86 gare con la nazionale spagnola, 229 gol con squadre di club e 87 assist in 630 gare con le maglie di Real Madrid, Juventus, Chelsea, Atletico, Milan e Galatasaray. Non si discute il valore del giocatore, che ha 32 anni e fisicamente è più che integro. Non si è mai realmente infortunato a lungo, anche se nella passata stagione ha avuto qualche stop in più per i suoi standard (ha saltato 16 gare in totale, record nella sua carriera). In carriera ha calciato 21 rigori, ne ha segnati 16 e sbagliati 5 (2 su 2 realizzati al Gala). Al Como si sta specializzando Nico Paz che parte in pole, ma occhio alla candidatura di Morata che potrebbe insidiarlo o diventare il suo vice. La doppia cifra di gol è sicuramente il suo obiettivo minimo: come prezzi può essere più di un semplice attaccante di provincia per l'asta. Meno in hype dell'anno scorso, ma comunque molto più di un low cost."
+      }
+    },
+    {
+      "nome": "PINAMONTI",
+      "team": "SAS",
+      "prezzi": {
+        "min": 27,
+        "max": 43,
+        "avg": 37.2
+      },
+      "stats": {
+        "t": 4,
+        "a": 3,
+        "i": 4,
+        "f": 7.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 43,
+        "fantaclassic_2025": 37,
+        "profeta_2025": 42,
+        "sos_fanta_2025": 27,
+        "fantaboom_2024": 43,
+        "fantaclassic_2024": 37,
+        "profeta_2024": 42,
+        "sos_fanta_2024": 27
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 1,
+          "assists": 0,
+          "minutes": 179,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 10,
+          "assists": 1,
+          "minutes": 2860,
+          "rating": 5.96
+        }
+      },
+      "notes": {
+        "comm": "Andrea Pinamonti è un “vecchio” nuovo acquisto del Sassuolo. L’attaccante è tornato dopo il prestito al Genoa e si è rimesso a disposizione dei neroverdi, per Grosso è la prima punta titolare. Ora, a 26 anni, inizia ad avere un po’ di esperienza in Serie A: già 212 partite con 50 gol. Per tre volte è andato in doppia cifra, l’anno scorso al Genoa e anche l’anno prima proprio al Sassuolo con 11 gol. Le sue caratteristiche sono note e non cambiano: gioca sempre, alla doppia cifra può arrivarci, ha il difetto di prendere voti bassi quando non segna. È il vice Berardi sui rigori."
+      }
+    },
+    {
+      "nome": "PELLEGRINO M.",
+      "team": "PAR",
+      "prezzi": {
+        "min": 37,
+        "max": 45,
+        "avg": 40.0
+      },
+      "stats": {
+        "t": 4,
+        "a": 3,
+        "i": 4,
+        "f": 6.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 40,
+        "fantaclassic_2025": 38,
+        "profeta_2025": 45,
+        "sos_fanta_2025": 37,
+        "fantaboom_2024": 40,
+        "fantaclassic_2024": 38,
+        "profeta_2024": 45,
+        "sos_fanta_2024": 37
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 180,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 3,
+          "assists": 0,
+          "minutes": 745,
+          "rating": 6.14
+        }
+      },
+      "notes": {
+        "comm": "Mateo Pellegrino ha finito la fase di rodaggio, adesso è pronto per essere titolare in Serie A. Col Parma ha fatto solo sei mesi da gennaio in poi, segnando tre gol. Dopo la partenza di Bonny cambia l’attacco del Parma, ma lui sarà titolare. Gigante da 192 cm e abilissimo nel gioco aereo, sia per quanto riguarda il colpo di testa che le sponde, è partito benissimo con la doppietta in Coppa Italia che ha fatto salire il suo prezzo pre-campionato. Poi, nessun bonus nelle prime due e l'arrivo di Cutrone: per questo si può pagare meno a settembre che ad agosto."
+      }
+    },
+    {
+      "nome": "DIAO",
+      "team": "COM",
+      "prezzi": {
+        "min": 15,
+        "max": 35,
+        "avg": 23.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 2,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 35,
+        "fantaclassic_2025": 20,
+        "profeta_2025": 23,
+        "sos_fanta_2025": 15,
+        "fantaboom_2024": 35,
+        "fantaclassic_2024": 20,
+        "profeta_2024": 23,
+        "sos_fanta_2024": 15
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 7,
+          "assists": 0,
+          "minutes": 1257,
+          "rating": 6.5
+        }
+      },
+      "notes": {
+        "comm": "Assane Diao è uno dei casi di questo inizio di fantacalcio. L'attaccante del Como era stato devastante nello scorso campionato segnando 8 gol in 15 partite di Serie A, listato centrocampista. Poi l'infortunio, che gli ha fatto perdere il finale di stagione e ora lo sta ancora condizionando. Il giocatore ha deciso di non operarsi, procederà con la terapia conservativa e il Como ha annunciato 5 settimane come tempi di recupero a partire dal 29 agosto. Se tutto andrà per il meglio, tornerà dunque dopo la sosta per le nazionali di ottobre, farebbe quindi meno di due mesi prima di partire per la Coppa d'Africa. C'è comunque sempre da verificare come va la terapia conservativa, è giusto che al fantacalico un po' di prudenza ci sia, tra questo infortunio e la Coppa d'Africa. Il suo prezzo dunque scende rispetto a inizio agosto, però si temeva pure peggio con operazione e 4 mesi di stop. Se è un buon acquisto o no al fanta ormai dipende solo dal prezzo all'asta, non si può pagare troppo."
+      }
+    },
+    {
+      "nome": "VARDY",
+      "team": "CRE",
+      "prezzi": {
+        "min": 22,
+        "max": 35,
+        "avg": 30.5
+      },
+      "stats": {
+        "t": 4,
+        "a": 4,
+        "i": 3,
+        "f": null
+      },
+      "allPrices": {
+        "fantaboom_2025": 30,
+        "fantaclassic_2025": 22,
+        "profeta_2025": 35,
+        "sos_fanta_2025": 35,
+        "fantaboom_2024": 30,
+        "fantaclassic_2024": 22,
+        "profeta_2024": 35,
+        "sos_fanta_2024": 35
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 9,
+          "assists": 4,
+          "minutes": 2839,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Jamie Vardy è stato il colpo a sorpresa della Cremonese e uno dei nomi che attireranno più curiosità al fantacalcio. L’attaccante inglese classe 1987 arriva dopo una carriera leggendaria al Leicester, con oltre 200 gol e più di 400 presenze in Premier League, oltre allo storico titolo vinto con Ranieri nel 2016. A 38 anni sarà titolare nell’attacco di Davide Nicola, portando esperienza e qualità. Se sta bene, uno come lui non può stare fuori. Nell’ultima stagione in Inghilterra ha collezionato 9 gol e 4 assist in 35 presenze, saltando soltanto una partita per una contusione: un dato che conferma la sua ottima condizione fisica. L’unico infortunio significativo negli ultimi anni risale a due stagioni fa, quando restò fermo un mese e mezzo per un problema al ginocchio. Inoltre, è un rigorista: dal dischetto 34 rigori realizzati in carriera su 43. Salvo sorprese sarà lui lo specialista dal dischetto. Al fantacalcio non sarà un low cost per l’hype che si porta dietro, ma è comunque un profilo interessante: titolare, rigorista e con ancora fame di gol. L’entusiasmo è altissimo, l’unica controindicazione può essere il prezzo se sale troppo."
+      }
+    },
+    {
+      "nome": "DAVIS K.",
+      "team": "UDI",
+      "prezzi": {
+        "min": 12,
+        "max": 28,
+        "avg": 20.0
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 2,
+        "f": 8.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 28,
+        "fantaclassic_2025": 17,
+        "profeta_2025": 23,
+        "sos_fanta_2025": 12,
+        "fantaboom_2024": 28,
+        "fantaclassic_2024": 17,
+        "profeta_2024": 23,
+        "sos_fanta_2024": 12
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 1,
+          "assists": 1,
+          "minutes": 144,
+          "rating": 6.75
+        },
+        "2024_25": {
+          "goals": 2,
+          "assists": 1,
+          "minutes": 1071,
+          "rating": 6.0
+        }
+      },
+      "notes": {
+        "comm": "Keinan Davis ha subito risposto sul campo all'arrivo di Buksa, con il gol realizzato su rigore contro l'Inter alla seconda giornata e una super prestazione a San Siro. Davis è alto 189 cm ed è un attaccante molto potente e strutturato fisicamente. Può giocare anche in coppia con un altro centravanti, lo ha già fatto l’anno scorso. I numeri non sono dalla sua, perché ha fatto solo 2 gol e 1 assist. Frenato dagli infortuni, ha chiuso con sole 16 partite a voto. Un numero che può aumentare quest’anno, contro l'Inter ha fatto vedere cose importanti. Ora dovrà trovare continuità e provare a ripetersi.\n\n"
+      }
+    },
+    {
+      "nome": "COLOMBO",
+      "team": "GEN",
+      "prezzi": {
+        "min": 10,
+        "max": 25,
+        "avg": 15.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 4,
+        "f": 5.25
+      },
+      "allPrices": {
+        "fantaboom_2025": 25,
+        "fantaclassic_2025": 10,
+        "profeta_2025": 15,
+        "sos_fanta_2025": 13,
+        "fantaboom_2024": 25,
+        "fantaclassic_2024": 10,
+        "profeta_2024": 15,
+        "sos_fanta_2024": 13
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 151,
+          "rating": 5.25
+        },
+        "2024_25": {
+          "goals": 6,
+          "assists": 2,
+          "minutes": 2249,
+          "rating": 5.9
+        }
+      },
+      "notes": {
+        "comm": "Lorenzo Colombo prova un’altra avventura in Serie A ed è andato al Genoa. Si giocherà la maglia da titolare con Vitinha dopo l'addio di Pinamonti. Sarà Vieira a decidere chi far giocare, da capire se ci sarà un titolare fisso o se deciderà di partita in partita. Attaccante di provincia, non ha il posto assicurato e quindi al momento per il fantacalcio è un low cost da quarto/quinto slot. Ha segnato 3 rigori su 4 in carriera, ma nel Genoa ci sono anche altri specialisti come Malinovskyi. Nell'ultima stagione, 6 gol e 2 assist in 36 partite a voto con la maglia dell'Empoli per Colombo. Il suo record di gol è proprio di 6 gol in una stagione di Serie A, al Genoa proverà a fare meglio."
+      }
+    },
+    {
+      "nome": "ESPOSITO SE.",
+      "team": "CAG",
+      "prezzi": {
+        "min": 13,
+        "max": 25,
+        "avg": 18.8
+      },
+      "stats": {
+        "t": 4,
+        "a": 4,
+        "i": 3,
+        "f": 6.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 25,
+        "fantaclassic_2025": 13,
+        "profeta_2025": 23,
+        "sos_fanta_2025": 14,
+        "fantaboom_2024": 25,
+        "fantaclassic_2024": 13,
+        "profeta_2024": 23,
+        "sos_fanta_2024": 14
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 127,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 8,
+          "assists": 0,
+          "minutes": 2341,
+          "rating": 6.17
+        }
+      },
+      "notes": {
+        "comm": "Sebastiano Esposito alla fine ha scelto il Cagliari, lo hanno cercato tante squadre tra cui il Parma e quindi evidentemente ha avuto garanzie. Può essere titolare, questa l’idea della società, anche se nell'ultimo giorno di mercato è arrivato Belotti. Occhio ai rigori, Esposito sarà uno degli specialisti. Per lui 21 rigori su 22 in carriera, ma quasi tutti a livello giovanile. L’anno scorso uno segnato e uno sbagliato all’Empoli, in più uno realizzato con l’Under 21. Sebastiano è anche molto bravo sui calci di punizione, è uno specialista e potrà calciarle. Per infortunio l’anno scorso ha saltato solo 20 giorni, aveva avuto qualche stop in più due anni fa. Al fantacalcio è il classico attaccante di provincia da alternare nel vostro terzo slot in base al calendario e al momento di forma. Nonostante l'arrivo del Gallo, dovrebbe comunque avere uno spazio molto importante.\n\n"
+      }
+    },
+    {
+      "nome": "LAURIENTÈ",
+      "team": "SAS",
+      "prezzi": {
+        "min": 13,
+        "max": 23,
+        "avg": 18.0
+      },
+      "stats": {
+        "t": 4,
+        "a": 4,
+        "i": 4,
+        "f": 5.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 23,
+        "fantaclassic_2025": 13,
+        "profeta_2025": 23,
+        "sos_fanta_2025": 13,
+        "fantaboom_2024": 23,
+        "fantaclassic_2024": 13,
+        "profeta_2024": 23,
+        "sos_fanta_2024": 13
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 150,
+          "rating": 5.5
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 2383,
+          "rating": 5.5
+        }
+      },
+      "notes": {
+        "comm": "Armand Laurienté alla fine è rimasto. Al Sassuolo è un buon titolare, un attaccante che non è un goleador ma può fare assist e portare buoni voti. 18 gol e 6 assist comunque nella passata stagione di Serie B: pressoché impossibile che replichi questi numeri in Serie A, ma proverà a raggiungere almeno quota 10/12 tra gol e assist.\n\n"
+      }
+    },
+    {
+      "nome": "BELOTTI",
+      "team": "CAG",
+      "prezzi": {
+        "min": 5,
+        "max": 20,
+        "avg": 13.5
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 2,
+        "f": null
+      },
+      "allPrices": {
+        "fantaboom_2025": 20,
+        "fantaclassic_2025": 9,
+        "profeta_2025": 20,
+        "sos_fanta_2025": 5,
+        "fantaboom_2024": 20,
+        "fantaclassic_2024": 9,
+        "profeta_2024": 20,
+        "sos_fanta_2024": 5
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 2,
+          "assists": 0,
+          "minutes": 611,
+          "rating": 5.96
+        }
+      },
+      "notes": {
+        "comm": "Andrea Belotti riparte dal Cagliari. L’attaccante si candida come possibile titolare con Pisacane, ma ci sarà comunque concorrenza. Di fatto prende il posto di Piccoli, ma molto difficilmente ripeterà il suo rendimento dello scorso anno. Belotti aveva deluso al Como, solo due gol. Poi il passaggio al Benfica a gennaio, in Portogallo 4 gol tra tutte le competizioni. Al Cagliari sarà un attaccante low cost, in linea di massima sempre da voto. Occhio anche ai rigori, sarà una delle opzioni principali: in carriera 34 segnati e 9 sbagliati."
+      }
+    },
+    {
+      "nome": "STULIC",
+      "team": "LEC",
+      "prezzi": {
+        "min": 6,
+        "max": 20,
+        "avg": 12.0
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 4,
+        "f": 5.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 14,
+        "fantaclassic_2025": 8,
+        "profeta_2025": 20,
+        "sos_fanta_2025": 6,
+        "fantaboom_2024": 14,
+        "fantaclassic_2024": 8,
+        "profeta_2024": 20,
+        "sos_fanta_2024": 6
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 217,
+          "rating": 5.5
+        },
+        "2024_25": {
+          "goals": 16,
+          "assists": 2,
+          "minutes": 2380,
+          "rating": 5.5
+        }
+      },
+      "notes": {
+        "comm": "Nikola Stulic è il sostituto di Krstovic al Lecce. Si tratta di una prima punta del 2001, alto 188 cm e di nazionalità serba. È anche nel giro della nazionale. Dotato di buon fisico, Stulic è un centravanti da area di rigore, un finalizzatore. Si fa trovare al posto giusto e ha fiuto del gol, molti arrivano su tap-in. Come caratteristiche al fantacalcio può essere quell’attaccante che quando non segna prende l’insufficienza. I gol li fa: nella scorsa stagione al Charleroi, in Belgio, 16 in 29 partite di campionato, inclusi i playoff. Il campionato italiano è più difficile e bisognerà anche vedere quante occasioni avrà al Lecce, non è una punta che inventa i gol ma deve essere assistito. Le squadre di Di Francesco comunque di solito creano, ma peccano in finalizzazione. Si giocherà il posto con Camarda, sono in due per una maglia con staffetta annunciata: chi non gioca dall’inizio subentra. Camarda ha il vantaggio di aver fatto tutta la preseason ma nella sosta le gerarchie si azzerano. Occhio anche ai rigori: la sensazione è che dal dischetto andrà proprio chi sarà in campo tra i due centravanti. Stulic può essere quindi rigorista: 5 su 6 in carriera, anche se solo due segnati negli ultimi tre anni. Il dualismo con Camarda fa sì che Stulic sia un attaccante low cost da ultimi slot al fanta, un bomber di provincia che si può prendere a prezzi vantaggiosi come scommessa davanti. Se vanno a poco si può pensare di avere entrambi al fanta."
+      }
+    },
+    {
+      "nome": "NZOLA",
+      "team": "PIS",
+      "prezzi": {
+        "min": 8,
+        "max": 13,
+        "avg": 10.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 3,
+        "f": 5.75
+      },
+      "allPrices": {
+        "fantaboom_2025": 13,
+        "fantaclassic_2025": 8,
+        "profeta_2025": 10,
+        "sos_fanta_2025": 12,
+        "fantaboom_2024": 13,
+        "fantaclassic_2024": 8,
+        "profeta_2024": 10,
+        "sos_fanta_2024": 12
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 61,
+          "rating": 5.75
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 61,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Mbala Nzola torna al fantacalcio e lo fa con la maglia del Pisa. Nell’ultima stagione l’attaccante ha giocato in prestito al Lens, facendo 6 gol e un assist in 21 partite, di cui 16 dall’inizio. Nella stagione precedente era stato un flop alla Fiorentina, mentre le cose migliori le aveva fatte in due differenti anni allo Spezia. Ora ha 28 anni e riparte da una piazza in provincia con l’obiettivo di lottare per la salvezza. Diventa così il classico centravanti di provincia e bassa classifica da alternare nel terzo slot insieme ad altri 2-3 attaccanti, schierando il migliore in base a forma e calendario. Siamo dunque intorno al quarto slot, non sarà propriamente low cost ma qualcosa di più. Di positivo ha il fatto che se sta bene gioca titolare, il “precedente” in questo tipo di piazza parla di 11 e 13 gol. Riesce a fare reparto da solo, sempre se torna quello dei tempi migliori. E poi è rigorista, dovrebbe essere il primo specialista (12 su 14 in carriera). Di negativo c’è che è abbastanza soggetto infortuni ed è un giocatore con un carattere non semplice, anche in campo si vede dai cartellini (l’anno scorso un rosso, nel 2022-23 ben 8 gialli. E poi c’è Gilardino che non sempre riesce a valorizzare le punte, con lui Retegui solo 7 gol."
+      }
+    },
+    {
+      "nome": "ORBAN G.",
+      "team": "VER",
+      "prezzi": {
+        "min": 6,
+        "max": 12,
+        "avg": 9.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 3,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 12,
+        "fantaclassic_2025": 11,
+        "profeta_2025": 10,
+        "sos_fanta_2025": 6,
+        "fantaboom_2024": 12,
+        "fantaclassic_2024": 11,
+        "profeta_2024": 10,
+        "sos_fanta_2024": 6
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 4,
+          "assists": 0,
+          "minutes": 690,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Gift Orban è un nuovo attaccante del Verona, arrivato dall’Hoffenheim. In Germania ha giocato gli ultimi sei mesi, facendo 4 gol in 13 partite di Bundesliga. Prima una parentesi poco fortunata al Lione. Aveva fatto bene al Gent, quando si parlava di lui come di un prospetto molto interessante. Premesse non del tutto mantenute, ma ora proverà ad affermarsi in Italia e ha ancora 23 anni. Alto 178 cm, è un attaccante rapido ed esplosivo, perfetto per giocare in un attacco a due. Non ha avuto grandi infortuni negli ultimi anni però uno stop è recente, un problema alla caviglia a fine campionato scorso. Non è uno specialista dei rigori, solo 2 segnati in carriera, però può candidarsi visto che al Verona non ci sono grandi interpreti. La Coppa d’Africa potrebbe non farla, era stato convocato nel 2023 ma non fa parte del giro della Nigeria al momento. Al fantacalcio si posiziona come opzione low cost in provincia, è uno di quelli con più margini, una scommessa che può dare frutti. Può anche aspirare a una maglia da titolare.\n"
+      }
+    },
+    {
+      "nome": "NGONGE",
+      "team": "TOR",
+      "prezzi": {
+        "min": 6,
+        "max": 23,
+        "avg": 11.5
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 4,
+        "f": 5.25
+      },
+      "allPrices": {
+        "fantaboom_2025": 10,
+        "fantaclassic_2025": 6,
+        "profeta_2025": 23,
+        "sos_fanta_2025": 7,
+        "fantaboom_2024": 10,
+        "fantaclassic_2024": 6,
+        "profeta_2024": 23,
+        "sos_fanta_2024": 7
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 161,
+          "rating": 5.25
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 238,
+          "rating": 5.75
+        }
+      },
+      "notes": {
+        "comm": "Cyril Ngonge ritrova Baroni al Torino. Lo aveva allenato al Verona nella prima parte della stagione 2023/24: ben 6 gol e 2 assist messi a segno in 19 partite di Serie A, per poi essere acquistato dal Napoli. In azzurro ha invece fatto fatica a imporsi, trovando solo un gol e un assist in un anno e mezzo in campionato. Davvero poco spazio soprattutto con Antonio Conte, vista la presenza di Politano e Neres in quel ruolo. Ora al Torino cambia tutto: il belga arriva per fare il titolare nel trio dietro alla punta. Con gli assist di Vlasic e le sponde di Zapata e Adams può davvero tornare quello di Verona: una bella scommessa per il Torino e per il fantacalcio, attaccante da possibile terzo slot o al massimo quarto. Con alto grado di titolarità e un costo che non sarà così basso."
+      }
+    },
+    {
+      "nome": "CUTRONE",
+      "team": "PAR",
+      "prezzi": {
+        "min": 6,
+        "max": 10,
+        "avg": 8.0
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 4,
+        "f": 10.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 9,
+        "fantaclassic_2025": 7,
+        "profeta_2025": 10,
+        "sos_fanta_2025": 6,
+        "fantaboom_2024": 9,
+        "fantaclassic_2024": 7,
+        "profeta_2024": 10,
+        "sos_fanta_2024": 6
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 1,
+          "assists": 0,
+          "minutes": 9,
+          "rating": 7.0
+        },
+        "2024_25": {
+          "goals": 7,
+          "assists": 4,
+          "minutes": 2053,
+          "rating": 6.02
+        }
+      },
+      "notes": {
+        "comm": "Patrick Cutrone resta in Serie A, ma cambia maglia: è un nuovo giocatore del Parma e si è subito presentato con un gol all'esordio contro l'Atalanta, subentrando dalla panchina. 7 gol e 4 assist in 33 partite di campionato nella passata stagione a Como, ora si mette a disposizione di Cuesta dopo la rottura del crociato del centravanti Frigan. Per ora il Parma sta giocando col 3-5-2, Cutrone può essere alternativo a Pellegrino ma i due possono anche giocare insieme. Bisognerà capire se il modulo resterà questo o meno, Cuesta aveva in mente anche un 4-3-3 e in quel caso Cutrone sarebbe solo alternativo all’argentino. Con l’attacco a due invece il ballottaggio diventa tra lui e Oristanio, che per caratteristiche potrebbe integrarsi meglio con Pellegrino. L’attaccante classe 1998 in Serie A ha segnato al massimo 10 gol con la maglia del Milan; in B il suo record è di 14 gol e 5 assist nel 23/24. 7 rigori segnati e 4 sbagliati, un errore proprio nella passata stagione a Como. Si può candidare quando è in campo, anche perché non ci sono grandi specialisti al momento. Non da primissima scelta assoluta, ma come uno dei candidati. Fisicamente arriva un giocatore in perfette condizioni: non si è mai fermato nella passata stagione. Al massimo ha saltato 6 gare nella stagione 23/24 (la sua migliore comunque per numeri). Solo un rosso in carriera ma in Primavera; 23 gialli, di cui 4 in Primavera. Non ha il posto fisso ma comunque andrà spesso a voto e può lasciare il segno sia giocando dall'inizio che a gara in corso."
+      }
+    },
+    {
+      "nome": "SARR A.",
+      "team": "VER",
+      "prezzi": {
+        "min": 1,
+        "max": 10,
+        "avg": 5.5
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 4,
+        "f": 5.25
+      },
+      "allPrices": {
+        "fantaboom_2025": 8,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 10,
+        "sos_fanta_2025": 3,
+        "fantaboom_2024": 8,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 10,
+        "sos_fanta_2024": 3
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 144,
+          "rating": 5.25
+        },
+        "2024_25": {
+          "goals": 4,
+          "assists": 0,
+          "minutes": 1918,
+          "rating": 5.86
+        }
+      },
+      "notes": {
+        "comm": "Amin Sarr in partenza è l’attaccante titolare del Verona, anche se c'è più concorrenza con gli arrivi di Orban e Giovane. 4 gol in 29 partite a voto per il centravanti, che si è preso il posto nella passata stagione e proverà a confermarlo quest'anno. Classico attaccante titolare di provincia per il fantacalcio, proverà a migliorare il suo bottino di bonus perché l’anno scorso era utile praticamente solo come primo cambio davanti, può fare di più."
+      }
+    },
+    {
+      "nome": "SANABRIA",
+      "team": "CRE",
+      "prezzi": {
+        "min": 5,
+        "max": 7,
+        "avg": 5.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 3,
+        "f": 6.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 7,
+        "fantaclassic_2025": 5,
+        "profeta_2025": 5,
+        "sos_fanta_2025": 6,
+        "fantaboom_2024": 7,
+        "fantaclassic_2024": 5,
+        "profeta_2024": 5,
+        "sos_fanta_2024": 6
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 1,
+          "minutes": 107,
+          "rating": 6.25
+        },
+        "2024_25": {
+          "goals": 2,
+          "assists": 1,
+          "minutes": 1330,
+          "rating": 5.7
+        }
+      },
+      "notes": {
+        "comm": "Antonio Sanabria è passato alla Cremonese e sarà titolare, è stato un acquisto importante per il club. Davide Nicola lo stima e lo voleva al centro del suo attacco: può giocare sia da prima punta che da seconda al fianco di un altro centravanti come De Luca. Sarà anche tra le opzioni per i rigori, è uno specialista. Per la Cremonese è un acquisto importante, che serve per la Serie A. Al fantacalcio è un low cost da slot secondari, utilissimo come riserva o in leghe abbastanza numerose."
+      }
+    },
+    {
+      "nome": "LUCCA",
+      "team": "NAP",
+      "prezzi": {
+        "min": 31,
+        "max": 55,
+        "avg": 41.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 4,
+        "f": 5.25
+      },
+      "allPrices": {
+        "fantaboom_2025": 55,
+        "fantaclassic_2025": 38,
+        "profeta_2025": 43,
+        "sos_fanta_2025": 31,
+        "fantaboom_2024": 55,
+        "fantaclassic_2024": 38,
+        "profeta_2024": 43,
+        "sos_fanta_2024": 31
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 157,
+          "rating": 5.5
+        },
+        "2024_25": {
+          "goals": 12,
+          "assists": 0,
+          "minutes": 2361,
+          "rating": 6.11
+        }
+      },
+      "notes": {
+        "comm": "Lorenzo Lucca cambia faccia al fantacalcio dopo il grave infortunio di Lukaku, che starà fuori minimo tre mesi. L'ex Udinese avrà più spazio perché si giocherà il posto con Hojlund, che rispetto a Romelu è meno ingombrante. Sarà una dualismo, il danese può essere di un gradino sopra a livello tecnico ma comunque sarà alternanza tra campionato e Champions. Lucca è un jolly in attacco ma più costoso rispetto a quando era \"riserva\" di Lukaku. Il prezzo non si impenna dopo il flop delle due giornate e anche perché poi comunque a certo punto della stagione il belga tornerà. Finché non c'è Lukaku può essere anche rigorista quando è in campo, se li gioca con De Bruyne e Politano. Parliamo di un giocatore integro fisicamente, 33 presenze l’anno scorso (tre gare saltate per uno stop muscolare al polpaccio). Nell’ultima stagione ha avuto un difetto: 10 cartellini gialli. Dovrà lavorarci."
+      }
+    },
+    {
+      "nome": "KRSTOVIC",
+      "team": "ATA",
+      "prezzi": {
+        "min": 43,
+        "max": 60,
+        "avg": 52.0
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 4,
+        "f": 6.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 50,
+        "fantaclassic_2025": 43,
+        "profeta_2025": 60,
+        "sos_fanta_2025": 55,
+        "fantaboom_2024": 50,
+        "fantaclassic_2024": 43,
+        "profeta_2024": 60,
+        "sos_fanta_2024": 55
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 1,
+          "minutes": 44,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 11,
+          "assists": 5,
+          "minutes": 3068,
+          "rating": 6.05
+        }
+      },
+      "notes": {
+        "comm": "Nikola Krstovic è il nuovo attaccante dell’Atalanta. Di fatto prende il posto in rosa di Retegui, forma il dualismo con Scamacca che almeno inizialmente parte avanti perché ha fatto tutta la preseason. Il montenegrino arriva da due stagioni in Serie A con il Lecce, si è fatto conoscere e a 25 anni è pronto per il salto. 7 gol e 1 assist al primo anno, 11 gol e 5 assist al secondo. Pochi infortuni e ottima continuità: 33 partite al primo anno e 37 l’anno scorso. Qualche cartellino di troppo ma potrà lavorarci. Alto 185 cm, è una prima punta classica. A volte anche troppo egoista, ma al Lecce non c’era un gioco particolarmente offensivo. Doveva provarci da solo: 137 tiri totali nel 2024-25, solo Yamal e Mbappé ne hanno provati di più in Europa. All’Atalanta sarà molto più assistito e quindi potrà segnare di più (e avere voti più alti), anche se perde un po’ di centralità e avrà più ballottaggi. La sfida è con Scamacca, ma c’è anche la Champions e quindi giocheranno entrambi, alternandosi. Krstovic ha più integrità dell’ex Sassuolo. Anche per i rigori sarà sfida. Il montenegrino vuole calciarli, ma non ha grandi numeri: 8 su 14 in carriera e 3 su 6 in Serie A. Potrà tirarli chi è in campo tra Krstovic e Scamacca oppure De Ketelaere, che si stava specializzando l’anno scorso."
+      }
+    },
+    {
+      "nome": "NKUNKU",
+      "team": "MIL",
+      "prezzi": {
+        "min": 36,
+        "max": 55,
+        "avg": 45.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 2,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 40,
+        "fantaclassic_2025": 52,
+        "profeta_2025": 55,
+        "sos_fanta_2025": 36,
+        "fantaboom_2024": 40,
+        "fantaclassic_2024": 52,
+        "profeta_2024": 55,
+        "sos_fanta_2024": 36
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 3,
+          "assists": 2,
+          "minutes": 940,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Christopher Nkunku è il rinforzo del Milan in attacco. Alto 177 cm, non è una prima punta, ma un jolly offensivo che Allegri, come ha detto lui stesso, dovrà capire come impiegare. La direzione è quella della difesa a tre, può esserci un attacco a due con Leao, Pulisic e Nkunku per due posti. Altrimenti un 3-4-3 (o ritorno al 4-3-3), specialmente se arriverà un’altra punta. Ora è un attacco “leggero” (Gimenez avrà sempre meno spazio), al netto della concorrenza uno come Nkunku se sta bene va sempre a voto. Gli infortuni sono un suo punto debole: ha saltato molte partite negli ultimi tre anni, a partire dalla rottura del legamento collaterale nel 2022. Era esploso al Lipsia con un massimo di 20 gol e 15 assist in campionato, è stata la sua stagione migliore. Al Chelsea non si è confermato giocando poco: troppi infortuni al primo anno e solo 2 partite da titolare in Premier, un po’ meglio l’anno scorso con 9 da titolare e 27 volte a voto. I bonus però sono stati pochi: solo 3 gol in campionato l’anno scorso e 3 due anni fa. Meglio in Conference, che ha giocato da titolare (fino all’infortunio di fine stagione) con 5 gol. Con la nazionale francese 1 gol in 14 partite. In Serie A potrà aumentare il numero dei bonus, uno con le sue caratteristiche di dribbling, tecnica e agilità può fare bene. La condizione però è che stia bene fisicamente, questa è l’incognita oltre a essere il motivo per cui non può essere pagato troppo, non come i top. L’ideale sarebbe riuscire a prenderlo come terzo slot. In carriera ha segnato 12 rigori su 15 calciati (sia al Lipsia che al Chelsea), è uno specialista e al Milan potrebbe partire subito dietro a Pulisic, che è il rigorista attuale e lo è stato l’anno scorso. Da vedere se eventualmente potrà sorprendere da questo punto di vista."
+      }
+    },
+    {
+      "nome": "OPENDA",
+      "team": "JUV",
+      "prezzi": {
+        "min": 35,
+        "max": 60,
+        "avg": 43.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 5,
+        "f": null
+      },
+      "allPrices": {
+        "fantaboom_2025": 40,
+        "fantaclassic_2025": 38,
+        "profeta_2025": 60,
+        "sos_fanta_2025": 35,
+        "fantaboom_2024": 40,
+        "fantaclassic_2024": 38,
+        "profeta_2024": 60,
+        "sos_fanta_2024": 35
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 9,
+          "assists": 5,
+          "minutes": 2463,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Lois Openda è un nuovo attaccante della Juve. È un classe 2000 belga, in nazionale ha fatto 3 gol in 27 presenze. Dopo essere esploso al Lens con 21 gol in 38 partite di Ligue 1 ha fatto bene al Lipsia: 24 gol in Bundesliga al primo anno e 9 al secondo. È un attaccante rapido e veloce, letale in contropiede ma agile anche in spazi stretti. Fa anche assist perché ne ha fatti 9 l’anno scorso e 7 due anni fa. Può fare la prima punta, che è il suo vero ruolo, ma sa anche partire più da sinistra per accentrarsi col destro. Vlahovic è più un centravanti classico da area di rigore, David e Openda possono anche partire più indietro e giocare insieme a un’altra punta. Nello scacchiere offensivo della Juve Openda può fare sia il vice Yildiz che il vice David o Vlahovic, è un jolly. Con le sue caratteristiche può essere devastante anche a gara in corso. Probabilmente l’unico problema al fantacalcio è legato proprio alla titolarità, ovviamente vista la concorrenza non può essere considerato un titolare fisso. Però tra turnover, Champions e gara in corso andrà quasi sempre a voto. Difficile nel suo caso pensare a una coppia, perché non è il vice “fisso” né di David, né di Vlahovic né di Yildiz. Anzi, avere più attaccanti della Juve in rosa può anche essere un problema a livello di gestione. Openda è quindi un jolly di alto livello, da mettere praticamente sempre a prescindere, come terzo slot da ruotare. Praticamente nessun infortunio in carriera, solo una partita saltata per uno stop di 5-6 giorni. Pochi anche i cartellini. È un rigorista da 14 segnati su 18 in carriera, ma alla Juve sarà solo un’alternativa dal dischetto. La prima scelta infatti rimane Locatelli come aveva detto Tudor, ma occhio anche Vlahovic con la permanenza e a David che è uno specialista. Openda sarà tra le opzioni di riserva, è comunque bravo a calciarli anche se ha fallito gli ultimi tre."
+      }
+    },
+    {
+      "nome": "LUKAKU",
+      "team": "NAP",
+      "prezzi": {
+        "min": 18,
+        "max": 35,
+        "avg": 23.2
+      },
+      "stats": {
+        "t": 1,
+        "a": 4,
+        "i": 1,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 35,
+        "fantaclassic_2025": 20,
+        "profeta_2025": 20,
+        "sos_fanta_2025": 18,
+        "fantaboom_2024": 35,
+        "fantaclassic_2024": 20,
+        "profeta_2024": 20,
+        "sos_fanta_2024": 18
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 14,
+          "assists": 9,
+          "minutes": 2870,
+          "rating": 6.29
+        }
+      },
+      "notes": {
+        "comm": "Romelu Lukaku crolla come prezzo al fantacalcio dopo il grave infortunio. Prima era un top, ora ovviamente non più. La lesione di alto grado del retto femorale della coscia sinistra lo costringerà ai box per un minimo di tre mesi, che possono allungarsi e diventare anche quattro. Non si opera, ma farà una terapia conservativa. Non sarà in lista Champions. All'asta va considerato solo un jolly, di fatto un giocatore che acquistate e non avete a disposizione subito, quindi dovrete avere cinque titolari nel reparto. Una volta che tornerà potrà essere di nuovo un top come rendimento (l'anno scorso 14 gol e 9 assist), ma solo dopo che sarà al 100% della condizione e questo non sarà immediato. Avere la coppia Lukaku-Lucca non basta, perché il Napoli prenderà un altro attaccante. Rimane quindi una situazione scomoda al fantacalcio, ancora in divenire. Resta il fatto che Lukaku crolla come spesa all'asta e non è più il vostro top di reparto, acquistarlo è un rischio se il prezzo se non è da occasione vera.\n"
+      }
+    },
+    {
+      "nome": "PICCOLI",
+      "team": "FIO",
+      "prezzi": {
+        "min": 17,
+        "max": 35,
+        "avg": 25.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 4,
+        "f": 6.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 35,
+        "fantaclassic_2025": 21,
+        "profeta_2025": 30,
+        "sos_fanta_2025": 17,
+        "fantaboom_2024": 35,
+        "fantaclassic_2024": 21,
+        "profeta_2024": 30,
+        "sos_fanta_2024": 17
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 77,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 10,
+          "assists": 1,
+          "minutes": 3142,
+          "rating": 6.0
+        }
+      },
+      "notes": {
+        "comm": "Roberto Piccoli è un nuovo acquisto della Fiorentina, Pioli ora può contare ora su un attacco importante. Due sono le opzioni: 3-5-2 con Kean e uno tra Gudmundsson, Piccoli e Dzeko oppure 3-4-1-2 con l’islandese, Moise e uno dei due centravanti arrivati in estate. Piccoli cambia status: da titolarissimo a Cagliari al turnover di Firenze, dove c’è anche la Conference. Come caratteristiche è il più simile a Kean, quindi sarà anche il suo vice in caso di rotazioni o infortuni. Una possibile gestione potrebbe essere Moise in campionato e Piccoli in Europa. Ma potrebbero anche giocare insieme. Roberto perde comunque appeal perché arrivava da una stagione con 37 partite e 10, ora all’asta costa meno. Ed è maggiormente un jolly. In più perde anche i rigori: al Cagliari era rigorista insieme a Mina, in viola sarà probabilmente la terza scelta dopo Kean e Gudmundsson. Rimane comunque un rigorista possibile, in carriera 4 su 5.\n\n"
+      }
+    },
+    {
+      "nome": "SIMEONE",
+      "team": "TOR",
+      "prezzi": {
+        "min": 8,
+        "max": 25,
+        "avg": 16.0
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 4,
+        "f": 5.75
+      },
+      "allPrices": {
+        "fantaboom_2025": 25,
+        "fantaclassic_2025": 12,
+        "profeta_2025": 8,
+        "sos_fanta_2025": 19,
+        "fantaboom_2024": 25,
+        "fantaclassic_2024": 12,
+        "profeta_2024": 8,
+        "sos_fanta_2024": 19
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 126,
+          "rating": 5.75
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 1,
+          "minutes": 440,
+          "rating": 5.92
+        }
+      },
+      "notes": {
+        "comm": "Giovanni Simeone cambia status al fantacalcio. Negli ultimi anni al Napoli era un jolly ma giocava davvero pochissimo, prendeva voto in una partita su due. L’anno scorso solamente un gol e un assist, ha deluso. Ora la situazione cambia anche se resta parzialmente un jolly, perché non sicuro del voto fisso alla lunga. Però si modifica completamente il minutaggio, che sarà molto più ampio: andrà a voto praticamente sempre. E così potrà aumentare anche il numero di gol. Non è un gran rigorista (solo 1 su 4 in carriera) ma non è molto soggetto a infortuni (ne ha avuti 4 in carriera). È una prima punta, quindi di base o giocherà lui o giocherà Zapata, che però arriva da un crociato. All’occorrenza però potrebbero anche giocare insieme se serve, in una attacco a due. Baroni dovrà pure studiare la coesistenza anche con Adams, con cui possono giocare sia lui che Duvan. In ogni caso coppie nell’attacco del Torino è meglio evitarle, anche perché Simeone-Zapata non sarà low cost e vi costerà troppo. Per il Cholito siamo intorno al 4° slot ed è uno degli attaccanti da ruotare nel terzo slot."
+      }
+    },
+    {
+      "nome": "DIA",
+      "team": "LAZ",
+      "prezzi": {
+        "min": 12,
+        "max": 30,
+        "avg": 19.0
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 3,
+        "f": 7.75
+      },
+      "allPrices": {
+        "fantaboom_2025": 20,
+        "fantaclassic_2025": 14,
+        "profeta_2025": 30,
+        "sos_fanta_2025": 12,
+        "fantaboom_2024": 20,
+        "fantaclassic_2024": 14,
+        "profeta_2024": 30,
+        "sos_fanta_2024": 12
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 1,
+          "assists": 0,
+          "minutes": 27,
+          "rating": 6.25
+        },
+        "2024_25": {
+          "goals": 9,
+          "assists": 4,
+          "minutes": 2194,
+          "rating": 6.01
+        }
+      },
+      "notes": {
+        "comm": "Boulaye Dia deve reinventarsi, ancora una volta. L’anno scorso si è calato nella parte della seconda punta, ha fatto la spalla di Castellanos. Quest’anno parte come vice Castellanos, ma sarà qualcosa di più. Intanto gli fa concorrenza, poi potrebbero anche giocare insieme se Sarri la valuterà come ipotesi. In partenza non sarà facile considerando il modulo, ovvero il 4-3-3. Dia si trasforma in jolly, ma i suoi 9 gol e 4 assist nell’ultima stagione li ha portati."
+      }
+    },
+    {
+      "nome": "ADAMS C.",
+      "team": "TOR",
+      "prezzi": {
+        "min": 9,
+        "max": 20,
+        "avg": 14.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 5,
+        "f": 5.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 17,
+        "fantaclassic_2025": 11,
+        "profeta_2025": 20,
+        "sos_fanta_2025": 9,
+        "fantaboom_2024": 17,
+        "fantaclassic_2024": 11,
+        "profeta_2024": 20,
+        "sos_fanta_2024": 9
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 54,
+          "rating": 5.5
+        },
+        "2024_25": {
+          "goals": 9,
+          "assists": 4,
+          "minutes": 2657,
+          "rating": 6.0
+        }
+      },
+      "notes": {
+        "comm": "Che Adams ha sfiorato la doppia cifra al suo primo anno in Serie A. Bonus non sempre facili da prendere al fantacalcio, ma la stagione alla fine è stata in linea con le aspettative per un totale di 13 bonus complessivi. E in più ha giocato sempre (o quasi) titolare, complice anche l’infortunio di Duvan Zapata che gli ha tolto il partner d’attacco lasciandolo anche troppo solo. Quest’anno sarà diverso, torna a essere maggiormente un jolly e/o seconda punta, poi molto dipenderà dalla continuità che riuscirà ad avere Zapata. Adams potrebbe anche essere sottovalutato all’asta…"
+      }
+    },
+    {
+      "nome": "DOUVIKAS",
+      "team": "COM",
+      "prezzi": {
+        "min": 13,
+        "max": 16,
+        "avg": 14.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 5,
+        "f": 7.75
+      },
+      "allPrices": {
+        "fantaboom_2025": 13,
+        "fantaclassic_2025": 16,
+        "profeta_2025": 15,
+        "sos_fanta_2025": 13,
+        "fantaboom_2024": 13,
+        "fantaclassic_2024": 16,
+        "profeta_2024": 15,
+        "sos_fanta_2024": 13
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 1,
+          "assists": 0,
+          "minutes": 127,
+          "rating": 6.25
+        },
+        "2024_25": {
+          "goals": 2,
+          "assists": 1,
+          "minutes": 578,
+          "rating": 6.21
+        }
+      },
+      "notes": {
+        "comm": "Tasos Douvikas non è più un sicuro titolare del Como dopo l'arrivo di Morata come centravanti. Il greco diventa il vice dell'ex Milan, almeno sulla carta, perché poi si giocheranno il posto. Non andrà sottovalutato troppo e si è visto già in campionato. Il prezzo è sceso dopo l'arrivo di Morata ma non troppo. Come jolly, dall'inizio o a gara in corso, continuerà a fare comodo. Il Como è una squadra che può segnare molto e anche se dovesse subentrare a volte può essere interessante e da mettere a prescindere."
+      }
+    },
+    {
+      "nome": "BONNY",
+      "team": "INT",
+      "prezzi": {
+        "min": 10,
+        "max": 27,
+        "avg": 18.8
+      },
+      "stats": {
+        "t": 2,
+        "a": 4,
+        "i": 5,
+        "f": 10.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 10,
+        "fantaclassic_2025": 15,
+        "profeta_2025": 23,
+        "sos_fanta_2025": 27,
+        "fantaboom_2024": 10,
+        "fantaclassic_2024": 15,
+        "profeta_2024": 23,
+        "sos_fanta_2024": 27
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 1,
+          "assists": 0,
+          "minutes": 36,
+          "rating": 7.0
+        },
+        "2024_25": {
+          "goals": 6,
+          "assists": 4,
+          "minutes": 2545,
+          "rating": 6.03
+        }
+      },
+      "notes": {
+        "comm": "Yoan Bonny fa parte della batteria di attaccanti dell’Inter e parte subito bene con il gol alla prima. Classe 2003, è un rinforzo su cui i nerazzurri hanno puntato in ottica futura, ma che sarà utile fin da subito. Ha concluso la sua prima stagione in Serie A con 6 gol e 4 assist, confermando la crescita iniziata in Serie B l’anno precedente, quando aveva chiuso con 5 gol e 7 assist. È un profilo che Chivu conosce bene e che ritroverà questa stagione a Milano, dopo averlo allenato al Parma. Non sarà titolare nelle gerarchie iniziali, c’è abbondanza nel reparto ma non mancheranno le rotazioni. Come caratteristiche sembra essere più il vice di Thuram, ma una coppia è comunque rischiosa, fattibile al massimo se Bonny andrà via a pochi crediti. Altrimenti l’ex Parma si può prendere da solo come jolly."
+      }
+    },
+    {
+      "nome": "CAMBIAGHI",
+      "team": "BOL",
+      "prezzi": {
+        "min": 2,
+        "max": 10,
+        "avg": 4.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 2,
+        "f": 5.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 10,
+        "fantaclassic_2025": 3,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 2,
+        "fantaboom_2024": 10,
+        "fantaclassic_2024": 3,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 2
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 180,
+          "rating": 5.75
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 3,
+          "minutes": 614,
+          "rating": 6.15
+        }
+      },
+      "notes": {
+        "comm": "Nicolò Cambiaghi spera di avere maggiore spazio dopo l’addio di Ndoye. C’è anche il nuovo arrivato Bernardeschi, ma in carriera ha giocato più a destra o in posizione centrale, più raramente a sinistra. Cambiaghi ha pienamente recuperato dalla rottura del crociato già nella passata stagione, chiusa con 1 gol e 3 assist in 17 partite a voto. Deciderà Italiano, che è solito ruotare tanto i suoi tra tutte le competizioni. Listato attaccante, l’ex Empoli è solo un low cost da ultimi slot."
+      }
+    },
+    {
+      "nome": "PEDRO",
+      "team": "LAZ",
+      "prezzi": {
+        "min": 2,
+        "max": 13,
+        "avg": 6.0
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 4,
+        "f": 5.75
+      },
+      "allPrices": {
+        "fantaboom_2025": 6,
+        "fantaclassic_2025": 2,
+        "profeta_2025": 13,
+        "sos_fanta_2025": 3,
+        "fantaboom_2024": 6,
+        "fantaclassic_2024": 2,
+        "profeta_2024": 13,
+        "sos_fanta_2024": 3
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 53,
+          "rating": 5.75
+        },
+        "2024_25": {
+          "goals": 10,
+          "assists": 1,
+          "minutes": 1093,
+          "rating": 6.21
+        }
+      },
+      "notes": {
+        "comm": "Pedro arriva da una stagione indimenticabile e senza logica al fantacalcio. A 37 anni ha fatto 10 gol in Serie A, nella stagione precedente soltanto 1. È difficile spiegare questo +9 da un anno all’altro, molti gol sono anche arrivati da subentrante. Ora a 38 anni ci riprova, continuerà a subentrare spesso e sarà un jolly. Non potete chiedergli ancora 10 gol (e non va pagato come uno da doppia cifra), ma può essere per un altro anno un jolly, appunto, da bonus."
+      }
+    },
+    {
+      "nome": "DALLINGA",
+      "team": "BOL",
+      "prezzi": {
+        "min": 1,
+        "max": 5,
+        "avg": 2.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 5,
+        "f": 6.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 4,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 5,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 4,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 5,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 17,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 3,
+          "assists": 2,
+          "minutes": 1163,
+          "rating": 5.96
+        }
+      },
+      "notes": {
+        "comm": "Thijs Dallinga ha deluso le aspettative nella passata stagione, la prima a Bologna. Oltre a Castro, ora c’è anche Immobile e dunque aumenta la concorrenza in attacco. Italiano deciderà di partita in partita, sappiamo che è solito ruotare i suoi con gli impegni ravvicinati. Rischia di giocare ancora meno Dallinga, che parte come terzo attaccante in gerarchia. Al fantacalcio è meglio fare altre scelte se cercate un voto sicuro, sconsigliata anche la coppia visto che i centravanti del Bologna sono tre e non due."
+      }
+    },
+    {
+      "nome": "MOSQUERA",
+      "team": "VER",
+      "prezzi": {
+        "min": 0,
+        "max": 5,
+        "avg": 2.5
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 5,
+        "f": 6.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 4,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 5,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 4,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 5,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 36,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 5,
+          "assists": 1,
+          "minutes": 1371,
+          "rating": 5.88
+        }
+      },
+      "notes": {
+        "comm": "Daniel Mosquera ha chiuso la stagione con 5 gol e 1 assist, andando a voto 33 volte. Un numero alto, se consideriamo che è quasi sempre subentrato. Mentre il numero di gol è “condizionato” dalla doppietta al Napoli alla prima che aveva illuso. Ora parte con hype praticamente azzerato, rimane un’opzione da leghe numerose."
+      }
+    },
+    {
+      "nome": "VITINHA O.",
+      "team": "GEN",
+      "prezzi": {
+        "min": 1,
+        "max": 4,
+        "avg": 2.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 2,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 4,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 2,
+        "fantaboom_2024": 4,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 2
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 21,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 2,
+          "assists": 3,
+          "minutes": 1337,
+          "rating": 5.89
+        }
+      },
+      "notes": {
+        "comm": "Vitinha si giocherà una maglia da titolare con il nuovo arrivato Colombo al centro dell’attacco del Genoa. All’occorrenza, il portoghese può giocare anche da esterno offensivo o da seconda punta. L’anno scorso 2 gol e 3 assist in 22 partite a voto, non molto: proverà a migliorare questo bottino di bonus, dipenderà anche dallo spazio che troverà. Non un titolare fisso col posto garantito in partenza, ma può comunque andare spesso e volentieri a voto, a volte dall’inizio e altre a gara in corso."
+      }
+    },
+    {
+      "nome": "ALMQVIST",
+      "team": "PAR",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.5
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 3,
+        "f": 6.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 136,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 1,
+          "minutes": 1120,
+          "rating": 5.79
+        }
+      },
+      "notes": {
+        "comm": "Pontus Almqvist non è una prima scelta per il fantacalcio, anche perché è penalizzato dal ruolo di attaccante essendo un esterno. Nel reparto è tra le seconde opzioni all’asta, non si tratta di un titolare fisso e porta pochi bonus, l’anno scorso soltanto un gol e un assist."
+      }
+    },
+    {
+      "nome": "GIMENEZ",
+      "team": "MIL",
+      "prezzi": {
+        "min": 25,
+        "max": 68,
+        "avg": 50.5
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 3,
+        "f": 5.25
+      },
+      "allPrices": {
+        "fantaboom_2025": 60,
+        "fantaclassic_2025": 49,
+        "profeta_2025": 68,
+        "sos_fanta_2025": 25,
+        "fantaboom_2024": 60,
+        "fantaclassic_2024": 49,
+        "profeta_2024": 68,
+        "sos_fanta_2024": 25
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 177,
+          "rating": 5.25
+        },
+        "2024_25": {
+          "goals": 5,
+          "assists": 2,
+          "minutes": 676,
+          "rating": 5.88
+        }
+      },
+      "notes": {
+        "comm": "Santiago Gimenez è rimasto al Milan. Il buon inizio in rossonero nelle prime partite del 2025 è ormai un lontano ricordo. Solo nel finale della scorsa stagione, subentrando, aveva avuto un sussulto ritrovando i bonus al fantacalcio. La nuova stagione è iniziata male, prima contro la Cremonese e poi contro il Lecce con anche uno sfortunato gol annullato. Adesso si fa dura per lui, perché con l'arrivo di Nkunku lo spazio si ridurrà. A inizio campionato, di fatto, ha giocato solo perché Leao era infortunato. Ora è solo un jolly, un attaccante di scorta per Allegri, che non lo vede benissimo. Infatti fino all'ultimo il Milan ha provato a scambiarlo, poi alla fine è rimasto. Non c'è grande fiducia in partenza attorno al Bebote, che sembra a terra anche psicologicamente. Può essere appunto un jolly da tenere in rosa e mettere in determinate partite, anche se nel Milan partirà dietro e non più come titolare. Però sappiamo che nel corso della stagione ci possono anche essere momenti positivi."
+      }
+    },
+    {
+      "nome": "DOVBYK",
+      "team": "ROM",
+      "prezzi": {
+        "min": 30,
+        "max": 52,
+        "avg": 38.5
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 4,
+        "f": 5.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 52,
+        "fantaclassic_2025": 32,
+        "profeta_2025": 40,
+        "sos_fanta_2025": 30,
+        "fantaboom_2024": 52,
+        "fantaclassic_2024": 32,
+        "profeta_2024": 40,
+        "sos_fanta_2024": 30
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 33,
+          "rating": 5.5
+        },
+        "2024_25": {
+          "goals": 12,
+          "assists": 2,
+          "minutes": 2430,
+          "rating": 6.0
+        }
+      },
+      "notes": {
+        "comm": "Artem Dovbyk alla fine è rimasto alla Roma. Ci sono state tante voci di mercato riguardo a una possibile partenza, questo perché da un punto di vista tecnico non è considerato l'attaccante ideale per Gasperini. In estate è arrivato Evan Ferguson che ha giocato da titolare le prime due partite, facendo bene (un assist). Ci sarà così un dualismo in attacco, Gasperini potrà alternarli tra campionato ed Europa League. Al suo primo anno in Italia l’ucraino ha segnato 12 gol, con i pro e contro della prima punta classica al fantacalcio. Il principale difetto sono i voti bassi quando non fa gol, spesso ha preso anche 6,5 e non 7 quando ha segnato. In partenza insegue e parte dietro nelle gerarchie, in questo momento Ferguson è il titolare e Dovbyk la riserva. Artem dovrà essere bravo a farsi trovare pronto quando verrà impiegato, sia dall'inizio che a gara in corso. Rispetto all'anno scorso non ha più il posto da centravanti assicurato. Anzi, ora parte da riserva. Ma questo non vuol dire che non avrà più spazio: ci sarà minutaggio anche per lui, dovrà però mostrare dei miglioramenti e convincere Gasperini. La coppia con Ferguson forse non è più impossibile se Dovbyk va via a poco. Il suo prezzo infatti è crollato col passare delle settimane."
+      }
+    },
+    {
+      "nome": "IMMOBILE",
+      "team": "BOL",
+      "prezzi": {
+        "min": 16,
+        "max": 45,
+        "avg": 25.0
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 2,
+        "f": 6.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 45,
+        "fantaclassic_2025": 16,
+        "profeta_2025": 20,
+        "sos_fanta_2025": 19,
+        "fantaboom_2024": 45,
+        "fantaclassic_2024": 16,
+        "profeta_2024": 20,
+        "sos_fanta_2024": 19
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 30,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 2031,
+          "rating": 6.0
+        }
+      },
+      "notes": {
+        "comm": "Ciro Immobile crolla come prezzo al fantacalcio dopo l'infortunio. Il Bologna ha stimato i tempi di recupero in 8 settimane a partire dal 25 agosto. Questo vuol dire che per Immobile all'asta ora cambia tutto. Già prima si giocava il posto con Castro però almeno partiva avanti. Ora starà fuori a lungo e quindi diventa maggiormente un jolly, poi al rientro dovrà lottare con l'argentino e recuperare la forma migliore. La partenza è in salita e il prezzo scende tantissimo come giusto che sia e come sempre capita per gli infortunati. Il suo precampionato era stato ottimo, così come aveva segnato parecchio anche in Turchia: al Besiktas aveva segnato 15 gol in 30 partite di campionato, più 4 assist. E quando gioca sarà probabilmente il primo rigorista, sono lui e Orsolini le scelte."
+      }
+    },
+    {
+      "nome": "VLAHOVIC",
+      "team": "JUV",
+      "prezzi": {
+        "min": 45,
+        "max": 70,
+        "avg": 52.5
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 3,
+        "f": 10.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 45,
+        "fantaclassic_2025": 50,
+        "profeta_2025": 45,
+        "sos_fanta_2025": 70,
+        "fantaboom_2024": 45,
+        "fantaclassic_2024": 50,
+        "profeta_2024": 45,
+        "sos_fanta_2024": 70
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 2,
+          "assists": 0,
+          "minutes": 38,
+          "rating": 7.0
+        },
+        "2024_25": {
+          "goals": 10,
+          "assists": 3,
+          "minutes": 1797,
+          "rating": 6.12
+        }
+      },
+      "notes": {
+        "comm": "Dusan Vlahovic ora diventa interessante al fantacalcio, è cambiato tutto nel corso di queste settimane. Anche in chiave fantacalcio, dopo i gol a Parma e Genoa nelle prime due di campionato. Alla fine Dusan è rimasto in bianconero e non è tornato Kolo Muani, dunque in attacco ci sono lui e David, in più è arrivato Openda che è un jolly (può giocare sia punta che alle spalle del centravanti). E così il serbo ha preso tantissimo appeal nelle aste, prezzo più che triplicato rispetto ad agosto. Perché non solo può subentrare (segnando) nel secondo tempo, ma può anche insidiare Jonathan David. Magari non prendendo una maglia da titolare in modo fisso, ma comunque giocando spesso in campionato per il turnover da Champions. Non sarà il primo slot dei tempi d'oro ma è almeno un secondo, è un semitop nella guida. E occhio anche ai rigori: Tudor non lo aveva menzionato in conferenza, ma Vlahovic è uno specialista da 28 su 32 in carriera e dietro a Locatelli c'è anche lui, eccome."
+      }
+    },
+    {
+      "nome": "LOOKMAN",
+      "team": "ATA",
+      "prezzi": {
+        "min": 25,
+        "max": 43,
+        "avg": 37.0
+      },
+      "stats": {
+        "t": 3,
+        "a": 5,
+        "i": 3,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 40,
+        "fantaclassic_2025": 25,
+        "profeta_2025": 43,
+        "sos_fanta_2025": 40,
+        "fantaboom_2024": 40,
+        "fantaclassic_2024": 25,
+        "profeta_2024": 43,
+        "sos_fanta_2024": 40
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 15,
+          "assists": 4,
+          "minutes": 2263,
+          "rating": 6.42
+        }
+      },
+      "notes": {
+        "comm": "Ademola Lookman resta un caso caldo anche se alla fine non dovrebbe andare via, né in Turchia né in Arabia Saudita. L'Atalanta lo reintegra e ora si aspetta di capire come si comporterà il giocatore, ma potrebbe tornare in campo. Per chi deve fare l’asta, ora tutto dipende dal prezzo e da quanto vanno gli altri attaccanti. Da occasione, Lookman può ancora essere un affare al fantacalcio. Può diventare rischioso se il prezzo sale troppo, ma fino a ora stava andando a circa il 2%, quindi molto poco. Il vostro “motto” deve essere questo: Lookman da jolly con un tridente già forte, così siete comunque coperti. Anche perché avrà la Coppa d’Africa e a gennaio potrebbe trasferirsi."
+      }
+    },
+    {
+      "nome": "DZEKO",
+      "team": "FIO",
+      "prezzi": {
+        "min": 11,
+        "max": 25,
+        "avg": 17.5
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 4,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 25,
+        "fantaclassic_2025": 14,
+        "profeta_2025": 20,
+        "sos_fanta_2025": 11,
+        "fantaboom_2024": 25,
+        "fantaclassic_2024": 14,
+        "profeta_2024": 20,
+        "sos_fanta_2024": 11
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 13,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 2247,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Edin Dzeko vuole essere protagonista nella Fiorentina, nonostante l'arrivo di Piccoli e un inizio in sordina. Classe 1986, a 39 anni non intende fare la riserva ma al fantacalcio è solo un jolly e non di più, il prezzo è calato. Però è ancora in forma e lo ha dimostrato anche nella scorsa stagione al Fenerbahce. In Turchia ha collezionato ben 53 presenze tra tutte le competizioni, segnando 21 gol e servendo 8 assist. In campionato 14 reti, 21 nella stagione precedente. A Firenze arriva per dare esperienza, qualità e peso offensivo. Può giocare insieme a Kean oppure al suo posto se è assente, ma c'è pure Piccoli e anche per questo va evitata la coppia. Per quanto riguarda i rigori, Edin non è una primissima scelta e non è mai stato un grande specialista in Italia, nessuno calciato all’Inter e più sbagliati che segnati alla Roma (3 a 5). In Turchia invece ne ha segnati 7 su 9. Potrebbe partire come semplice alternativa dal dischetto.\n\n"
+      }
+    },
+    {
+      "nome": "LANG",
+      "team": "NAP",
+      "prezzi": {
+        "min": 12,
+        "max": 20,
+        "avg": 16.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 2,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 20,
+        "fantaclassic_2025": 13,
+        "profeta_2025": 20,
+        "sos_fanta_2025": 12,
+        "fantaboom_2024": 20,
+        "fantaclassic_2024": 13,
+        "profeta_2024": 20,
+        "sos_fanta_2024": 12
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 17,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 1914,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Noa Lang raccoglie l’eredità di Kvaratskhelia al Napoli sei mesi dopo il suo addio, ma parte in sordina. Il ruolo è quello: ala sinistra. Nell’ultima stagione è stato protagonista del titolo del PSV con 11 gol e 10 assist in campionato. Si parla spesso del suo carattere ma in campo le ultime due espulsioni sono arrivate nel lontano 2021-22. Nell’ultimo campionato solo 2 ammonizioni. Non è uno specialista per punizioni e rigori, è più un giocatore di velocità e dribbling che può portare bonus su azione. Penalizzato dal ruolo di attaccante al fantacalcio, non è bomber ma un esterno che può portare buoni voti e assist. Partenza lenta che fa calare il suo prezzo."
+      }
+    },
+    {
+      "nome": "CAMARDA",
+      "team": "LEC",
+      "prezzi": {
+        "min": 10,
+        "max": 25,
+        "avg": 15.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 4,
+        "f": 5.25
+      },
+      "allPrices": {
+        "fantaboom_2025": 12,
+        "fantaclassic_2025": 14,
+        "profeta_2025": 25,
+        "sos_fanta_2025": 10,
+        "fantaboom_2024": 12,
+        "fantaclassic_2024": 14,
+        "profeta_2024": 25,
+        "sos_fanta_2024": 10
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 128,
+          "rating": 5.25
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 214,
+          "rating": 5.92
+        }
+      },
+      "notes": {
+        "comm": "Francesco Camarda è uno dei migliori giovani talenti del calcio italiano, il Lecce lo ha preso in prestito con diritto di riscatto e controriscatto più dei bonus per presenze e gol che farà. Sono degli incentivi, lo spazio lo avrà anche dopo l'arrivo di Stulic. Titolare o no, Camarda avrà comunque le sue possibilità, con Di Francesco che storicamente punta molto sui giovani. Nella scorsa stagione ha totalizzato 10 presenze (o meglio spezzoni) con la maglia rossonera, quindi l'impatto con la Serie A c'è già stato: questo dovrà essere l’anno dello slancio, trovando i primi gol da professionista. Scommessa intrigante, ancora di più dopo la partenza di Krstovic. Al suo posto è arrivato Stulic, ma sicuramente il montenegrino era più ingombrante. Lì c'era titolare e riserva, ora invece c'è un dualismo più aperto."
+      }
+    },
+    {
+      "nome": "RODRIGUEZ JE.",
+      "team": "COM",
+      "prezzi": {
+        "min": 8,
+        "max": 11,
+        "avg": 9.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 4,
+        "f": 6.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 10,
+        "fantaclassic_2025": 8,
+        "profeta_2025": 10,
+        "sos_fanta_2025": 11,
+        "fantaboom_2024": 10,
+        "fantaclassic_2024": 8,
+        "profeta_2024": 10,
+        "sos_fanta_2024": 11
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 179,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 1129,
+          "rating": 6.5
+        }
+      },
+      "notes": {
+        "comm": "Jesus Rodriguez è uno dei più talentuosi tra gli acquisti del Como. Operazione da 22,5 milioni solo di base fissa, più 5 di bonus. Il prezzo di chi arriva per essere protagonista, non una comparsa. Anche se è molto giovane, ha solo 19 anni. Un gioiellino spagnolo del 2005 che proviene dal Betis ed è alto 185 cm. È destro di piede e fa l’ala sinistra, in quella posizione non mancherà la concorrenza nel Como ma Fabregas può valorizzare tutti. E di Jesus ha grande stima. Vista la giovanissima età deve ancora esplodere, fin qui ha fatto una sola vera stagione, l’ultima. In tutto 32 presenze (poco più della metà da titolare) col Betis in prima squadra, 3 gol e 2 assist. Con l’Under 21 spagnola 5 partite e un gol. È tra i più penalizzati dal fanta-ruolo di attaccante, resta comunque una scommessa jolly per chi punta sui giovane talenti."
+      }
+    },
+    {
+      "nome": "ADDAI",
+      "team": "COM",
+      "prezzi": {
+        "min": 5,
+        "max": 9,
+        "avg": 7.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 2,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 9,
+        "fantaclassic_2025": 9,
+        "profeta_2025": 5,
+        "sos_fanta_2025": 8,
+        "fantaboom_2024": 9,
+        "fantaclassic_2024": 9,
+        "profeta_2024": 5,
+        "sos_fanta_2024": 8
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 335,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Jayden Addai è uno degli esterni d’attacco a disposizione di Fabregas per il nuovo Como. Il classe 2005 olandese è un’ala mancina che gioca a destra a cui piace accentrarsi. Giocatore rapido che si esalta nel dribbling, un buon prospetto che sembra essere già pronto per la Serie A. Protagonista in preseason ma un po’ penalizzato dal fanta-ruolo di attaccante. Resta comunque un’opzione interessante come scommessa davanti, pur non essendo un goleador (tre gol l’anno scorso all’AZ Alkmaar)."
+      }
+    },
+    {
+      "nome": "KUHN",
+      "team": "COM",
+      "prezzi": {
+        "min": 7,
+        "max": 20,
+        "avg": 11.5
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 3,
+        "f": 5.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 9,
+        "fantaclassic_2025": 10,
+        "profeta_2025": 20,
+        "sos_fanta_2025": 7,
+        "fantaboom_2024": 9,
+        "fantaclassic_2024": 10,
+        "profeta_2024": 20,
+        "sos_fanta_2024": 7
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 34,
+          "rating": 5.5
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 1876,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Nicolas Kuhn è uno degli esterni più “pronti” in casa Como. Ala prevalentemente di destra ma che può giocare anche a sinistra (di piede è mancino). Anche lui è stato pagato una cifra importante: 19 milioni per prelevarlo dal Celtic. È un'ala molto prolifica a livello numerico: solo nell'ultima stagione in Scozia ha messo a segno complessivamente ben 21 gol e 15 assist in 51 partite, dati assolutamente positivi e da tenere in considerazione. Al fantacalcio è listato come attaccante, quindi passa agli slot secondari e non avrà il posto fisso nel vostro tridente. Però parliamo di un giocatore molto interessante. Come detto è prolifico ed è anche nel pieno della maturità, perché ha 25 anni. È forse il più maturo tra i nuovi arrivati in casa Como, anche se dovrà passare dal campionato scozzese a quello italiano e questa è un'incognita. Ha però segnato anche tre gol nell'ultima Champions, non pochi. Zero espulsioni in carriera, non molti i cartellini gialli. Nell'ultima stagione solo 10 giorni saltati per infortuni muscolari, lo stop precedente era nel 2023. Non è, al momento, un rigorista."
+      }
+    },
+    {
+      "nome": "GIOVANE",
+      "team": "VER",
+      "prezzi": {
+        "min": 7,
+        "max": 10,
+        "avg": 8.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 4,
+        "f": 7.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 8,
+        "fantaclassic_2025": 10,
+        "profeta_2025": 10,
+        "sos_fanta_2025": 7,
+        "fantaboom_2024": 8,
+        "fantaclassic_2024": 10,
+        "profeta_2024": 10,
+        "sos_fanta_2024": 7
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 1,
+          "minutes": 180,
+          "rating": 6.5
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 1,
+          "minutes": 180,
+          "rating": 7.0
+        }
+      },
+      "notes": {
+        "comm": "Giovane Santana do Nascimento, per tutti Giovane, è l’ultima scommessa del Verona. Un club che regala spesso al fantacalcio dei talenti interessanti. Qui si tratta di un attaccante, è alto 184 cm ed è un classe 2003. Mancino, ha un buon piede e abilità di tiro. Può fare la prima e la seconda punta. Al Corinthians, dove è arrivato nel 2022, non ha avuto molto spazio da titolare, giocando 47 partite e segnando solo 3 gol. Ha però giocato anche nel Brasile Under 20 e Under 23. Le qualità ce le ha, ma deve adattarsi alla Serie A. Per questo è la classica scommessa sudamericana da ultimo slot."
+      }
+    },
+    {
+      "nome": "DOMINGUEZ B.",
+      "team": "BOL",
+      "prezzi": {
+        "min": 2,
+        "max": 7,
+        "avg": 3.5
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 4,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 7,
+        "fantaclassic_2025": 3,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 2,
+        "fantaboom_2024": 7,
+        "fantaclassic_2024": 3,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 2
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 3,
+          "assists": 2,
+          "minutes": 1310,
+          "rating": 6.28
+        }
+      },
+      "notes": {
+        "comm": "Benjamin Dominguez ha chiuso la scorsa stagione con 3 gol e 2 assist in 20 partite a voto. C’era Ndoye sulla fascia sinistra, ora lo svizzero è partito e Dominguez può avere più continuità. Nella passata stagione si sono visti sprazzi importanti di Dominguez, ora dovrà essere bravo lui a prendersi il posto a sinistra. Comunque Italiano è solito alternare i suoi, quindi non si può parlare di maglia garantita. All’asta è da prendere come low cost in attacco e non di più per ora, da quarto/quinto slot a seconda delle leghe."
+      }
+    },
+    {
+      "nome": "BONAZZOLI",
+      "team": "CRE",
+      "prezzi": {
+        "min": 0,
+        "max": 6,
+        "avg": 2.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 2,
+        "f": 10.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 6,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 2,
+        "fantaboom_2024": 6,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 2
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 1,
+          "assists": 0,
+          "minutes": 84,
+          "rating": 7.5
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 0,
+          "minutes": 1321,
+          "rating": 7.5
+        }
+      },
+      "notes": {
+        "comm": "Federico Bonazzoli è tornato, segnando un gran gol alla prima contro il Milan. Ora riprende valore al fantacalcio, prima dell’inizio del campionato era ai minimi. Rimane molto low cost, però ha un po’ di appeal in più e si giocherà il posto nell’attacco della Cremonese, Nicola vuole continuare a rivitalizzarlo. Ma la concorrenza è importantissima là davanti, a maggior ragione dopo gli arrivi di Vardy e Sanabria.\n\n"
+      }
+    },
+    {
+      "nome": "BUKSA",
+      "team": "UDI",
+      "prezzi": {
+        "min": 4,
+        "max": 10,
+        "avg": 6.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 2,
+        "f": 6.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 6,
+        "fantaclassic_2025": 7,
+        "profeta_2025": 10,
+        "sos_fanta_2025": 4,
+        "fantaboom_2024": 6,
+        "fantaclassic_2024": 7,
+        "profeta_2024": 10,
+        "sos_fanta_2024": 4
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 209,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 12,
+          "assists": 1,
+          "minutes": 1702,
+          "rating": 6.0
+        }
+      },
+      "notes": {
+        "comm": "Adam Buksa rinforza l’attacco dell’Udinese, sostituisce Lorenzo Lucca ed è stato pagato circa 5 milioni. Si tratta di una prima punta fisica, è alto 191 cm ed è mancino di piede. Ha un buon piede e fa sia sponde che cambi di gioco, oltre ad avere un tiro potente. Ha 29 anni e fa parte della nazionale polacca, con cui ha fatto 23 partite e 7 gol. Nell’ultima stagione ha giocato al Midtjylland facendo 12 gol in 24 partite di campionato. Più 3 gol tra qualificazioni Champions ed Europa League. Il suo record di gol è 16 due anni fa in Turchia e nel 2021 in MLS. È anche rigorista, 12 su 13 in carriera di cui 4 l’anno scorso. Può diventare il primo rigorista dell’Udinese ed essere anche titolare, facendo così il classico attaccante di provincia low cost di buon livello, appena sopra a quelli da ultimo slot."
+      }
+    },
+    {
+      "nome": "SULEMANA K.",
+      "team": "ATA",
+      "prezzi": {
+        "min": 3,
+        "max": 10,
+        "avg": 6.5
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 3,
+        "f": 5.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 6,
+        "fantaclassic_2025": 7,
+        "profeta_2025": 10,
+        "sos_fanta_2025": 3,
+        "fantaboom_2024": 6,
+        "fantaclassic_2024": 7,
+        "profeta_2024": 10,
+        "sos_fanta_2024": 3
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 45,
+          "rating": 5.75
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 1427,
+          "rating": 6.0
+        }
+      },
+      "notes": {
+        "comm": "Kamaldeen Sulemana rafforza il reparto offensivo dell’Atalanta. Si tratta di un’ala sinistra, questo il suo ruolo naturale. Ma può giocare anche in altre posizioni dell’attacco. Non è detto che sarà un sicuro titolare, ma il ghanese classe 2002 è stato comunque pagato 17 milioni, non poco. Nell’ultima disastrosa stagione del Southampton ha fatto solo un gol in Premier. Non è stato nemmeno sempre titolare fisso, solo 17 dal primo minuto. A Juric però è piaciuto e con lui, tra tutte le competizioni, ha fatto 2 gol e 2 assist in 15 partite. Nell’ultima annata ha anche perso 10 partite per colpa di due infortuni, addirittura 24 nella stagione precedente. In nazionale ghanese ha 19 presenze all’attivo, senza gol."
+      }
+    },
+    {
+      "nome": "ESPOSITO F.P.",
+      "team": "INT",
+      "prezzi": {
+        "min": 2,
+        "max": 8,
+        "avg": 4.5
+      },
+      "stats": {
+        "t": 2,
+        "a": 4,
+        "i": 5,
+        "f": 6.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 5,
+        "fantaclassic_2025": 3,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 8,
+        "fantaboom_2024": 5,
+        "fantaclassic_2024": 3,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 8
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 22,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 2781,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Pio Esposito è il nuovo che avanza. Chivu lo ha definito il futuro della Nazionale italiana, è l’attaccante in rampa di lancio in questo momento. L’Inter ha rifiutato offerte importanti, decidendo di tenerlo in rosa. Sarà uno degli elementi del reparto d’attacco, non parte come titolare ovviamente ma sarà un jolly. Classe 2005, Esposito è alto 191 cm e ha caratteristiche che mancano nel reparto nerazzurro. L’anno scorso ha fatto 19 gol in Serie B allo Spezia. All’Inter potrà fare qualche gol quando gioca per il turnover o da subentrante. Se poi dovesse avere troppo poco spazio, potrebbe andar via in prestito a gennaio, salendo di valutazione al fanta."
+      }
+    },
+    {
+      "nome": "BRAVO",
+      "team": "UDI",
+      "prezzi": {
+        "min": 1,
+        "max": 15,
+        "avg": 5.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 5,
+        "f": 5.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 4,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 15,
+        "sos_fanta_2025": 3,
+        "fantaboom_2024": 4,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 15,
+        "sos_fanta_2024": 3
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 61,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 2,
+          "assists": 0,
+          "minutes": 688,
+          "rating": 6.0
+        }
+      },
+      "notes": {
+        "comm": "Iker Bravo dopo una prima stagione di ambientamento in Italia prova ad affermarsi al suo secondo anno. È ancora molto giovane, perché è un classe 2005. È partito bene, ora a sta a lui confermarsi e migliorare le 16 partite a voto con 2 gol della scorsa stagione. Rischia di avere meno spazio di quanto si poteva pensare dopo gli arrivi della fase finale di mercato (Buksa e Zaniolo su tutti). La concorrenza ora c'è eccome nel reparto avanzato dell'Udinese.\n\n"
+      }
+    },
+    {
+      "nome": "ABOUKHLAL",
+      "team": "TOR",
+      "prezzi": {
+        "min": 1,
+        "max": 10,
+        "avg": 4.0
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 4,
+        "f": 5.5
+      },
+      "allPrices": {
+        "fantaboom_2025": 3,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 10,
+        "sos_fanta_2025": 2,
+        "fantaboom_2024": 3,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 10,
+        "sos_fanta_2024": 2
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 42,
+          "rating": 5.5
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 1907,
+          "rating": 5.5
+        }
+      },
+      "notes": {
+        "comm": "Zakaria Aboukhlal è uno dei volti nuovi del Torino di Baroni. Arriva dal Tolosa, è un esterno offensivo che può giocare su entrambe le fasce. Nell'ultima Ligue 1 ha realizzato 7 gol e 4 assist, il record personale è di 10 reti nel campionato 2022/23 (sempre nella massima divisione francese). 25 gol e 9 assist in 83 gare con la maglia dei francesi, in precedenza giocava nell'AZ Alkmaar. Ha giocato prevalentemente da ala destra (137 partite), ma anche a sinistra (65 partite, meno della metà). È arrivato anche Ngonge, sarà Baroni a provare i due e decidere chi agirà su una fascia e chi sull’altra. Entrambi preferirebbero a destra, ma possono comunque giocare insieme. Al fantacalcio è listato attaccante, da centrocampista sarebbe stato sicuramente più intrigante. Così, è un colpo indicativamente da quarto/quinto slot a seconda delle leghe e del numero di partecipanti.\n\n"
+      }
+    },
+    {
+      "nome": "LUVUMBO",
+      "team": "CAG",
+      "prezzi": {
+        "min": 2,
+        "max": 3,
+        "avg": 2.5
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 2,
+        "f": 6.25
+      },
+      "allPrices": {
+        "fantaboom_2025": 3,
+        "fantaclassic_2025": 2,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 3,
+        "fantaboom_2024": 3,
+        "fantaclassic_2024": 2,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 3
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 61,
+          "rating": 6.25
+        },
+        "2024_25": {
+          "goals": 2,
+          "assists": 2,
+          "minutes": 1614,
+          "rating": 5.98
+        }
+      },
+      "notes": {
+        "comm": "Zito Luvumbo è un talento ancora in cerca di consacrazione al fantacalcio. La scorsa stagione è stata condizionata dagli infortuni, che ne hanno limitato spazio e continuità, nonostante abbia chiuso comunque in crescita con buoni voti. Quest’anno parte con la concorrenza di Sebastiano Esposito, anche se potrebbero pure giocare insieme. Ma comunque al momento il suo hype cala, rimane da slot secondari."
+      }
+    },
+    {
+      "nome": "BANDA",
+      "team": "LEC",
+      "prezzi": {
+        "min": 0,
+        "max": 2,
+        "avg": 1.0
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 2,
+        "f": 5.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 2,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 2
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 59,
+          "rating": 5.5
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 1,
+          "minutes": 609,
+          "rating": 5.77
+        }
+      },
+      "notes": {
+        "comm": "Lameck Banda è andato solo 13 volte a voto nella passata stagione, con 1 assist. Di Francesco crede molto in lui e lo ha detto apertamente, ora sarà Banda a dover dare risposte sul campo. Niente posto garantito, anzi, c’è grande abbondanza e lui è listato attaccante. Da centrocampista sarebbe stato più appetibile al fanta, così meno e non si possono neanche fare coppie. Siamo sugli ultimi slot in attacco, non di più al momento."
+      }
+    },
+    {
+      "nome": "BAYO V.",
+      "team": "UDI",
+      "prezzi": {
+        "min": 1,
+        "max": 5,
+        "avg": 2.0
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 4,
+        "f": 5.75
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 5,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 5,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 92,
+          "rating": 5.75
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 2258,
+          "rating": 5.5
+        }
+      },
+      "notes": {
+        "comm": "Sono sempre dei jolly ma con ancora meno spazio previsto, occhio anche al mercato in alcuni casi. Opzioni esclusivamente da leghe molto numerose."
+      }
+    },
+    {
+      "nome": "BORRELLI",
+      "team": "CAG",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.5
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 4,
+        "f": 5.25
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 105,
+          "rating": 5.5
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 2555,
+          "rating": 5.5
+        }
+      },
+      "notes": {
+        "comm": "Sono jolly che possono fare comodo in leghe numerose per completare il reparto, si vedrà con la preseason se qualcuno potrà avere più spazio del previsto."
+      }
+    },
+    {
+      "nome": "KILICSOY",
+      "team": "CAG",
+      "prezzi": {
+        "min": 1,
+        "max": 8,
+        "avg": 3.0
+      },
+      "stats": {
+        "t": 3,
+        "a": 4,
+        "i": 4,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 8,
+        "sos_fanta_2025": 2,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 8,
+        "sos_fanta_2024": 2
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 9,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 1317,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Semih Kilicsoy è una scommessa per l’attacco del Cagliari. Si tratta di un giocatore offensivo, alto 187 cm, che può fare la punta o l’esterno d’attacco, ed è molto giovane perché è del 2005. Conta però già 4 presenze in nazionale maggiore e 16 gol in 87 partite al Besiktas, dove è cresciuto. Molto bene due anni con 11 gol in 23 presenze in campionato, di cui 20 da titolare. L’anno scorso invece ha giocato di più ma meno da titolare (solo 11 volte, era chiuso da Immobile), segnando 3 gol. Rischia di trovare ancora meno spazio dopo l'arrivo di Belotti.\n\n"
+      }
+    },
+    {
+      "nome": "MOREO",
+      "team": "PIS",
+      "prezzi": {
+        "min": 0,
+        "max": 2,
+        "avg": 0.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 3,
+        "f": 6.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 2,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 2
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 127,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 2662,
+          "rating": 6.5
+        }
+      },
+      "notes": {
+        "comm": "Stefano Moreo è un trequartista del Pisa, si gioca una maglia nei due alle spalle della punta nel 3-4-2-1 di Gilardino. Avrà spazio, dall’inizio o a gara in corso. È alto 191 cm ed è un classe ’93, ha esperienza ed è in nerazzurro dal 2023. L’anno scorso 7 gol e 7 assist in Serie B, al fanta è listato attaccante e quindi solo da leghe numerose."
+      }
+    },
+    {
+      "nome": "N'DRI",
+      "team": "LEC",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.5
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 3,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 1,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 1,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 17,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 313,
+          "rating": 5.86
+        }
+      },
+      "notes": {
+        "comm": "Konan N’Dri è uno degli esterni a disposizione del Lecce. Di Francesco dovrà fare le sue scelte, c’è abbondanza sugli esterni ma ne vuole quattro in modo da poterne cambiare due a gara in corso. A volte titolare, a volte subentrante, l’ivoriano non è un titolare sicuro ma può andare spesso a voto. In attacco però c’è di meglio per titolarità e bonus."
+      }
+    },
+    {
+      "nome": "AMBROSINO",
+      "team": "NAP",
+      "prezzi": {
+        "min": 0,
+        "max": 0,
+        "avg": 0.0
+      },
+      "stats": {
+        "t": 0,
+        "a": 0,
+        "i": 0,
+        "f": 0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 0,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 0
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 5,
+          "assists": 3,
+          "minutes": 2229,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Non sono giocatori su cui puntare per il fantacalcio, potete fare altre scelte."
+      }
+    },
+    {
+      "nome": "BENEDYCZAK",
+      "team": "PAR",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 2,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 10,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 213,
+          "rating": 5.67
+        }
+      },
+      "notes": {
+        "comm": "Adrian Benedyczak arriva da una stagione condizionata dagli infortuni. Ha potenzialità, ma è andato a voto soltanto 6 volte, quindi non si è praticamente mai visto. Nessun gol né assist l’anno scorso, quest’anno proverà a migliorare ma rimane una soluzione di secondo piano al fantacalcio, anche se con Cuesta può avere più spazio."
+      }
+    },
+    {
+      "nome": "BUFFON L.",
+      "team": "PIS",
+      "prezzi": {
+        "min": 0,
+        "max": 0,
+        "avg": 0.0
+      },
+      "stats": {
+        "t": 0,
+        "a": 0,
+        "i": 0,
+        "f": 0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 0,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 0
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 13,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Non si tratta di prime scelte per l’attacco, anzi. Sono opzioni rischiose e che non dovrebbero avere molto spazio."
+      }
+    },
+    {
+      "nome": "CANCELLIERI",
+      "team": "LAZ",
+      "prezzi": {
+        "min": 0,
+        "max": 2,
+        "avg": 1.5
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 3,
+        "f": 5.75
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 2,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 2,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 2,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 2
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 151,
+          "rating": 5.75
+        },
+        "2024_25": {
+          "goals": 3,
+          "assists": 0,
+          "minutes": 1440,
+          "rating": 5.76
+        }
+      },
+      "notes": {
+        "comm": "Matteo Cancellieri è una delle sorprese del precampionato della Lazio. Ha approfittato dei problemi di salute di Isaksen per mettersi in mostra e convincere Sarri. Ora se la può giocare. Non vuol dire che sarà titolare, ma sarà quantomeno preso in considerazione e potrà andare spesso a voto."
+      }
+    },
+    {
+      "nome": "CHEDDIRA",
+      "team": "SAS",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 4,
+        "f": null
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 11,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Walid Cheddira alla fine non è andato all’Udinese ma al Sassuolo. L’attaccante arriva da una stagione deludente in Liga, solo 1 gol in 22 partite. In Serie A aveva fatto 7 gol al Frosinone con 36 partite a voto. Al Sassuolo invece non parte come titolare ma da vice Pinamonti. Soluzione solo da lega numerosa."
+      }
+    },
+    {
+      "nome": "DE LUCA",
+      "team": "CRE",
+      "prezzi": {
+        "min": 0,
+        "max": 5,
+        "avg": 1.2
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 3,
+        "f": 10.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 5,
+        "sos_fanta_2025": 0,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 5,
+        "sos_fanta_2024": 0
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 1,
+          "assists": 0,
+          "minutes": 19,
+          "rating": 7.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 1661,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Non sono giocatori su cui puntare per il fantacalcio, potete fare altre scelte.\n"
+      }
+    },
+    {
+      "nome": "DJURIC",
+      "team": "PAR",
+      "prezzi": {
+        "min": 0,
+        "max": 2,
+        "avg": 0.8
+      },
+      "stats": {
+        "t": 2,
+        "a": 3,
+        "i": 2,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 2,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 5,
+          "assists": 1,
+          "minutes": 1554,
+          "rating": 6.0
+        }
+      },
+      "notes": {
+        "comm": "Milan Djuric non parte come titolare nel Parma di Cuesta. Nella scorsa stagione ha segnaot 5 gol, di cui 4 al Monza. È un attaccante con caratteristiche precise, è alto quasi 2 metri e può far comodo anche a gara in corso. È però un’opzione solo da leghe numerose."
+      }
+    },
+    {
+      "nome": "EKHATOR",
+      "team": "GEN",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.2
+      },
+      "stats": {
+        "t": 2,
+        "a": 3,
+        "i": 3,
+        "f": 5.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 29,
+          "rating": 5.5
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 1,
+          "minutes": 787,
+          "rating": 5.87
+        }
+      },
+      "notes": {
+        "comm": "Sono sempre dei jolly ma con ancora meno spazio previsto, occhio anche al mercato in alcuni casi. Opzioni esclusivamente da leghe molto numerose."
+      }
+    },
+    {
+      "nome": "EKUBAN",
+      "team": "GEN",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.2
+      },
+      "stats": {
+        "t": 2,
+        "a": 3,
+        "i": 2,
+        "f": 6.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 12,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 1,
+          "assists": 3,
+          "minutes": 543,
+          "rating": 6.0
+        }
+      },
+      "notes": {
+        "comm": "Sono jolly che possono fare comodo in leghe numerose per completare il reparto, si vedrà con la preseason se qualcuno potrà avere più spazio del previsto."
+      }
+    },
+    {
+      "nome": "FRIGAN",
+      "team": "PAR",
+      "prezzi": {
+        "min": 0,
+        "max": 2,
+        "avg": 0.5
+      },
+      "stats": {
+        "t": 1,
+        "a": 3,
+        "i": 1,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 0,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 0
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 175,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 2679,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Matija Frigan è arrivato al Parma ma si è subito rotto il crociato, non è quindi da prendere al fantacalcio. Era un’operazione importante perché è arrivato per 10 milioni dal Westerlo, ma ha avuto grande sfortuna."
+      }
+    },
+    {
+      "nome": "GUEYE",
+      "team": "UDI",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.2
+      },
+      "stats": {
+        "t": 1,
+        "a": 3,
+        "i": 4,
+        "f": null
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 6,
+          "assists": 1,
+          "minutes": 1127,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Idrissa Gueye è un talento per l’Udinese che verrà. Per il presente ma soprattutto per il futuro. È un attaccante centrale senegalese di 185 cm, classe 2006. Arriva dal Metz, l’anno scorso ha fatto 5 gol in 17 partite in Ligue 2. Opzione da leghe numerose come scommessa oppure per chi ha le conferme. Se ne parla molto, molto bene, vedremo se riuscirà ad esplodere già quest’anno."
+      }
+    },
+    {
+      "nome": "JOHNSEN",
+      "team": "CRE",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.2
+      },
+      "stats": {
+        "t": 2,
+        "a": 3,
+        "i": 4,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 1487,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Dennis Johnsen torna in Serie A e lo fa con la maglia della Cremonese. Attaccante esterno classe ’98, era già stato al fantacalcio con la maglia del Venezia. In quel caso più buoni voti che bonus. In B ha fatto 8 gol e 9 assist, difficile replicare questi numeri in A ma può rimanere un titolare low cost da ultimissimi slot."
+      }
+    },
+    {
+      "nome": "MEISTER",
+      "team": "PIS",
+      "prezzi": {
+        "min": 0,
+        "max": 2,
+        "avg": 0.8
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 4,
+        "f": 5.25
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 144,
+          "rating": 5.5
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 548,
+          "rating": 6.0
+        }
+      },
+      "notes": {
+        "comm": "Sono sempre dei jolly ma con ancora meno spazio previsto, occhio anche al mercato in alcuni casi. Opzioni esclusivamente da leghe molto numerose."
+      }
+    },
+    {
+      "nome": "MILIK",
+      "team": "JUV",
+      "prezzi": {
+        "min": 0,
+        "max": 0,
+        "avg": 0.0
+      },
+      "stats": {
+        "t": 0,
+        "a": 0,
+        "i": 0,
+        "f": 0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 0,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 0
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Non sono giocatori su cui puntare per il fantacalcio, potete fare altre scelte."
+      }
+    },
+    {
+      "nome": "MORO L.",
+      "team": "SAS",
+      "prezzi": {
+        "min": 0,
+        "max": 0,
+        "avg": 0.0
+      },
+      "stats": {
+        "t": 0,
+        "a": 0,
+        "i": 0,
+        "f": 0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 0,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 0
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 1,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 1066,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Non sono giocatori su cui puntare per il fantacalcio, potete fare altre scelte."
+      }
+    },
+    {
+      "nome": "MOUMBAGNA",
+      "team": "CRE",
+      "prezzi": {
+        "min": 0,
+        "max": 10,
+        "avg": 2.5
+      },
+      "stats": {
+        "t": 3,
+        "a": 3,
+        "i": 2,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 10,
+        "sos_fanta_2025": 0,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 10,
+        "sos_fanta_2024": 0
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 8,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Faris Moumbagna è un nuovo attaccante della Cremonese. Si tratta di una punta camerunese classe 2000, è alto 185 cm. Arriva dal Marsiglia dove ha giocato solo la prima partita della scorsa stagione, poi la rottura del crociato. Arriva da un anno di inattività e alla Cremonese si troverà molti giocatori davanti nel suo ruolo, non è una prima scelta al fantacalcio."
+      }
+    },
+    {
+      "nome": "NJIE",
+      "team": "TOR",
+      "prezzi": {
+        "min": 0,
+        "max": 0,
+        "avg": 0.0
+      },
+      "stats": {
+        "t": 0,
+        "a": 0,
+        "i": 0,
+        "f": 0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 0,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 0
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 385,
+          "rating": 6.0
+        }
+      },
+      "notes": {
+        "comm": "Non si tratta di prime scelte per l’attacco, anzi. Sono opzioni rischiose e che non dovrebbero avere molto spazio."
+      }
+    },
+    {
+      "nome": "NOSLIN",
+      "team": "LAZ",
+      "prezzi": {
+        "min": 0,
+        "max": 2,
+        "avg": 1.0
+      },
+      "stats": {
+        "t": 2,
+        "a": 4,
+        "i": 4,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 1,
+        "profeta_2025": 2,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 1,
+        "profeta_2024": 2,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 2,
+          "assists": 2,
+          "minutes": 893,
+          "rating": 6.0
+        }
+      },
+      "notes": {
+        "comm": "Sono sempre dei jolly ma con ancora meno spazio previsto, occhio anche al mercato in alcuni casi. Opzioni esclusivamente da leghe molto numerose."
+      }
+    },
+    {
+      "nome": "OKEREKE",
+      "team": "CRE",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.2
+      },
+      "stats": {
+        "t": 2,
+        "a": 3,
+        "i": 2,
+        "f": 6.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 81,
+          "rating": 6.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 2076,
+          "rating": 6.0
+        }
+      },
+      "notes": {
+        "comm": "Non sono giocatori su cui puntare per il fantacalcio, potete fare altre scelte."
+      }
+    },
+    {
+      "nome": "PAVOLETTI",
+      "team": "CAG",
+      "prezzi": {
+        "min": 0,
+        "max": 1,
+        "avg": 0.2
+      },
+      "stats": {
+        "t": 2,
+        "a": 3,
+        "i": 2,
+        "f": 0.0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 1,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 1
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 2,
+          "assists": 0,
+          "minutes": 452,
+          "rating": 5.95
+        }
+      },
+      "notes": {
+        "comm": "Sono sempre dei jolly ma con ancora meno spazio previsto, occhio anche al mercato in alcuni casi. Opzioni esclusivamente da leghe molto numerose."
+      }
+    },
+    {
+      "nome": "PIERINI",
+      "team": "SAS",
+      "prezzi": {
+        "min": 0,
+        "max": 0,
+        "avg": 0.0
+      },
+      "stats": {
+        "t": 0,
+        "a": 0,
+        "i": 0,
+        "f": 0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 0,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 0
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 1,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 82,
+          "rating": 5.75
+        }
+      },
+      "notes": {
+        "comm": "Non si tratta di prime scelte per l’attacco, anzi. Sono opzioni rischiose e che non dovrebbero avere molto spazio.\n\n"
+      }
+    },
+    {
+      "nome": "SKJELLERUP",
+      "team": "SAS",
+      "prezzi": {
+        "min": 0,
+        "max": 0,
+        "avg": 0.0
+      },
+      "stats": {
+        "t": 0,
+        "a": 0,
+        "i": 0,
+        "f": 0
+      },
+      "allPrices": {
+        "fantaboom_2025": 0,
+        "fantaclassic_2025": 0,
+        "profeta_2025": 0,
+        "sos_fanta_2025": 0,
+        "fantaboom_2024": 0,
+        "fantaclassic_2024": 0,
+        "profeta_2024": 0,
+        "sos_fanta_2024": 0
+      },
+      "performance": {
+        "2025_26": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 0,
+          "rating": 0.0
+        },
+        "2024_25": {
+          "goals": 0,
+          "assists": 0,
+          "minutes": 174,
+          "rating": 0.0
+        }
+      },
+      "notes": {
+        "comm": "Non sono giocatori su cui puntare per il fantacalcio, potete fare altre scelte."
       }
     }
   ]

--- a/scripts/generate_database.py
+++ b/scripts/generate_database.py
@@ -27,12 +27,6 @@ SOURCES = {
 
 def load_source(path: Path) -> list[dict]:
     wb = load_workbook(path, read_only=True)
-    ws = wb.active
-    rows = ws.iter_rows(values_only=True)
-    try:
-        header = [str(c).lower() for c in next(rows)]
-    except StopIteration:  # empty sheet
-        return []
     mapping = {
         "nome": "name",
         "ruolo": "role",
@@ -48,28 +42,34 @@ def load_source(path: Path) -> list[dict]:
         "mv": "rating",
         "commento": "comm",
     }
-    cols = [mapping.get(c, c) for c in header]
     result: list[dict] = []
-    for row in rows:
-        if all(cell is None for cell in row):
+    for ws in wb.worksheets:
+        rows = ws.iter_rows(values_only=True)
+        try:
+            header = [str(c).lower() for c in next(rows)]
+        except StopIteration:  # empty sheet
             continue
-        data = {cols[i]: row[i] for i in range(len(cols))}
-        for col in ["team", "goals", "assists", "minutes", "rating", "comm"]:
-            if col not in data or data[col] is None:
-                data[col] = "" if col in ("team", "comm") else 0
-        result.append(
-            {
-                "name": data.get("name", ""),
-                "team": data.get("team", ""),
-                "role": data.get("role", ""),
-                "price": data.get("price", 0),
-                "goals": data.get("goals", 0),
-                "assists": data.get("assists", 0),
-                "minutes": data.get("minutes", 0),
-                "rating": data.get("rating", 0),
-                "comm": data.get("comm", ""),
-            }
-        )
+        cols = [mapping.get(c, c) for c in header]
+        for row in rows:
+            if all(cell is None for cell in row):
+                continue
+            data = {cols[i]: row[i] for i in range(len(cols))}
+            for col in ["team", "goals", "assists", "minutes", "rating", "comm"]:
+                if col not in data or data[col] is None:
+                    data[col] = "" if col in ("team", "comm") else 0
+            result.append(
+                {
+                    "name": data.get("name", ""),
+                    "team": data.get("team", ""),
+                    "role": data.get("role", ""),
+                    "price": data.get("price", 0),
+                    "goals": data.get("goals", 0),
+                    "assists": data.get("assists", 0),
+                    "minutes": data.get("minutes", 0),
+                    "rating": data.get("rating", 0),
+                    "comm": data.get("comm", ""),
+                }
+            )
     return result
 
 


### PR DESCRIPTION
## Summary
- Update `load_source` to process every worksheet in a workbook
- Regenerate `players_database.json` so defender entries include their comments

## Testing
- `python scripts/generate_database.py`
- `python -m py_compile scripts/generate_database.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc96ed6f208324b24f0dbb7427abb4