### PR TITLE
Add player card click handling and hide comments

### DIFF
--- a/index.html
+++ b/index.html
@@ -1475,11 +1475,10 @@
                         const othersInfo = others[key];
                         const price = purchasedInfo?.price ?? t.price;
                         const playerData = findPlayer(t.name, t.role);
-                        const comment = playerData?.notes?.comm ? `<div class="player-comment">${playerData.notes.comm}</div>` : '';
                         const boughtClass = purchasedInfo ? 'bought' : '';
                         const externalClass = othersInfo ? 'bought-elsewhere' : '';
                         html += `
-                        <div class="player-card ${boughtClass} ${externalClass}">
+                        <div class="player-card ${boughtClass} ${externalClass}" data-name="${t.name}" data-role="${role}">
                             <div class="player-info">
                                 <div class="player-name">${roleIcons[role] ?? ''} ${t.name}</div>
                                 <div class="player-team">Ruolo: ${role} • Slot
@@ -1487,7 +1486,6 @@
                                         ${getRoleSlots(role).map(s => `<option value="${s}" ${t.slot == s ? 'selected' : ''}>${s}</option>`).join('')}
                                     </select>
                                 </div>
-                                ${comment}
                             </div>
                             <div class="price-badge">
                                 <div class="smart-price">${Math.round(price)}<span class="coin-icon">🪙</span></div>
@@ -1503,6 +1501,11 @@
                     });
                 });
                 container.innerHTML = html || '<p>Nessun obiettivo selezionato</p>';
+                container.querySelectorAll('.player-card').forEach(card => {
+                    card.addEventListener('click', () => {
+                        showPlayerDetails(card.dataset.name, card.dataset.role);
+                    });
+                });
                 container.querySelectorAll('.slot-select').forEach(sel => {
                     sel.addEventListener('change', e => {
                         const key = e.target.dataset.key;


### PR DESCRIPTION
## Summary
- Hide player comments in target grid and attach dataset attributes for each player card
- Add click listeners to target player cards to trigger `showPlayerDetails`

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bca27ad1dc8324adb6394f5260e77b