### PR TITLE
Reset slot adjustments on plan changes

### DIFF
--- a/index.html
+++ b/index.html
@@ -1281,12 +1281,9 @@
                 const input = document.getElementById(`slot-plan-${role}-${slot}`);
                 if (input) {
                     input.addEventListener('input', e => {
+                        slotBudgetAdjustments[role][slot] = 0;
                         slotPlan[role][slot] = parseInt(e.target.value) || 0;
-                        updateBudgetUI();
-                        recomputeSlotTargets();
-                        filterFeasibleTargets();
                         updateSmartPricing();
-                        updateTargetsUI();
                         updateSlotSummary(role);
                     });
                 }


### PR DESCRIPTION
## Summary
- Clear slot-specific budget adjustments when slot plan inputs change
- Consolidate budget and target recalculation to a single `updateSmartPricing` call

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb6a1cb0c83249b81424b790283f9