### PR TITLE
Remove historical price clamps in target price calculation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1525,9 +1525,9 @@
                 const planned = slotPlan[role]?.[slot] || 0;
                 const perPlayer = planned > 0 ? slotBudget / planned : 0;
                 return {
-                    ideal: Math.round(Math.min(player.prezzi.min, perPlayer)),
-                    suggested: Math.round(Math.min(player.prezzi.avg, perPlayer)),
-                    max: Math.round(Math.min(player.prezzi.max, slotBudget))
+                    ideal: Math.round(perPlayer),
+                    suggested: Math.round(perPlayer),
+                    max: Math.round(slotBudget)
                 };
             } else {
                 const roleData = budget.roles[role];
@@ -1535,9 +1535,9 @@
                 const remainingSlots = roleData.needed - roleData.count;
                 const perSlot = remainingSlots > 0 ? Math.floor(remainingBudget / remainingSlots) : 0;
                 return {
-                    ideal: Math.round(Math.min(player.prezzi.min, perSlot)),
-                    suggested: Math.round(Math.min(player.prezzi.avg, perSlot)),
-                    max: Math.round(Math.min(player.prezzi.max, remainingBudget))
+                    ideal: Math.round(perSlot),
+                    suggested: Math.round(perSlot),
+                    max: Math.round(remainingBudget)
                 };
             }
         }


### PR DESCRIPTION
## Summary
- allow target price calculations to use full slot or remaining budgets without clamping to historical player prices

## Testing
- `node - <<'NODE'
const fs=require('fs');
const {JSDOM}=require('jsdom');
const html=fs.readFileSync('index.html','utf8');
const dom=new JSDOM(html,{url:'https://example.com',runScripts:'dangerously',beforeParse(w){w.fetch=()=>Promise.resolve({json:()=>Promise.resolve({P:[],D:[],C:[],A:[]})});}});
const w=dom.window;
w.eval("slotPlan['D']['1']=1;slotPlan['D']['2']=2;slotPlan['D']['3']=2;slotPlan['D']['4']=3;budget.roles['D'].max=72;");
console.log('calc', w.eval("JSON.stringify(calculateTargetPrices({}, 'D', '1'))"));
NODE`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bda5df080c832497c7863a53358d0d