### PR TITLE
Even slot budget allocation and smart pricing refresh

### DIFF
--- a/index.html
+++ b/index.html
@@ -1285,6 +1285,7 @@
                         updateBudgetUI();
                         recomputeSlotTargets();
                         filterFeasibleTargets();
+                        updateSmartPricing();
                         updateTargetsUI();
                         updateSlotSummary(role);
                     });
@@ -1673,40 +1674,33 @@
             Object.entries(targets).forEach(([key, t]) => {
                 const slotKey = `${t.role}:${t.slot}`;
                 const budget = slotBudgets[t.role]?.[t.slot] || 0;
-                const plannedCount = slotPlan?.[t.role]?.[t.slot] || 0;
                 const fixed = t.fixedPrice ? Math.round(t.fixedPrice) : 0;
                 grouped[slotKey] = grouped[slotKey] || {
                     budget,
-                    plannedCount,
                     fixedTotal: 0,
-                    fixedCount: 0,
                     variable: []
                 };
                 const group = grouped[slotKey];
                 group.budget = budget;
-                if (plannedCount) group.plannedCount = plannedCount;
                 if (fixed) {
                     group.fixedTotal += fixed;
-                    group.fixedCount += 1;
                     targets[key].targetPrice = fixed;
                 } else {
-                    group.variable.push({ key });
+                    group.variable.push(key);
                 }
             });
             Object.values(grouped).forEach(group => {
                 const remainingBudget = Math.max(group.budget - group.fixedTotal, 0);
-                const variable = group.variable;
-                if (variable.length > 0) {
-                    const denominator = group.plannedCount ? Math.max(group.plannedCount - group.fixedCount, variable.length) : variable.length;
-                    const share = Math.round(remainingBudget / (denominator || 1));
+                if (group.variable.length > 0) {
+                    const share = Math.round(remainingBudget / group.variable.length);
                     let assigned = 0;
-                    variable.forEach(({ key }) => {
+                    group.variable.forEach(key => {
                         targets[key].targetPrice = share;
                         assigned += share;
                     });
                     const diff = remainingBudget - assigned;
                     if (diff !== 0) {
-                        const lastKey = variable[variable.length - 1].key;
+                        const lastKey = group.variable[group.variable.length - 1];
                         targets[lastKey].targetPrice = Math.max(0, (targets[lastKey].targetPrice || 0) + diff);
                     }
                 }
@@ -1716,7 +1710,7 @@
         function filterFeasibleTargets(role = null) {
             Object.entries(targets).forEach(([key, t]) => {
                 if (role && t.role !== role) return;
-                const base = t.fixedPrice ? t.fixedPrice : t.price;
+                const base = t.fixedPrice || 0;
                 const target = t.targetPrice ?? base;
                 t.unreachable = !purchased[key] && target < base;
             });


### PR DESCRIPTION
## Summary
- Divide remaining slot budgets equally among unfixed targets
- Base target feasibility on fixed or target prices only
- Refresh smart price hints immediately after slot plan changes

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node <script>` (manual simulation)

------
https://chatgpt.com/codex/tasks/task_e_68bdb3ff0a708324ab1a389900f3b164