### PR TITLE
Use current budgets for slot redistribution

### DIFF
--- a/index.html
+++ b/index.html
@@ -1632,10 +1632,10 @@
             const slots = getRoleSlots(role).filter(s => s !== slot);
             if (!slots.length) return;
             const currentBudgets = calculateSlotBudgets()[role];
-            const total = slots.reduce((sum, s) => sum + (currentBudgets[s] - (slotBudgetAdjustments[role][s] || 0)), 0);
+            const total = slots.reduce((sum, s) => sum + currentBudgets[s], 0);
             if (total <= 0) return;
             slots.forEach(s => {
-                const share = (currentBudgets[s] - (slotBudgetAdjustments[role][s] || 0)) / total;
+                const share = currentBudgets[s] / total;
                 slotBudgetAdjustments[role][s] = (slotBudgetAdjustments[role][s] || 0) + delta * share;
             });
         }


### PR DESCRIPTION
## Summary
- Fix `redistributeDelta` to compute totals and shares from current slot budgets
- Adjust slot budget redistribution to scale by `currentBudgets[s] / total`

## Testing
- `npm test` (fails: Error: no test specified)
- node script verifying proportional overspend/underspend redistribution


------
https://chatgpt.com/codex/tasks/task_e_68bd5df9775083248abbe6e28e3591ce