### PR TITLE
Maintain fixed total cap when updating budget strategy

### DIFF
--- a/index.html
+++ b/index.html
@@ -975,6 +975,7 @@
                 'A': { max: 140, spent: 0, count: 0, needed: 6 }
             }
         };
+        const initialTotal = budget.total.max;
         const strategy = {};
         const targets = JSON.parse(localStorage.getItem('targets') || '{}');
         const purchased = {};
@@ -1488,9 +1489,9 @@
         }
 
         function updateSmartPricing() {
-            const remainingTotal = budget.total.max - budget.total.spent;
+            budget.total.max = initialTotal;
             ['P','D','C','A'].forEach(role => {
-                budget.roles[role].max = budget.roles[role].spent + Math.round(remainingTotal * (strategy[role] || 0) / 100);
+                budget.roles[role].max = Math.round(initialTotal * (strategy[role] || 0) / 100);
             });
             Object.keys(targets).forEach(key => {
                 const t = targets[key];
@@ -1505,17 +1506,9 @@
         }
 
         function saveStrategy() {
-            const total = budget.total.max;
-            let newTotal = 0;
             ['P','D','C','A'].forEach(role => {
-                const val = parseInt(budgetView.querySelector(`#strategy-${role}`).value) || 0;
-                strategy[role] = val;
-                const roleMax = Math.round(total * val / 100);
-                budget.roles[role].max = roleMax;
-                newTotal += roleMax;
+                strategy[role] = parseInt(budgetView.querySelector(`#strategy-${role}`).value) || 0;
             });
-            budget.total.max = newTotal;
-            updateBudgetUI();
             updateSmartPricing();
         }
 


### PR DESCRIPTION
## Summary
- Maintain an immutable 500-credit total by storing an `initialTotal` constant
- Recalculate role budgets using the full cap in `updateSmartPricing`
- Simplify `saveStrategy` so updating percentages no longer alters the total cap

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node -e "const { JSDOM } = require('jsdom'); (async () => { const dom = await JSDOM.fromFile('index.html', { runScripts: 'dangerously', resources: 'usable', url: 'https://example.org/', beforeParse(w){ w.fetch = () => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }); } }); if(dom.window.document.readyState==='loading'){ await new Promise(r => dom.window.addEventListener('DOMContentLoaded', r)); } ['P','D','C'].forEach(r => dom.window.document.querySelector(`#strategy-${r}`).value='0'); dom.window.document.querySelector('#strategy-A').value='52'; dom.window.saveStrategy(); const maxA = dom.window.document.querySelector('#budget-A-max').textContent; const spentA = dom.window.document.querySelector('#budget-A').textContent; console.log('Attack allocation:', `${spentA}/${maxA}`); })();"`

------
https://chatgpt.com/codex/tasks/task_e_68bd44eed2e48324a693e3c5a5e07564